### PR TITLE
feat: add Codex agent-level protected branch enforcement (#35)

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -3,3 +3,4 @@ set -eu
 
 bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-claude-code-enforcement.sh
+./.ai-policy/scripts/test-codex-enforcement.sh

--- a/.ai-policy/scripts/test-codex-enforcement.sh
+++ b/.ai-policy/scripts/test-codex-enforcement.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for Codex agent-level protected branch enforcement.
+# Covers Path 1 (Shell/Bash via hooks.json → bash hook) and
+# Path 2 (MCP via disabled_tools in config.toml).
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PASS=0
+FAIL=0
+
+assert_blocked() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 2, got $exit_code)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 0, got $exit_code)"
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local file="$2"
+  local expected="$3"
+  if grep -qF "$expected" "$file"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected '$expected' in $file)"
+  fi
+}
+
+BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+HOOKS_JSON="$ROOT_DIR/.codex/hooks.json"
+CONFIG_TOML="$ROOT_DIR/.codex/config.toml"
+
+# ── Prerequisite: config files exist ──
+
+echo "Prerequisite checks:"
+
+if [ -f "$HOOKS_JSON" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: .codex/hooks.json exists"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: .codex/hooks.json missing"
+fi
+
+if [ -f "$CONFIG_TOML" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: .codex/config.toml exists"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: .codex/config.toml missing"
+fi
+
+# ── Path 1: Shell/Bash blocking via hooks.json → bash hook ──
+
+echo "Path 1 — Shell/Bash blocking (Codex PreToolUse → bash hook):"
+
+# Verify hooks.json wires PreToolUse to the bash hook.
+assert_contains "hooks.json references PreToolUse" "$HOOKS_JSON" '"PreToolUse"'
+assert_contains "hooks.json references bash hook script" "$HOOKS_JSON" "block-protected-branch-bash.sh"
+
+# Test the bash hook directly with Codex-format payloads.
+# Simulate being on a protected branch by overriding current-branch.sh.
+TMPDIR_TEST="$(mktemp -d)"
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
+
+# Override to return "main".
+cat > "$TMPDIR_TEST/current-branch-fake-main.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "main"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-main.sh"
+
+# Override to return a feature branch.
+cat > "$TMPDIR_TEST/current-branch-fake-feature.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "feature/test"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-feature.sh"
+
+# --- Tests on protected branch ---
+cp "$TMPDIR_TEST/current-branch-fake-main.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git commit on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "ls on main (simulated)" "$rc"
+
+# --- Tests on feature branch ---
+cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git commit on feature/test (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push on feature/test (simulated)" "$rc"
+
+# Restore real script.
+cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+rm -rf "$TMPDIR_TEST"
+
+# ── Path 2: MCP tool blocking via disabled_tools in config.toml ──
+
+echo "Path 2 — MCP tool blocking (config.toml disabled_tools):"
+
+assert_contains "codex_hooks feature flag enabled" "$CONFIG_TOML" "codex_hooks = true"
+assert_contains "push_files disabled" "$CONFIG_TOML" "push_files"
+assert_contains "create_or_update_file disabled" "$CONFIG_TOML" "create_or_update_file"
+assert_contains "delete_file disabled" "$CONFIG_TOML" "delete_file"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[features]
+codex_hooks = true
+
+[mcp_servers.github]
+disabled_tools = ["push_files", "create_or_update_file", "delete_file"]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes #35.

Adds deterministic blocking for Codex agents attempting to write to protected branches via both execution paths.

## What changed

- **`.codex/hooks.json`** — PreToolUse hook wires Bash tool calls to the existing `.ai-policy/hooks/block-protected-branch-bash.sh`. Blocks `git commit` and `git push` on protected branches before execution.
- **`.codex/config.toml`** — Enables `codex_hooks` feature flag. Disables GitHub MCP write tools (`push_files`, `create_or_update_file`, `delete_file`) via `disabled_tools`.
- **`.ai-policy/scripts/test-codex-enforcement.sh`** — 13 automated tests covering Path 1 (Bash hook) and Path 2 (disabled_tools config verification).
- **`.ai-policy/scripts/project-validation.sh`** — Wires in the new Codex test script.

## Validation

23/23 tests pass (10 existing Claude Code + 13 new Codex).

## Known limitations

- MCP tool blocking via `disabled_tools` is unconditional (all branches, not just protected ones) — this is the only deterministic option available; Codex PreToolUse does not fire for MCP tool calls.
- `merge_pull_request` remains unblocked (no branch field in its payload).
- Codex hooks are experimental and behind a feature flag.