### PR TITLE
Add GitHub coupling and human-AI collaboration note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ AI coding agents routinely skip validation, expand scope beyond what was approve
 
 The workflow is written for the agent. The design decision files are written for the human maintainer.
 
+The workflow assumes GitHub for issue tracking and branching. It is designed as a tightly coupled human-AI collaboration where each side has defined responsibilities — the human scopes work, reviews plans, and approves actions; the agent plans, implements, and validates. Future versions will support more configurable and automated modes.
+
 **Prerequisites:** bash, git.
 
 ## Approach


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the workflow's design assumptions and future direction. It now explicitly states that the workflow assumes GitHub for issue tracking and branching, and describes the division of responsibilities between the human and AI agent. It also mentions plans for future configurability and automation.

Documentation improvements:

* Added a paragraph to the `README.md` explaining that the workflow assumes GitHub for issue tracking and branching, outlines the human-AI collaboration model, and notes that future versions will offer more configurable and automated modes.