### PR TITLE
Extract Logging and Observability to on-demand skill (#64)

### DIFF
--- a/.claude/skills/failure-analysis/SKILL.md
+++ b/.claude/skills/failure-analysis/SKILL.md
@@ -17,7 +17,7 @@ When tests pass and validation succeeds, the agent believes the implementation i
 This skill works alongside these workflow sections — consult them during investigation:
 
 - **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — use the project's diagnostic approaches when gathering evidence; prefer automated observation over asking the human to report.
+- **Logging and Observability** — load the `logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.claude/skills/logging-and-observability/SKILL.md
+++ b/.claude/skills/logging-and-observability/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: logging-and-observability
+description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
+---
+
+# Logging and Observability
+
+Read this file when the change requires runtime observability to validate correctness.
+This skill ensures the agent has enough runtime visibility to prove its changes work.
+
+## Changes That Typically Need Observability
+
+- Data writes or sync operations.
+- State transitions.
+- User-facing flows.
+- Silently failing error handling paths.
+- Integration points between layers.
+
+## When Adding Logging
+
+- Use the project's existing logging approach.
+- If no logging approach exists, flag this in the plan.
+- Log the action, relevant identifiers, and outcome.
+- Include enough context to trace a problem without a debugger.
+- Do not add logging for trivial operations.
+- Do not add logging that would expose sensitive user data.
+- Do not log full data payloads unless explicitly needed.
+- If a change affects writes, sync behaviour, state transitions, or reactive screens, decide whether temporary diagnostic logging is needed to verify the runtime path.
+- Prefer logs or probes that confirm which code path executed.
+- Prefer logs or probes that confirm which identifiers were used.
+- Prefer logs or probes that confirm which state transition occurred.
+- If observability is too weak to distinguish between competing hypotheses, flag this before continuing.
+- Remove temporary diagnostics before completion unless the human approves keeping them.
+- If a higher-risk change fails manual verification before the runtime path is proven, decide whether temporary diagnostics or another direct observation method is needed before asking the human to retry.
+
+## When Investigating Root Causes or Verifying Runtime Behaviour
+
+- Prefer automated diagnostics over asking the human to observe and report.
+- Write diagnostics that capture structured, non-sensitive output.
+- Capture event types, state changes, control flow decisions, and timestamps when relevant.
+- Run the diagnostic.
+- Read the results.
+- Use the results to drive the next step.
+- If a diagnostic cannot avoid capturing sensitive data, do not write it.
+- Describe what to look for.
+- Let the human observe it directly.
+- Only ask the human to provide logs or reproduce behaviour when automated observation is not possible.
+- If only the human can trigger the condition, ask the human to trigger it and provide the raw output.
+- Do not ask the human to interpret the results.
+- Do not write diagnostics that output sensitive data, including tokens, credentials, PII, full payloads, or anything that could identify a real user.

--- a/.github/skills/failure-analysis/SKILL.md
+++ b/.github/skills/failure-analysis/SKILL.md
@@ -17,7 +17,7 @@ When tests pass and validation succeeds, the agent believes the implementation i
 This skill works alongside these workflow sections — consult them during investigation:
 
 - **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — use the project's diagnostic approaches when gathering evidence; prefer automated observation over asking the human to report.
+- **Logging and Observability** — load the `logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.github/skills/logging-and-observability/SKILL.md
+++ b/.github/skills/logging-and-observability/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: logging-and-observability
+description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
+---
+
+# Logging and Observability
+
+Read this file when the change requires runtime observability to validate correctness.
+This skill ensures the agent has enough runtime visibility to prove its changes work.
+
+## Changes That Typically Need Observability
+
+- Data writes or sync operations.
+- State transitions.
+- User-facing flows.
+- Silently failing error handling paths.
+- Integration points between layers.
+
+## When Adding Logging
+
+- Use the project's existing logging approach.
+- If no logging approach exists, flag this in the plan.
+- Log the action, relevant identifiers, and outcome.
+- Include enough context to trace a problem without a debugger.
+- Do not add logging for trivial operations.
+- Do not add logging that would expose sensitive user data.
+- Do not log full data payloads unless explicitly needed.
+- If a change affects writes, sync behaviour, state transitions, or reactive screens, decide whether temporary diagnostic logging is needed to verify the runtime path.
+- Prefer logs or probes that confirm which code path executed.
+- Prefer logs or probes that confirm which identifiers were used.
+- Prefer logs or probes that confirm which state transition occurred.
+- If observability is too weak to distinguish between competing hypotheses, flag this before continuing.
+- Remove temporary diagnostics before completion unless the human approves keeping them.
+- If a higher-risk change fails manual verification before the runtime path is proven, decide whether temporary diagnostics or another direct observation method is needed before asking the human to retry.
+
+## When Investigating Root Causes or Verifying Runtime Behaviour
+
+- Prefer automated diagnostics over asking the human to observe and report.
+- Write diagnostics that capture structured, non-sensitive output.
+- Capture event types, state changes, control flow decisions, and timestamps when relevant.
+- Run the diagnostic.
+- Read the results.
+- Use the results to drive the next step.
+- If a diagnostic cannot avoid capturing sensitive data, do not write it.
+- Describe what to look for.
+- Let the human observe it directly.
+- Only ask the human to provide logs or reproduce behaviour when automated observation is not possible.
+- If only the human can trigger the condition, ask the human to trigger it and provide the raw output.
+- Do not ask the human to interpret the results.
+- Do not write diagnostics that output sensitive data, including tokens, credentials, PII, full payloads, or anything that could identify a real user.

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -570,15 +570,15 @@ Rationale: The trigger for changing approaches should be evidence, not frustrati
 
 ---
 
-### Logging and Observability: When to add logging
+### Logging and Observability: Loading instruction
 
-> "Decide whether additional logging or observability is needed when the change introduces user-facing flows, data writes, sync operations, state transitions, silently failing error handling paths, or integration points between layers."
+> "Load the `logging-and-observability` skill when the change requires runtime observability to validate correctness."
 
-Rationale: These are the areas where problems are hardest to diagnose after the fact. Logging here provides the most diagnostic value per line.
+Rationale: The skill provides runtime visibility so the agent can prove its changes work. The specific scenarios that need observability live inside the skill to keep the core workflow lean. Extracting the detailed rules to an on-demand skill reclaims always-on context budget.
 
 ---
 
-### Logging and Observability: Adding logging
+### Logging and Observability skill: Adding logging
 
 > "Use the project's existing logging approach."
 
@@ -630,7 +630,7 @@ Rationale: Asking the human to retry without diagnostics produces no new informa
 
 ---
 
-### Logging and Observability: Investigation
+### Logging and Observability skill: Investigation
 
 > "Prefer automated diagnostics over asking the human to observe and report."
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -189,40 +189,7 @@ Before proceeding in failure analysis mode, load the `failure-analysis` skill.
 
 ## Logging and Observability
 
-Decide whether additional logging or observability is needed when the change introduces user-facing flows, data writes, sync operations, state transitions, silently failing error handling paths, or integration points between layers.
-
-When adding logging:
-
-- Use the project's existing logging approach.
-- If no logging approach exists, flag this in the plan.
-- Log the action, relevant identifiers, and outcome.
-- Include enough context to trace a problem without a debugger.
-- Do not add logging for trivial operations.
-- Do not add logging that would expose sensitive user data.
-- Do not log full data payloads unless explicitly needed.
-- If a change affects writes, sync behaviour, state transitions, or reactive screens, decide whether temporary diagnostic logging is needed to verify the runtime path.
-- Prefer logs or probes that confirm which code path executed.
-- Prefer logs or probes that confirm which identifiers were used.
-- Prefer logs or probes that confirm which state transition occurred.
-- If observability is too weak to distinguish between competing hypotheses, flag this before continuing.
-- Remove temporary diagnostics before completion unless the human approves keeping them.
-- If a higher-risk change fails manual verification before the runtime path is proven, decide whether temporary diagnostics or another direct observation method is needed before asking the human to retry.
-
-When investigating root causes or verifying runtime behaviour:
-
-- Prefer automated diagnostics over asking the human to observe and report.
-- Write diagnostics that capture structured, non-sensitive output.
-- Capture event types, state changes, control flow decisions, and timestamps when relevant.
-- Run the diagnostic.
-- Read the results.
-- Use the results to drive the next step.
-- If a diagnostic cannot avoid capturing sensitive data, do not write it.
-- Describe what to look for.
-- Let the human observe it directly.
-- Only ask the human to provide logs or reproduce behaviour when automated observation is not possible.
-- If only the human can trigger the condition, ask the human to trigger it and provide the raw output.
-- Do not ask the human to interpret the results.
-- Do not write diagnostics that output sensitive data, including tokens, credentials, PII, full payloads, or anything that could identify a real user.
+Load the `logging-and-observability` skill when the change requires runtime observability to validate correctness.
 
 ## Command Approval
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 1.1.0
+Version: 1.2.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-spec.md
+++ b/project-spec.md
@@ -49,9 +49,9 @@ Version: 1.0.0
 - `project-spec-template.md`: template for creating `project-spec.md` in a target repository.
 - `project-spec-design-decisions.md`: maintenance rules for keeping `project-spec.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`), each self-contained in a `SKILL.md` file.
+- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`, `logging-and-observability`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-spec.md`.
-- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`), each self-contained in a `SKILL.md` file.
+- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`, `logging-and-observability`), each self-contained in a `SKILL.md` file.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Extracted the 36-line Logging and Observability section from `ai-workflow.md` into an on-demand skill loaded when runtime observability is needed to validate correctness
- Created skill files in `.claude/skills/logging-and-observability/` and `.github/skills/logging-and-observability/`
- Updated failure-analysis skill cross-references, line-by-line rationale, and project-spec
- Bumped `ai-workflow.md` to v1.2.0

## Test plan
- [x] Validation suite passes (23/23)
- [x] Skill appears in Claude Code available skills list
- [x] Review taxonomy applied to full `ai-workflow.md` — no cross-contamination or placement issues found
- [x] Manual review: confirm no logging rules remain inlined in core workflow
- [x] Manual review: confirm skill content matches original section

Closes #64