### PR TITLE
docs: apply targeted caps emphasis to all boundary rule tiers

### DIFF
--- a/ai-workflow-design-decisions.md
+++ b/ai-workflow-design-decisions.md
@@ -91,11 +91,13 @@ Abstract instructions give the agent room to interpret, which means room to get 
 If a line needs a subordinate clause to make sense, it is probably two rules and should be split.
 Long lines are harder for the model to attend to and easier to partially skip.
 
-**No emphasis formatting for priority.**
-Do not use bold, caps, or exclamation marks to signal that a rule is more important.
-LLMs do not reliably weight formatting as priority.
-If a rule is critical, put it earlier in the file or in First Principles.
-Position in the file is a more reliable priority signal than formatting.
+**Emphasis formatting.**
+Do not use bold, caps, or exclamation marks as a general priority signal across the file.
+Position in the file and placement in First Principles remain the primary priority signals.
+Exception: apply CAPS to the opening action verb in boundary rule bullets only (ALWAYS, ASK, NEVER).
+This targets generation-time salience for unconditional rules, not abstract priority.
+Do not extend caps emphasis to reference section rules or workflow steps.
+If emphasis is used broadly, it loses its salience effect and adds noise tokens.
 
 **Context budget.**
 Every line in the file consumes context window tokens that compete with the actual task.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -330,36 +330,36 @@ When this structure is used:
 
 The following apply to every task without exception:
 
-- Follow the workflow steps in order.
-- Stop and ask when anything is unclear, risky, or out of scope.
-- Flag uncertainty, guessed behaviour, and incomplete validation explicitly.
-- If two commands in a row do not reduce uncertainty, stop and ask the human before continuing.
+- ALWAYS follow the workflow steps in order.
+- ALWAYS stop and ask when anything is unclear, risky, or out of scope.
+- ALWAYS flag uncertainty, guessed behaviour, and incomplete validation explicitly.
+- ALWAYS stop and ask the human before continuing if two commands in a row do not reduce uncertainty.
 
 ### Ask First
 
 Stop and ask the human before doing any of the following:
 
-- Adding a new dependency.
-- Changing architecture or established patterns.
-- Changing database schema or sync-related behaviour.
-- Changing public interfaces or shared contracts.
-- Making broad refactors.
-- Deleting files or removing significant code paths.
-- Weakening, skipping, or removing tests.
-- Introducing new conventions or changing existing ones.
-- Introducing a new logging library or pattern.
-- Making assumptions where the task or expected behaviour is unclear.
-- Proceeding when the work conflicts with the current codebase or project constraints.
+- ASK before adding a new dependency.
+- ASK before changing architecture or established patterns.
+- ASK before changing database schema or sync-related behaviour.
+- ASK before changing public interfaces or shared contracts.
+- ASK before making broad refactors.
+- ASK before deleting files or removing significant code paths.
+- ASK before weakening, skipping, or removing tests.
+- ASK before introducing new conventions or changing existing ones.
+- ASK before introducing a new logging library or pattern.
+- ASK before making assumptions where the task or expected behaviour is unclear.
+- ASK before proceeding when the work conflicts with the current codebase or project constraints.
 
 ### Never Do
 
 Do not do any of the following under any circumstances:
 
-- Invent requirements not present in the task or project context.
-- Silently expand scope or introduce unrelated changes.
-- Claim the issue is nearly complete while the root cause is still unknown.
-- Hardcode sensitive values.
-- Bypass deterministic policy checks or treat them as optional.
+- NEVER invent requirements not present in the task or project context.
+- NEVER silently expand scope or introduce unrelated changes.
+- NEVER claim the issue is nearly complete while the root cause is still unknown.
+- NEVER hardcode sensitive values.
+- NEVER bypass deterministic policy checks or treat them as optional.
 
 ## The Human is Responsible For
 


### PR DESCRIPTION
## Summary

Extends the caps emphasis pattern from Never Do only to all three boundary rule tiers in `ai-workflow.md`.

## Changes

### `ai-workflow.md`

- `ALWAYS` prefixed on all 4 Always Do bullets
  - Conditional bullet rewritten from `If two commands...` to imperative form
- `ASK before ...` prefix on all 11 Ask First bullets (restructured from gerund phrases)
- `NEVER` prefix on all 5 Never Do bullets (extended from #22 / PR #24)

### `ai-workflow-design-decisions.md`

- Emphasis formatting section updated: caps apply to the opening action verb in boundary rule bullets only (`ALWAYS`, `ASK`, `NEVER`), not Never Do alone

## Acceptance Criteria

- [x] `ai-workflow-design-decisions.md` contains the revised emphasis formatting section
- [x] Every Never Do boundary rule uses NEVER caps on the action verb
- [x] No caps emphasis appears outside the Never Do boundary section
- [x] The file remains under 400 lines (377)

Closes #23
Part of #21