### PR TITLE
Add rebase safety rules to GitHub Workflow section

### DIFF
--- a/ai-workflow-design-decisions/context-budget-and-maintenance.md
+++ b/ai-workflow-design-decisions/context-budget-and-maintenance.md
@@ -63,6 +63,7 @@ Use this prompt when requesting a chronological session log for workflow mainten
 Produce a chronological log of this chat session for maintenance of the file ai-workflow.md.
 List the following: 
 - [Tooling or environment, e.g. VS Code Copilot, ChatGPT app, CLI agent.]
+- [AI Workflow Version] 
 - [Model if known, e.g. GPT-5.4.]
 - [Repo or project.]
 List each material observation, decision, proposed wording change, accepted change, rejected change, and file edit in order.

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -344,7 +344,7 @@ Rationale: Prevents wasted time debugging failures the change did not cause.
 
 Rationale: Fixing unrelated failures is scope drift and may introduce new problems.
 
-> "If a test that passed in the baseline now fails, treat the change as the cause until proven otherwise."
+> "If a test that passed in the baseline now fails, treat the change as wrong until proven otherwise."
 
 Rationale: The default assumption should be that the change broke it. This prevents the agent from dismissing regressions.
 
@@ -399,10 +399,6 @@ Rationale: Modifying tests to make them pass is a form of scope drift and can ma
 > "Do not run validation commands in parallel when they can share ports, build outputs, caches, or runtime state."
 
 Rationale: Parallel validation with shared state produces flaky, non-deterministic results that waste debugging time.
-
-> "If a previously passing test fails after the change, treat the change as wrong until proven otherwise."
-
-Rationale: The fundamental regression rule. Without this, agents dismiss failures and continue.
 
 > "Run smoke tests and the global test suite after each meaningful implementation pass."
 
@@ -732,6 +728,18 @@ Rationale: Ensures CI runs against the current target state, not a stale snapsho
 
 Rationale: Staleness can accumulate during implementation. The rebase must be fresh at the point of the remote action.
 
+> "Before rebasing, compare tracked files between the branch and target and check whether gitignored or untracked local files exist at paths the target state tracks."
+
+Rationale: Catches two classes of problem before the rebase starts: junk files committed on the branch that would be carried forward, and local gitignored files at paths the target tracks that git would overwrite or delete.
+
+> "If either check reveals unexpected files or path overlap, stop and report before proceeding."
+
+Rationale: Stopping before the rebase gives the human the information needed to decide whether to proceed, clean up the branch, or back up local files. Proceeding blindly leads to cleanup operations that risk destroying local files.
+
+> "If a rebase produces modify/delete conflicts, stop and discuss with the human before resolving."
+
+Rationale: Modify/delete conflicts signal divergent branch history that may require dropping commits or restructuring rather than mechanical resolution. Mechanical resolution without understanding the divergence can carry forward files that should have been dropped.
+
 > "If the task changes significantly during implementation, update the issue or flag the mismatch to the human."
 
 Rationale: The issue is the scope contract. If implementation diverges, the issue must be updated or the human must be informed.
@@ -867,6 +875,10 @@ Rationale: Broad refactors touch many files, increase review burden, and risk re
 > "Deleting files or removing significant code paths."
 
 Rationale: Deletion is hard to reverse and may remove functionality that is not obviously referenced.
+
+> "Running `git reset --hard` or any command that discards uncommitted working-tree state."
+
+Rationale: These commands destroy uncommitted changes including gitignored files at conflicting paths. The damage is irreversible and often invisible until the files are needed.
 
 > "Weakening, skipping, or removing tests."
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 1.0.0
+Version: 1.1.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -128,7 +128,7 @@ Before implementation, run a baseline validation:
 
 When comparing post-implementation results against the baseline:
 
-- If a test that passed in the baseline now fails, treat the change as the cause until proven otherwise.
+- If a test that passed in the baseline now fails, treat the change as wrong until proven otherwise.
 - If a test that failed in the baseline still fails, do not attribute it to the change.
 - Report pre-existing failures separately from change-related failures.
 
@@ -154,7 +154,6 @@ When running validation:
 
 - Do not modify smoke tests or the global test suite unless the task explicitly requires it.
 - Do not run validation commands in parallel when they can share ports, build outputs, caches, or runtime state.
-- If a previously passing test fails after the change, treat the change as wrong until proven otherwise.
 - Run smoke tests and the global test suite after each meaningful implementation pass.
 - Do not treat passing smoke tests and the global test suite as proof that the requested behaviour works.
 - Treat existing passing tests as evidence of stability.
@@ -248,6 +247,10 @@ Every task must follow the GitHub branching workflow:
 - Rebase the issue branch onto the target branch before starting implementation.
 - Rebase the issue branch onto the target branch before creating a pull request.
 - If new commits have landed on the target branch since the last rebase, rebase again before the next remote GitHub action.
