### PR TITLE
fix: use git rev-parse --show-toplevel in .claude/settings.json hooks (#41)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
           }
         ]
       },
@@ -20,12 +20,12 @@
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\""
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "\"$CLAUDE_PROJECT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

Fixes #41.

VS Code Copilot agent mode reads `.claude/settings.json` PreToolUse hooks but does not set `$CLAUDE_PROJECT_DIR` (a Claude Code-specific variable). This caused hook paths to resolve to `/.ai-policy/hooks/...` at the filesystem root, producing non-blocking `No such file or directory` warnings — meaning branch protection was entirely inactive in VS Code Copilot sessions.

## Change

Replaced `$CLAUDE_PROJECT_DIR` with `$(git rev-parse --show-toplevel)` in all three `command` values in `.claude/settings.json`. This matches the pattern already used in `.codex/hooks.json` (confirmed working, 13/13 tests pass).

## Validation

- 23/23 automated tests pass (same as baseline)
- `test-claude-code-enforcement.sh`: 10/10 — MCP and Bash hook blocking verified
- `test-codex-enforcement.sh`: 13/13 — no regressions

## Manual verification needed

In a VS Code Copilot agent session:
- **Success:** no broken-path warnings; `git commit`/`git push` on `main` blocked with `Blocked: ...`
- **Failure:** same `No such file or directory` warnings as before