### PR TITLE
feat: add Claude Code PreToolUse hooks for protected branch enforcement

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-bash.sh
+++ b/.ai-policy/hooks/block-protected-branch-bash.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu
+
+# PreToolUse hook for Claude Code.
+# Blocks Bash git commands (commit, push) when on a protected branch.
+# Reads tool_input from JSON on stdin.
+# Exit 2 = block, exit 0 = allow.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1091
+. "$ROOT_DIR/.ai-policy/policy.env"
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')"
+
+# Only check git commit and git push commands.
+case "$COMMAND" in
+  git\ commit*|git\ push*) ;;
+  *) exit 0 ;;
+esac
+
+CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"
+
+for protected in $PROTECTED_BRANCHES; do
+  if [ "$CURRENT_BRANCH" = "$protected" ]; then
+    echo "Blocked: '$COMMAND' on protected branch '$CURRENT_BRANCH'." >&2
+    echo "Create or switch to an issue-scoped branch before continuing." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.ai-policy/hooks/block-protected-branch-mcp.sh
+++ b/.ai-policy/hooks/block-protected-branch-mcp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eu
+
+# PreToolUse hook for Claude Code.
+# Blocks MCP write tools that target a protected branch.
+# Reads tool_input from JSON on stdin.
+# Exit 2 = block, exit 0 = allow.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1091
+. "$ROOT_DIR/.ai-policy/policy.env"
+
+INPUT="$(cat)"
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
+
+# Extract the target branch from tool_input.
+# push_files, create_or_update_file, delete_file use "branch".
+# create_pull_request uses "base" (the branch being merged into).
+BRANCH="$(printf '%s' "$INPUT" | jq -r '.tool_input.branch // .tool_input.base // empty')"
+
+if [ -z "$BRANCH" ]; then
+  # No branch info available (e.g. merge_pull_request) — cannot check, allow.
+  exit 0
+fi
+
+for protected in $PROTECTED_BRANCHES; do
+  if [ "$BRANCH" = "$protected" ]; then
+    echo "Blocked: MCP tool '$TOOL_NAME' targets protected branch '$BRANCH'." >&2
+    echo "Create or switch to an issue-scoped branch before continuing." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -eu
 
-bash -n ./.ai-policy/scripts/*.sh ./.githooks/*
+bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
+./.ai-policy/scripts/test-claude-code-enforcement.sh

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for Claude Code agent-level protected branch enforcement.
+# Covers Path 1 (Shell/Bash) and Path 2 (MCP).
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PASS=0
+FAIL=0
+
+assert_blocked() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 2, got $exit_code)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 0, got $exit_code)"
+  fi
+}
+
+MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
+BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+
+# ── Path 2: MCP tool blocking ──
+
+echo "Path 2 — MCP tool blocking:"
+
+# Test 1: push_files targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"main","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "push_files to main" "$rc"
+
+# Test 2: create_or_update_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_or_update_file","tool_input":{"branch":"master","owner":"x","repo":"y","path":"f","content":"c","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_or_update_file to master" "$rc"
+
+# Test 3: delete_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__delete_file","tool_input":{"branch":"main","owner":"x","repo":"y","path":"f","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "delete_file on main" "$rc"
+
+# Test 4: create_pull_request with base=main → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_pull_request base=main" "$rc"
+
+# Test 5: push_files targeting non-protected branch → allowed
+rc=0
+printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"feature/foo","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "push_files to feature/foo" "$rc"
+
+# Test 6: merge_pull_request (no branch field) → allowed (limitation)
+rc=0
+printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+
+# ── Path 1: Shell/Bash blocking ──
+
+echo "Path 1 — Shell/Bash blocking:"
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+  # On a protected branch — commit and push should be blocked.
+
+  # Test 7: git commit on protected branch → blocked
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_blocked "git commit on $CURRENT_BRANCH" "$rc"
+
+  # Test 8: git push on protected branch → blocked
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_blocked "git push on $CURRENT_BRANCH" "$rc"
+
+  # Test 9: non-git command on protected branch → allowed
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_allowed "ls on $CURRENT_BRANCH" "$rc"
+
+else
+  # On a non-protected branch — all should be allowed.
+
+  # Test 7: git commit on non-protected branch → allowed
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_allowed "git commit on $CURRENT_BRANCH" "$rc"
+
+  # Test 8: git push on non-protected branch → allowed
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/x"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_allowed "git push on $CURRENT_BRANCH" "$rc"
+
+  # Test 9: non-git command on non-protected branch → allowed
+  rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  assert_allowed "ls on $CURRENT_BRANCH" "$rc"
+fi
+
+# Test 10: Bash hook blocks git commit when current-branch.sh returns a protected name.
+# We override the PATH to inject a fake current-branch.sh that returns "main".
+TMPDIR_TEST="$(mktemp -d)"
+cat > "$TMPDIR_TEST/current-branch.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "main"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch.sh"
+
+# Temporarily replace the real script with the fake one.
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
+cp "$TMPDIR_TEST/current-branch.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+
+# Restore immediately.
+cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+rm -rf "$TMPDIR_TEST"
+
+assert_blocked "git commit when current-branch returns main (simulated)" "$rc"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__.*github.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh\""
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ai-policy/state/validation.status
 .claude/
+!.claude/settings.json


### PR DESCRIPTION
## Summary

Adds agent-level deterministic blocking for protected branch operations in Claude Code, closing #33.

## Changes

- **`.claude/settings.json`** — Project-level PreToolUse hooks for MCP tools (`mcp__.*github.*`) and Bash (`git commit`, `git push`).
- **`.ai-policy/hooks/block-protected-branch-mcp.sh`** — Extracts `branch`/`base` from MCP tool input; blocks if protected.
- **`.ai-policy/hooks/block-protected-branch-bash.sh`** — Checks current git branch for `git commit`/`git push`; blocks if protected.
- **`.ai-policy/scripts/test-claude-code-enforcement.sh`** — 10 automated tests covering both paths.
- **`.ai-policy/scripts/project-validation.sh`** — Extended to syntax-check hook scripts and run enforcement tests.
- **`.gitignore`** — Updated to track `.claude/settings.json`.

## Testing

- 10/10 automated tests pass (6 MCP path, 4 Bash path).
- Bash hook confirmed blocking at runtime in a live Claude Code session on `main`.
- MCP hook script logic verified by unit tests (no GitHub MCP server available for runtime dispatch test).

## Known limitations

- `merge_pull_request` MCP tool has no branch field in its input — cannot be branch-checked. GitHub server-side branch protection is the fallback.
- MCP matcher `mcp__.*github.*` depends on the MCP server being named `github`.

Closes #33