### PR TITLE
feat: add VS Code Copilot protected branch enforcement via PreToolUse hooks

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -4,3 +4,4 @@ set -eu
 bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-claude-code-enforcement.sh
 ./.ai-policy/scripts/test-codex-enforcement.sh
+./.ai-policy/scripts/test-vscode-copilot-enforcement.sh

--- a/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+++ b/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for VS Code Copilot agent-level protected branch enforcement.
+# Covers Path 1 (Shell/Bash via PreToolUse → bash hook) and
+# Path 2 (MCP via PreToolUse → mcp hook).
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PASS=0
+FAIL=0
+
+assert_blocked() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 2, got $exit_code)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 0, got $exit_code)"
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local file="$2"
+  local expected="$3"
+  if grep -qF "$expected" "$file"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected '$expected' in $file)"
+  fi
+}
+
+HOOK_JSON="$ROOT_DIR/.github/hooks/block-protected-branch.json"
+MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
+BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+
+# ── Prerequisite: config file exists and is valid JSON ──
+
+echo "Prerequisite checks:"
+
+if [ -f "$HOOK_JSON" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: .github/hooks/block-protected-branch.json exists"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: .github/hooks/block-protected-branch.json missing"
+fi
+
+if jq empty "$HOOK_JSON" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: hook config is valid JSON"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: hook config is not valid JSON"
+fi
+
+assert_contains "hook config references PreToolUse" "$HOOK_JSON" '"PreToolUse"'
+assert_contains "hook config references MCP hook script" "$HOOK_JSON" "block-protected-branch-mcp.sh"
+assert_contains "hook config references bash hook script" "$HOOK_JSON" "block-protected-branch-bash.sh"
+
+# ── Path 2: MCP tool blocking via PreToolUse → mcp hook ──
+
+echo "Path 2 — MCP tool blocking (PreToolUse → mcp hook):"
+
+# Test: push_files targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"main","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "push_files to main" "$rc"
+
+# Test: create_or_update_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_or_update_file","tool_input":{"branch":"master","owner":"x","repo":"y","path":"f","content":"c","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_or_update_file to master" "$rc"
+
+# Test: delete_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__delete_file","tool_input":{"branch":"main","owner":"x","repo":"y","path":"f","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "delete_file on main" "$rc"
+
+# Test: create_pull_request with base=main → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_pull_request base=main" "$rc"
+
+# Test: push_files targeting non-protected branch → allowed
+rc=0
+printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"feature/foo","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "push_files to feature/foo" "$rc"
+
+# Test: merge_pull_request (no branch field) → allowed (known limitation)
+rc=0
+printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+
+# ── Path 1: Shell/Bash blocking via PreToolUse → bash hook ──
+
+echo "Path 1 — Shell/Bash blocking (PreToolUse → bash hook):"
+
+# Use simulated branch to test both protected and non-protected scenarios.
+TMPDIR_TEST="$(mktemp -d)"
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
+
+# Override to return "main".
+cat > "$TMPDIR_TEST/current-branch-fake-main.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "main"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-main.sh"
+
+# Override to return a feature branch.
+cat > "$TMPDIR_TEST/current-branch-fake-feature.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "feature/test"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-feature.sh"
+
+# --- Tests on protected branch ---
+cp "$TMPDIR_TEST/current-branch-fake-main.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git commit on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"ls -la"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "ls on main (simulated)" "$rc"
+
+# --- Tests on feature branch ---
+cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git commit on feature/test (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin feature/test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push on feature/test (simulated)" "$rc"
+
+# Restore real script.
+cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+rm -rf "$TMPDIR_TEST"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.github/hooks/block-protected-branch.json
+++ b/.github/hooks/block-protected-branch.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
+      },
+      {
+        "type": "command",
+        "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\""
+      }
+    ]
+  }
+}

--- a/project-spec.md
+++ b/project-spec.md
@@ -57,14 +57,15 @@ Version: 1.0.0
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`.
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, and `.github/hooks/`.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
+- `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.codex/config.toml`, `.codex/hooks.json`: Codex-specific agent configuration and hook definitions.
 - `.claude/settings.json`: Claude Code local settings including hook configuration.
 
 ## Testing Overview
 - Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`.
-- Validation also runs two enforcement integration tests: `test-claude-code-enforcement.sh` and `test-codex-enforcement.sh`.
+- Validation also runs three enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, and `test-vscode-copilot-enforcement.sh`.
 - No unit test framework exists; there are no automated tests for documentation content.
 - Manual verification is the primary check for documentation changes.
 


### PR DESCRIPTION
## Summary

Adds deterministic protected branch enforcement for VS Code Copilot agent via the PreToolUse hooks mechanism (Preview).

Closes #34

## What changed

- **`.github/hooks/block-protected-branch.json`** — VS Code Copilot PreToolUse hook config that wires to the shared `.ai-policy/hooks/` scripts for both MCP and Shell/Bash paths.
- **`.ai-policy/scripts/test-vscode-copilot-enforcement.sh`** — 16 automated tests covering both execution paths (MCP tool blocking + shell command blocking).
- **`.ai-policy/scripts/project-validation.sh`** — Updated to run the new test suite.
- **`project-spec.md`** — Documents the new hook config and test.

## How it works

- **Path 1 (Shell/Bash):** PreToolUse hook runs `block-protected-branch-bash.sh` before terminal commands. Blocks `git commit`/`git push` when on a protected branch (exit 2).
- **Path 2 (MCP):** PreToolUse hook runs `block-protected-branch-mcp.sh` before MCP tool calls. Blocks `push_files`, `create_or_update_file`, `delete_file`, `create_pull_request` when targeting a protected branch.

Both hooks reuse the existing shared scripts — no new hook scripts were needed.

## Testing

- **Automated:** 39/39 tests pass (16 new + 23 existing, no regressions)
- **Manual verification:** MCP `push_files` to `main` blocked at runtime after window reload; commit allowed on feature branch. MCP `create_pull_request` to `main` also blocked (consistent with Claude Code enforcement).

## Known limitations

- `merge_pull_request` has no `branch`/`base` field — allowed through (same as Claude Code/Codex enforcement). Mitigated by GitHub branch protection.
- `send_to_terminal` not covered by bash hook — mitigated by `.githooks/pre-commit` and `pre-push`.
- VS Code hooks feature is Preview — behaviour may change in future releases.