### PR TITLE
feat: add selective inline rationale to ai-workflow.md

### DIFF
--- a/ai-workflow-design-decisions.md
+++ b/ai-workflow-design-decisions.md
@@ -72,7 +72,8 @@ When there is a conditional, put the condition first: "If X, do Y."
 Do not hedge: avoid "consider", "you might want to", "it is generally a good idea to."
 The file instructs. It does not teach, persuade, or justify.
 Do not include rationale for bright-line mechanical rules where the instruction is unambiguous on its own.
-Include rationale for judgment-heavy rules with ambiguous boundaries, where the agent needs to understand the purpose to avoid violating the spirit.
+Include inline rationale for a rule only when all three criteria are met: the rule requires a judgment call, an agent could comply with the literal wording while violating the intent, and understanding the why would materially change how the agent applies the rule in ambiguous cases.
+Use the format: rule sentence on its own line, then "(Why: rationale.)" on the next line or in a parenthetical on the same line.
 Every rationale line consumes tokens that compete with the actual task, so each one must earn its place.
 
 
@@ -152,7 +153,7 @@ The log should omit filler conversation and low-signal tool noise.
 Use this prompt when requesting a chronological session log for workflow maintenance.
 
 ```text
-Produce a chronological log for maintenance of the file ai-workflow.md.
+Produce a chronological log of this chat session for maintenance of the file ai-workflow.md.
 List the following: 
 - [Tooling or environment, e.g. VS Code Copilot, ChatGPT app, CLI agent.]
 - [Model if known, e.g. GPT-5.4.]

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -32,7 +32,7 @@ The human reviews and approves at defined checkpoints.
 
    - Read `project-spec.md` and relevant files.
    - Review the code areas the task is likely to touch.
-   - Extract the intended outcome from the issue before using implementation suggestions.
+   - Extract the intended outcome from the issue before using implementation suggestions. (Why: Issue text is often stale or speculative; treating implementation suggestions as authoritative causes the agent to implement the wrong thing.)
    - See [Planning Requirements](#planning-requirements).
 
 3. **Produce a code-aware plan.**
@@ -115,7 +115,7 @@ Before implementation, produce a plan that includes:
 When writing the plan:
 
 - Treat the issue goal as authoritative.
-- Treat issue-suggested implementation details as provisional until the current codebase confirms them.
+- Treat issue-suggested implementation details as provisional until the current codebase confirms them. (Why: Issues are written before implementation and may not reflect the current codebase.)
 - Do not assume the files, data flow, or control points named in the issue are the real execution path.
 - If the issue and the current codebase disagree, prioritise the codebase and flag the mismatch to the human.
 - If the issue suggests a structure that the current codebase does not follow, plan against the real structure and flag the mismatch to the human.
@@ -126,7 +126,7 @@ When writing the plan:
 During implementation:
 
 - Use `project-spec.md` for initial context on architectural patterns, project structure, and conventions.
-- Prefer extending current patterns over introducing new ones.
+- Prefer extending current patterns over introducing new ones. (Why: New patterns increase review surface, reduce predictability, and create maintenance drift.)
 - Keep changes focused and relevant to the approved plan.
 
 ## Scope Control
@@ -136,9 +136,9 @@ Keep the change focused on the approved task:
 - If the issue contains multiple unrelated objectives, flag this and ask the human whether to split them into separate tasks.
 - If the task would require changes across many unrelated areas of the codebase, flag the risk and suggest decomposition.
 - Do only the work required to complete the task.
-- Do not treat "while I am here" changes as free.
-- Separate fixes, refactors, and feature work unless the task clearly requires them together.
-- If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation.
+- Do not treat "while I am here" changes as free. (Why: Each unplanned change introduces untested risk and dilutes commit traceability.)
+- Separate fixes, refactors, and feature work unless the task clearly requires them together. (Why: Mixing change types obscures the commit's intent and makes review harder.)
+- If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation. (Why: Unreviewed scope expansions break the human approval model and introduce unvalidated changes.)
 
 ## Validation Requirements
 
@@ -233,7 +233,7 @@ When in failure analysis mode:
 - Gather evidence before proposing another fix.
 - Test at least one concrete hypothesis before asking the human to retry the flow, refresh the app, clear cache, restart the dev server, or repeat manual verification.
 - Prioritise code path, persistence, sync, routing, and UI binding explanations over environment or caching unless evidence shows otherwise.
-- Do not signal a flawed approach based on difficulty alone.
+- Do not signal a flawed approach based on difficulty alone. (Why: Difficulty is normal implementation friction; only evidence of wrong assumptions signals a flawed approach.)
 - Signal a flawed approach only when evidence shows the assumptions were wrong.
 
 ## Logging and Observability


### PR DESCRIPTION
## Summary

Implements #22 (sub-issue of #21).

Audits every rule in `ai-workflow.md` against the three-part criteria and adds `(Why: ...)` inline rationale to the 7 qualifying rules.

## Changes

### `ai-workflow.md`
- "Extract the intended outcome from the issue before using implementation suggestions." — issue text is often stale or speculative
- "Treat issue-suggested implementation details as provisional…" — issues are written before implementation
- "Prefer extending current patterns over introducing new ones." — new patterns increase review surface and create maintenance drift
- "Do not treat 'while I am here' changes as free." — each unplanned change introduces untested risk and dilutes commit traceability
- "Separate fixes, refactors, and feature work…" — mixing change types obscures commit intent
- "If a larger problem is discovered, flag it as follow-up work…" — unreviewed scope expansions break the human approval model
- "Do not signal a flawed approach based on difficulty alone." — difficulty is normal friction, not evidence of wrong assumptions

### `ai-workflow-design-decisions.md`
- Writing Style section: replaced the 3-line rationale guidance with 4 lines specifying the three-part criteria and the `(Why: ...)` format

## Acceptance criteria check
- [x] Every rule with inline rationale passes all three criteria
- [x] No rule with inline rationale fails any criterion
- [x] No caps emphasis added (out of scope for this sub-issue)
- [x] File is under 400 lines (377)
- [x] One sentence per line maintained throughout
- [x] Design decisions updated with three-part test and format spec

Closes #22