### PR TITLE
Repo audit polish: README, .gitignore, GEMINI.md, version reset (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# Runtime state
 .ai-policy/state/validation.status
+
+# Local settings
 .claude/settings.local.json
 .vscode/settings.json
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Editor artifacts
+*.swp
+*.swo
+.idea/
+
+# Logs
+*.log

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,6 @@
+# Instructions
+
+Read the following files before responding to any request in this repository:
+
+- `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
+- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/README.md
+++ b/README.md
@@ -2,29 +2,132 @@
 
 Project-agnostic workflow and maintenance documents for AI-assisted coding.
 
-This repository provides a small set of files that help a human maintain consistent guardrails for an AI coding agent across repositories.
-The workflow is written for the agent.
-The design decision files are written for the human maintainer.
+AI coding agents routinely skip validation, expand scope beyond what was approved, and ignore human checkpoints. This repository provides a small set of governance files that prevent those failures by giving the agent an explicit workflow with enforced rules and required human approvals.
+
+The workflow is written for the agent. The design decision files are written for the human maintainer.
+
+**Prerequisites:** bash, git.
+
+## Approach
+
+This project is built in layers, simple to complex. Each layer is designed to deliver the maximum gain for the minimum effort and maintenance. Staying with a layer long enough to learn its limitations is the point — a new layer is only added when the current one hits a tipping point.
+
+The first layer was a single monolithic workflow file — one document that told the agent what to do. That worked until the workflow grew complex enough that it needed to be split into on-demand context (skills) and deterministic blockers (policy hooks) that enforce rules without relying on the agent to follow them.
+
+The current focus is finding the right split between always-on global rules and on-demand rules that are loaded only when relevant. After that: formally defined rules, and eventually multi-agent coordination.
+
+Tipping points are a judgement call. They come from real-world usage in other repositories — observing where agents actually fail, recording those patterns, and learning which new methods work. The `observed-ai-failings.md` file is where those lessons accumulate.
+
+## History
+
+1. **Single workflow file.** The project started as one document — `ai-workflow.md` — that told the agent what to do: confirm the task, plan, implement, validate, get approval. No enforcement, no tooling.
+2. **Failures drove new rules.** Real-world usage across multiple repos and agents surfaced repeated failures: agents skipping branches, bypassing checkpoints, running validation in parallel, pushing without approval. Each pattern was recorded in `observed-ai-failings.md` and addressed with a targeted workflow rule.
+3. **Deterministic enforcement.** Workflow rules alone were not enough — agents ignored them under momentum. The `.ai-policy/` layer and `.githooks/` were added to block protected-branch writes and require passed validation before commit or push, without relying on the agent to comply.
+4. **Agent-specific enforcement.** Git hooks only cover the shell path. Agents that use MCP connectors bypass hooks entirely. Enforcement was extended to Claude Code (PreToolUse hooks) and Codex (disabled_tools + PreToolUse hooks) to cover both execution paths.
+5. **On-demand skills.** The monolithic workflow file grew too large for agent context budgets. Planning and failure analysis were split into standalone skill files loaded only when the workflow step requires them.
+6. **Current: global vs on-demand rules.** Finding the right boundary between rules that must always be loaded and rules that can be deferred to skills.
 
 ## Repository Contents
 
-- `ai-workflow.md`: Canonical workflow for AI-assisted coding tasks, including planning, checkpoints, validation, failure analysis, and GitHub handoff rules.
-- `ai-workflow-design-decisions.md`: Maintenance rules and structural rationale for editing `ai-workflow.md`.
-- `project-spec-template.md`: Template for creating a `project-spec.md` file in a target repository.
-- `project-spec-design-decisions.md`: Maintenance rules for keeping `project-spec.md` factual, concise, and aligned with implementation truth.
-- `observed-ai-failings.md`: Log of concrete failure patterns observed in real AI-agent sessions.
-- `.claude/skills/failure-analysis/SKILL.md`: Step-by-step process for investigating contradictions between implementation and runtime behaviour (also mirrored in `.github/skills/`).
+### Agent-facing files
 
-## Intended Use
+- `ai-workflow.md` — canonical workflow for AI-assisted coding tasks, including planning, checkpoints, validation, failure analysis, and GitHub handoff rules.
+- `project-spec.md` — factual reference for this repository's implementation state, created from `project-spec-template.md`.
+- `project-spec-template.md` — template for creating `project-spec.md` in a target repository.
 
-Use this repository as a source of reusable governance files for another software project.
+### Agent instruction entry points
 
-Typical setup:
+- `CLAUDE.md` — Claude Code agent instructions.
+- `AGENTS.md` — Codex agent instructions.
+- `GEMINI.md` — Gemini CLI agent instructions.
+- `.github/copilot-instructions.md` — VS Code Copilot agent instructions.
 
-1. Copy `ai-workflow.md` into the target repository and load it through that repository's AI-agent instructions.
-2. Create `project-spec.md` in the target repository from `project-spec-template.md`.
-3. Use the two design decision documents when refining either file.
-4. Record repeated real-world agent failure patterns in `observed-ai-failings.md`.
+### Skills
+
+- `.claude/skills/planning/SKILL.md` — code-aware planning process (Claude Code).
+- `.claude/skills/failure-analysis/SKILL.md` — failure investigation process (Claude Code).
+- `.github/skills/planning/SKILL.md` — code-aware planning process (Copilot).
+- `.github/skills/failure-analysis/SKILL.md` — failure investigation process (Copilot).
+
+### Policy enforcement
+
+- `.ai-policy/` — shell scripts that enforce protected-branch and validation-state rules.
+- `.ai-policy/scripts/test-claude-code-enforcement.sh` — enforcement integration tests for Claude Code.
+- `.ai-policy/scripts/test-codex-enforcement.sh` — enforcement integration tests for Codex.
+- `.githooks/pre-commit`, `.githooks/pre-push` — git hooks that call `.ai-policy/` scripts.
+- `.claude/settings.json` — Claude Code hook configuration for protected-branch blocking.
+- `.codex/config.toml`, `.codex/hooks.json` — Codex agent configuration and hook definitions.
+
+### Maintenance documents
+
+- `ai-workflow-design-decisions/` — scoped maintenance rules and rationale for editing `ai-workflow.md`.
+- `project-spec-design-decisions.md` — maintenance rules for keeping `project-spec.md` factual and concise.
+- `observed-ai-failings.md` — log of concrete failure patterns observed in real AI-agent sessions.
+
+## Installation by Tool
+
+Copy the relevant files into your target repository. Each agent needs its own instruction entry point, the shared workflow and spec files, and the policy enforcement layer.
+
+### Claude Code
+
+```
+CLAUDE.md
+.claude/
+.ai-policy/
+.githooks/
+ai-workflow.md
+project-spec.md          # create from project-spec-template.md
+```
+
+### VS Code Copilot
+
+```
+.github/copilot-instructions.md
+.github/skills/
+.ai-policy/
+.githooks/
+ai-workflow.md
+project-spec.md          # create from project-spec-template.md
+```
+
+### Codex
+
+```
+AGENTS.md
+.codex/
+.ai-policy/
+.githooks/
+ai-workflow.md
+project-spec.md          # create from project-spec-template.md
+```
+
+### Gemini CLI
+
+```
+GEMINI.md
+.ai-policy/
+.githooks/
+ai-workflow.md
+project-spec.md          # create from project-spec-template.md
+```
+
+> Gemini-specific skills and enforcement hooks are not yet available. See [#36](https://github.com/philippe-ths/ai-coding-workflow/issues/36).
+
+After copying, add the governance files and folders to the target repository's `.gitignore` if they should not be committed there.
+
+### Post-install setup
+
+Install the git hooks:
+
+```bash
+./.ai-policy/scripts/install-hooks.sh
+```
+
+Run validation:
+
+```bash
+./.ai-policy/scripts/run-validation.sh
+```
 
 ## What This Repository Optimizes For
 
@@ -40,28 +143,3 @@ Typical setup:
 - Treat the codebase and runtime behavior of the target repository as the source of truth.
 - Prefer concrete instructions over abstract guidance.
 - Update templates and workflow files when repeated failure patterns justify a rule change.
-
-## AI Policy Hooks
-
-This repo includes a lightweight local policy layer in `.ai-policy/` and `.githooks/`.
-
-Current protections:
-
-- block commit on protected branches
-- block push on protected branches
-- require a passed validation status before commit
-- require a passed validation status before push
-
-Setup:
-
-```bash
-./.ai-policy/scripts/install-hooks.sh
-```
-
-Run validation through the policy wrapper:
-
-```bash
-./.ai-policy/scripts/run-validation.sh
-```
-
-The validation state file is local runtime state and should not be committed.

--- a/ai-workflow-design-decisions/observed-ai-failings-guide.md
+++ b/ai-workflow-design-decisions/observed-ai-failings-guide.md
@@ -16,6 +16,9 @@ Record what happened, not theories unless they are useful.
 ### Title
 - [Short name for the failure pattern.]
 
+### Version
+- [Current version from `ai-workflow.md`.]
+
 ### Date
 - [YYYY-MM-DD]
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 1.2.0
+Version: 1.0.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/observed-ai-failings.md
+++ b/observed-ai-failings.md
@@ -1,9 +1,14 @@
 # Observed AI Failings
 
+Each entry is tagged with the workflow version that was active when the failure was observed. A version tag does not guarantee the failure has been resolved in later versions — the same pattern may resurface with different tools, models, or task conditions.
+
 ## Entry 1
 
 ### Title
 - Command thrashing before checkpoint approval.
+
+### Version
+- pre-1.0.0.
 
 ### Date
 - 2026-03-29.
@@ -35,6 +40,9 @@
 ### Title
 - Interrupted critical step treated as completed work.
 
+### Version
+- pre-1.0.0.
+
 ### Date
 - 2026-03-29.
 
@@ -64,6 +72,9 @@
 
 ### Title
 - Mandatory workflow gates bypassed on simple tasks.
+
+### Version
+- pre-1.0.0.
 
 ### Date
 - 2026-03-29.
@@ -99,6 +110,12 @@
 ### Title
 - Pushed code and created PR without confirmation.
 
+### Version
+- pre-1.0.0.
+
+### Version
+- pre-1.0.0.
+
 ### Date
 - 2026-03-29.
 
@@ -129,6 +146,9 @@
 ### Title
 Implemented issue work directly on main.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-30.
 
@@ -157,6 +177,9 @@ This appears general across tasks because branch isolation is a baseline workflo
 
 ### Title
 Conflicting validation commands run in parallel.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-03-30.
@@ -187,6 +210,9 @@ This appears general across tasks because it affects validation reliability anyw
 ### Title
 Implemented issue work directly on main before creating issue branch.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -216,6 +242,9 @@ This is a recurrence of the pattern in Entry 5 under a different model and repo,
 ### Title
 Skipped rebase onto target branch before implementation and PR creation.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -244,6 +273,9 @@ This appears general across tasks because rebase discipline applies to any branc
 
 ### Title
 Incomplete baseline validation before implementation.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-03-31.
@@ -275,6 +307,9 @@ This appears general across tasks because baseline validation completeness appli
 ### Title
 Validation commands run in parallel sharing build outputs.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -304,6 +339,9 @@ This is a recurrence of the pattern in Entry 6 under a different model and repo,
 
 ### Title
 Multiple GitHub actions executed in a single pass without separate approvals.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-03-31.
@@ -335,6 +373,9 @@ This appears general across tasks because it affects any workflow with multiple 
 ### Title
 Branch naming convention not followed.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -364,6 +405,9 @@ This appears general across tasks because agents may default to their own naming
 
 ### Title
 Pre-existing build error not handled in baseline validation workflow.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-03-31.
@@ -395,6 +439,9 @@ This appears general across tasks because baseline recording discipline applies 
 ### Title
 Sandboxed git operations failed requiring permission escalation.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -424,6 +471,9 @@ This is specific to sandboxed or restricted execution environments but affects a
 
 ### Title
 MCP connector PR creation cancelled and retried.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-03-31.
@@ -455,6 +505,9 @@ This is specific to MCP or connector-based remote actions but applies to any wor
 ### Title
 Empty placeholder files lost on remote branch push.
 
+### Version
+pre-1.0.0.
+
 ### Date
 2026-03-31.
 
@@ -484,6 +537,9 @@ This is specific to MCP or API-based remote tree creation workflows that do not 
 
 ### Title
 Committed and pushed directly to main with hooks not installed.
+
+### Version
+pre-1.0.0.
 
 ### Date
 2026-04-03.

--- a/project-spec.md
+++ b/project-spec.md
@@ -54,6 +54,7 @@ Version: 1.0.0
 - `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`), each self-contained in a `SKILL.md` file.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
+- `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement.
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`.


### PR DESCRIPTION
## Summary

- Rewrite README with approach philosophy, project history timeline, per-tool installation paths (Claude Code, Copilot, Codex, Gemini CLI), and prerequisites
- Expand .gitignore with OS/editor/log artifact patterns
- Add GEMINI.md agent instruction entry point
- Reset ai-workflow.md version to 1.0.0
- Tag all 17 observed-ai-failings entries with pre-1.0.0 and add version disclaimer
- Add version field to observed-ai-failings entry template
- Update project-spec.md with GEMINI.md reference

Also done outside this branch:
- Deleted 7 stale local branches, pruned 10 stale remote tracking refs
- Closed issue #33 (implemented via PR #37)
- Added status comments to issues #34, #36, #39

## Remaining after merge

- Tag `v1.0.0` release on main

Closes #61