+- Before rebasing, compare tracked files between the branch and target and check whether gitignored or untracked local files exist at paths the target state tracks.
+- If either check reveals unexpected files or path overlap, stop and report before proceeding.
+  (Why: Rebase carries forward all tracked files from the branch, and git overwrites local files at conflicting paths regardless of gitignore status.)
+- If a rebase produces modify/delete conflicts, stop and discuss with the human before resolving.
 - If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 - Treat commit creation, push to remote, and pull request creation as separate GitHub actions.
 - Confirm repo-local deterministic policy is active before relying on protected-branch or validation enforcement.
@@ -297,6 +300,7 @@ Stop and ask the human before doing any of the following:
 - ASK before changing public interfaces or shared contracts.
 - ASK before making broad refactors.
 - ASK before deleting files or removing significant code paths.
+- ASK before running `git reset --hard` or any command that discards uncommitted working-tree state.
 - ASK before weakening, skipping, or removing tests.
 - ASK before introducing new conventions or changing existing ones.
 - ASK before introducing a new logging library or pattern.

--- a/observed-ai-failings.md
+++ b/observed-ai-failings.md
@@ -569,3 +569,55 @@ The agent does not reference or check `.ai-policy/` before performing remote git
 
 ### Scope
 This appears general across tasks because hook installation and branch protection checks are prerequisites for any GitHub handoff action.
+
+## Entry 18
+
+### Title
+Destructive git operations destroyed gitignored local files during rebase recovery.
+
+### Version
+1.0.0.
+
+### Date
+2026-04-09.
+
+### Context
+Tooling was Claude Code CLI.
+Model was Claude Opus 4.6.
+Repo was philippe-ths/FCP-Auto-Editor for issue #7.
+
+### What Happened
+The agent resumed work on a stale branch (2 ahead, 8 behind main) and ran `git rebase main`.
+The branch contained junk files (copy-named directories and unrelated workflow files) committed alongside legitimate work.
+The rebase produced modify/delete conflicts on files that main had removed, but the agent resolved them mechanically and continued without questioning the branch history.
+After the user flagged tracked junk files, the agent spent many consecutive investigative commands trying to understand why `git status` showed clean despite unexpected files on disk, instead of immediately comparing tracked files between branches.
+The agent then attempted recovery by running `git reset --hard` twice — first to the pre-rebase state, then dropping a commit — without considering the impact on gitignored local files that existed at the same paths as tracked files on the branch.
+The resets destroyed gitignored local files: `ai-workflow.md`, `project-spec.md`, `.codex/`, `.githooks/`, and parts of `.ai-policy/` and `.github/` were deleted or gutted.
+The agent did not realise the destruction had occurred until the user asked how the files would be restored.
+
+### Why It Matters
+Gitignored files are not protected from git operations when branches track files at the same paths.
+`git rebase`, `git checkout`, and `git reset --hard` can overwrite or delete untracked and gitignored files in this situation.
+The agent treated gitignored files as inherently safe, which is incorrect.
+The destruction was silent and only discovered because the user explicitly asked about restoration.
+
+### Rules Ignored
+- Workflow step 1 (check branch state): Branch state was checked superficially by commit counts, not by examining tracked file differences between branches.
+- Scope control: A cleanup commit unrelated to the task scope was rebased without questioning whether it belonged.
+- Validation requirements (baseline): Declaring the branch clean based on passing tests alone, without verifying the tracked file set matched expectations.
+- GitHub workflow (rebase): The rebase was performed mechanically without verifying the result was correct before proceeding.
+- Boundary rules (stop and ask when risky): The agent did not stop when the rebase produced modify/delete conflicts on files deleted from main, a signal that the branch history was messy.
+- Boundary rules (two commands without reducing uncertainty): The agent ran many consecutive investigative commands without stopping to explain or ask the user.
+- MARR approval requirements: `git reset --hard` is equally destructive as committing or pushing, but was run without discussing the risk to local files.
+
+### Trigger Pattern
+This pattern appears when a branch tracks files at paths that also exist as gitignored local files, and the agent performs destructive git operations (rebase, reset, checkout) without inventorying what local files would be affected.
+
+### Early Warning Signs
+- The branch being rebased has a messy history with commits that add or remove files unrelated to the task.
+- Rebase conflicts involve files that exist on one branch but not the other, especially modify/delete conflicts.
+- The repository has gitignored files at paths that overlap with tracked files on other branches.
+- The agent runs `git reset --hard` without first listing what untracked or gitignored files exist in the working tree.
+
+### Scope
+This appears general across tasks because any repository that uses gitignored local configuration files (workflow files, policy scripts, hooks) is vulnerable when branches track files at the same paths and destructive git operations are performed without checking for path overlap.


### PR DESCRIPTION
## Summary

- Record Entry 18 in `observed-ai-failings.md` documenting destructive git rebase recovery failure
- Add 3 rebase safety rules to GitHub Workflow section (pre-rebase checks, modify/delete conflict handling)
- Add `git reset --hard` to Ask First boundary rules
- Consolidate redundant validation regression rule (was stated twice with different wording)
- Bump `ai-workflow.md` to v1.1.0

Closes #63

## Test plan

- [x] Validation passes (23/23 tests)
- [x] Manual review of new rule wording and placement
- [x] Verify `line-by-line-rationale.md` entries match the new rules