### PR TITLE
Improve skill descriptions and add cross-references

### DIFF
--- a/.claude/skills/failure-analysis/SKILL.md
+++ b/.claude/skills/failure-analysis/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: failure-analysis
-description: "Failure analysis process for when things go wrong during implementation. Use when: manual verification fails; runtime behaviour contradicts the implementation; test results conflict with observed behaviour; a fix attempt does not resolve the problem; investigation is needed before making another code change."
+description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
 ---
 
 # Failure Analysis Mode
 
 Read this file when entering failure analysis mode.
-Enter failure analysis mode when manual verification fails, when runtime behaviour contradicts the implementation, or when test results conflict with observed behaviour.
-This file contains the full process for investigating and resolving those contradictions.
+This file contains the full process for investigating and resolving contradictions between the agent's expectations and user-observed reality.
+
+## Why This Mode Exists
+
+When tests pass and validation succeeds, the agent believes the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between the agent's understanding and reality. The agent's natural response is to jump to the nearest quick fix — but if the agent's understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them during investigation:
+
+- **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
+- **Logging and Observability** — use the project's diagnostic approaches when gathering evidence; prefer automated observation over asking the human to report.
 
 ## Process
 

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: planning
-description: "Code-aware planning process for Step 3 of the workflow. Use when: the agent is about to produce a code-aware plan, i.e. when executing Step 3 of the workflow. Do not use at any other step."
+description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 
 # Code-Aware Planning
 
-Read this file when producing a code-aware plan at Step 3 of the workflow.
+Read this file when producing a code-aware plan before implementation.
 This file contains the full requirements for a valid plan.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when building the plan:
+
+- **Scope Control** — plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
+- **Validation Requirements** — plans must account for how the change will be validated, including baseline comparison.
 
 ## What the Plan Must Contain
 

--- a/.github/skills/failure-analysis/SKILL.md
+++ b/.github/skills/failure-analysis/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: failure-analysis
-description: "Failure analysis process for when things go wrong during implementation. Use when: manual verification fails; runtime behaviour contradicts the implementation; test results conflict with observed behaviour; a fix attempt does not resolve the problem; investigation is needed before making another code change."
+description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
 ---
 
 # Failure Analysis Mode
 
 Read this file when entering failure analysis mode.
-Enter failure analysis mode when manual verification fails, when runtime behaviour contradicts the implementation, or when test results conflict with observed behaviour.
-This file contains the full process for investigating and resolving those contradictions.
+This file contains the full process for investigating and resolving contradictions between the agent's expectations and user-observed reality.
+
+## Why This Mode Exists
+
+When tests pass and validation succeeds, the agent believes the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between the agent's understanding and reality. The agent's natural response is to jump to the nearest quick fix — but if the agent's understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them during investigation:
+
+- **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
+- **Logging and Observability** — use the project's diagnostic approaches when gathering evidence; prefer automated observation over asking the human to report.
 
 ## Process
 

--- a/.github/skills/planning/SKILL.md
+++ b/.github/skills/planning/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: planning
-description: "Code-aware planning process for Step 3 of the workflow. Use when: the agent is about to produce a code-aware plan, i.e. when executing Step 3 of the workflow. Do not use at any other step."
+description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 
 # Code-Aware Planning
 
-Read this file when producing a code-aware plan at Step 3 of the workflow.
+Read this file when producing a code-aware plan before implementation.
 This file contains the full requirements for a valid plan.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when building the plan:
+
+- **Scope Control** — plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
+- **Validation Requirements** — plans must account for how the change will be validated, including baseline comparison.
 
 ## What the Plan Must Contain
 


### PR DESCRIPTION
## Summary

Closes #58 (remaining scope — indirection item was resolved in #59).

- **Broadened skill descriptions** for both `planning` and `failure-analysis` to focus on intent rather than step numbers or narrow trigger conditions.
- **Added "Why This Mode Exists" section** to `failure-analysis` explaining the gap between agent's perspective (tests pass) and user-observed reality (app is broken), and why the skill prevents quick-fix spiraling.
- **Added cross-references** from skills to related workflow sections (Scope Control, Validation Requirements, Logging and Observability).
- Changes applied to both `.claude/skills/` and `.github/skills/` versions.

## Eval finding

Ran the skill-creator's description optimization eval framework (108 runs across multiple description variants). Found the eval framework doesn't trigger any skills in `claude -p` one-shot mode — including known capability skills like `claude-api`. Process/methodology skills rely on workflow-directed loading as the primary triggering path, which is working correctly.

## Test plan

- [x] Validation suite passes (23/23)
- [x] Verify skill descriptions read clearly in agent system context
- [ ] In a future session, confirm workflow directive ("Load the `planning` skill") still works with updated content