### PR TITLE
Add rebase and baseline validation steps to workflow

### DIFF
--- a/ai-workflow-design-decisions.md
+++ b/ai-workflow-design-decisions.md
@@ -162,6 +162,35 @@ When reviewing the file for structural problems, classify each line as one of:
 - **Candidate to move.** The line could be offloaded to a reference section with a pointer left behind.
 
 
+## Baseline Validation and Rebasing
+
+### Why rebase at the start of a task
+
+Working on a stale branch means the agent writes code against an outdated state.
+Files may have moved, APIs may have changed, or new conflicts may have accumulated.
+Code that is correct against the old state can be silently wrong against current main.
+Rebasing before implementation ensures the starting point matches reality.
+
+### Why rebase before creating a pull request
+
+The target branch may have moved forward during implementation.
+Rebasing before the PR ensures CI runs against the current target state, not a stale snapshot.
+It also reduces the chance of merge conflicts appearing after the PR is created.
+
+### Why run a baseline test suite before implementation
+
+The workflow rule "If a previously passing test fails after the change, treat the change as wrong until proven otherwise" is unenforceable without a known-good baseline.
+Without a baseline, neither the human nor the agent can distinguish a regression from a pre-existing failure.
+Both will naturally assume the change caused the failure, leading to wasted time debugging something that was already broken.
+Running smoke tests and the global test suite after rebasing but before implementation establishes the comparison point.
+Pre-existing failures are recorded so they can be excluded from post-implementation blame.
+
+### Why the baseline runs after rebasing
+
+The baseline must reflect the true starting state.
+If the baseline ran before rebasing, it would validate a stale branch state that the implementation will never build on.
+The sequence is: rebase, then baseline, then implement.
+
 ## Observed AI Failings
 
 Use `observed-ai-failings.md` file to record concrete AI-agent failure patterns seen in real sessions.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -21,6 +21,9 @@ The human reviews and approves at defined checkpoints.
    - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
    - Check branch state.
    - See [GitHub Workflow](#github-workflow).
+   - Rebase onto the target branch.
+   - Run baseline validation.
+   - See [Validation Requirements](#validation-requirements).
    - Confirm the task is a bounded change.
    - See [Scope Control](#scope-control).
    - Complete this step before analysing implementation details.
@@ -138,24 +141,34 @@ Keep the change focused on the approved task:
 
 ## Validation Requirements
 
+Before implementation, run a baseline validation:
+
+1. Run smoke tests.
+2. Run the global test suite.
+3. Record which tests pass and which tests fail.
+4. Treat any pre-existing failure as a known failure for the duration of the task.
+5. Do not attempt to fix pre-existing failures unless the task requires it.
+
+When comparing post-implementation results against the baseline:
+
+- If a test that passed in the baseline now fails, treat the change as the cause until proven otherwise.
+- If a test that failed in the baseline still fails, do not attribute it to the change.
+- Report pre-existing failures separately from change-related failures.
+
 Run validation after every code change.
 Run the following checks in order:
 
 1. **Smoke tests.**
-
    - Confirm the app builds and starts without errors.
 
 2. **Global test suite.**
-
    - Run the full existing test suite.
 
 3. **Targeted tests.**
-
    - Run tests specific to the changed area.
    - If no targeted tests exist, flag this.
 
 4. **New tests.**
-
    - Add tests if the change introduces behaviour that existing tests do not cover.
    - Run the new tests.
 
@@ -278,6 +291,9 @@ Every task must follow the GitHub branching workflow:
 - Use `fix/` for bug fixes.
 - Use `refactor/` for refactors.
 - Keep branch work focused on the issue scope.
+- Rebase the issue branch onto the target branch before starting implementation.
+- Rebase the issue branch onto the target branch before creating a pull request.
+- If new commits have landed on the target branch since the last rebase, rebase again before the next remote GitHub action.
 - If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 - Treat commit creation, push to remote, and pull request creation as separate GitHub actions.
 - Do not infer approval for one GitHub action from approval for another GitHub action.


### PR DESCRIPTION
## Summary

- Add rebase onto target branch and baseline validation run to Step 1 of the workflow
- Add rebasing rules (before implementation, before PR, on target branch changes) to GitHub Workflow section
- Add baseline validation subsection to Validation Requirements with pre-existing failure tracking
- Add design rationale for all three decisions to ai-workflow-design-decisions.md

Closes #10