### PR TITLE
feat: add Gemini CLI protected branch enforcement

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -5,3 +5,4 @@ bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-claude-code-enforcement.sh
 ./.ai-policy/scripts/test-codex-enforcement.sh
 ./.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+./.ai-policy/scripts/test-gemini-enforcement.sh

--- a/.ai-policy/scripts/test-gemini-enforcement.sh
+++ b/.ai-policy/scripts/test-gemini-enforcement.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for Gemini CLI agent-level protected branch enforcement.
+# Covers Path 1 (Shell/Bash via hooks.BeforeTool → bash hook) and
+# Path 2 (MCP via hooks.BeforeTool → mcp hook).
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PASS=0
+FAIL=0
+
+assert_blocked() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 2, got $exit_code)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1"
+  local exit_code="$2"
+  if [ "$exit_code" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit 0, got $exit_code)"
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local file="$2"
+  local expected="$3"
+  if grep -qF "$expected" "$file"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected '$expected' in $file)"
+  fi
+}
+
+MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
+BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+SETTINGS_JSON="$ROOT_DIR/.gemini/settings.json"
+
+# ── Prerequisite: config file exists ──
+
+echo "Prerequisite checks:"
+
+if [ -f "$SETTINGS_JSON" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: .gemini/settings.json exists"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: .gemini/settings.json missing"
+fi
+
+# ── Config wiring checks ──
+
+echo "Config wiring:"
+
+assert_contains "settings.json references BeforeTool" "$SETTINGS_JSON" '"BeforeTool"'
+assert_contains "settings.json references bash hook script" "$SETTINGS_JSON" "block-protected-branch-bash.sh"
+assert_contains "settings.json references mcp hook script" "$SETTINGS_JSON" "block-protected-branch-mcp.sh"
+assert_contains "settings.json matches run_shell_command" "$SETTINGS_JSON" "run_shell_command"
+assert_contains "settings.json matches mcp github pattern" "$SETTINGS_JSON" "mcp_.*github.*"
+
+# ── Path 2: MCP tool blocking via BeforeTool → mcp hook ──
+
+echo "Path 2 — MCP tool blocking (Gemini BeforeTool → mcp hook):"
+
+# Gemini uses single-underscore MCP naming: mcp_github_<tool>
+# The shared mcp hook checks tool_input.branch / tool_input.base regardless of tool_name format.
+
+# Test: push_files targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp_github_push_files","tool_input":{"branch":"main","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "push_files to main" "$rc"
+
+# Test: create_or_update_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp_github_create_or_update_file","tool_input":{"branch":"master","owner":"x","repo":"y","path":"f","content":"c","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_or_update_file to master" "$rc"
+
+# Test: delete_file targeting protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp_github_delete_file","tool_input":{"branch":"main","owner":"x","repo":"y","path":"f","message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "delete_file on main" "$rc"
+
+# Test: create_pull_request with base=main → blocked
+rc=0
+printf '{"tool_name":"mcp_github_create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_pull_request base=main" "$rc"
+
+# Test: push_files targeting non-protected branch → allowed
+rc=0
+printf '{"tool_name":"mcp_github_push_files","tool_input":{"branch":"feature/foo","owner":"x","repo":"y","files":[],"message":"m"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "push_files to feature/foo" "$rc"
+
+# Test: merge_pull_request (no branch field) → allowed (limitation)
+rc=0
+printf '{"tool_name":"mcp_github_merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+
+# ── Path 1: Shell/Bash blocking via BeforeTool → bash hook ──
+
+echo "Path 1 — Shell/Bash blocking (Gemini BeforeTool → bash hook):"
+
+# Gemini's shell tool is run_shell_command, but the hook reads tool_input.command
+# from stdin JSON, which is the same field regardless of tool name.
+
+# Simulate being on a protected branch by overriding current-branch.sh.
+TMPDIR_TEST="$(mktemp -d)"
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
+
+# Override to return "main".
+cat > "$TMPDIR_TEST/current-branch-fake-main.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "main"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-main.sh"
+
+# Override to return a feature branch.
+cat > "$TMPDIR_TEST/current-branch-fake-feature.sh" <<'FAKE'
+#!/usr/bin/env bash
+echo "feature/test"
+FAKE
+chmod +x "$TMPDIR_TEST/current-branch-fake-feature.sh"
+
+# --- Tests on protected branch ---
+cp "$TMPDIR_TEST/current-branch-fake-main.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git commit on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"ls -la"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "ls on main (simulated)" "$rc"
+
+# --- Tests on feature branch ---
+cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git commit -m test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git commit on feature/test (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin feature/test"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push on feature/test (simulated)" "$rc"
+
+# Restore real script.
+cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+rm -rf "$TMPDIR_TEST"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "mcp_.*github.*",
+        "hooks": [
+          {
+            "name": "block-protected-branch-mcp",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\"",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "block-protected-branch-bash",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/project-spec.md
+++ b/project-spec.md
@@ -57,15 +57,16 @@ Version: 1.0.0
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, and `.github/hooks/`.
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
+- `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration for protected branch enforcement.
 - `.codex/config.toml`, `.codex/hooks.json`: Codex-specific agent configuration and hook definitions.
 - `.claude/settings.json`: Claude Code local settings including hook configuration.
 
 ## Testing Overview
 - Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`.
-- Validation also runs three enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, and `test-vscode-copilot-enforcement.sh`.
+- Validation also runs four enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, and `test-gemini-enforcement.sh`.
 - No unit test framework exists; there are no automated tests for documentation content.
 - Manual verification is the primary check for documentation changes.
 


### PR DESCRIPTION
## Summary

Adds agent-level deterministic blocking for protected branch operations in Gemini CLI, completing enforcement parity across all four supported agents (Claude Code, Codex, VS Code Copilot, Gemini CLI).

Closes #36

## Changes

### Path 1 — Shell/Bash blocking
- `hooks.BeforeTool` matcher on `run_shell_command` invokes the shared `.ai-policy/hooks/block-protected-branch-bash.sh` script
- Blocks `git commit` and `git push` when on a protected branch (`main`, `master`)

### Path 2 — MCP tool blocking
- `hooks.BeforeTool` matcher on `mcp_.*github.*` invokes the shared `.ai-policy/hooks/block-protected-branch-mcp.sh` script
- Blocks MCP write tools (`push_files`, `create_or_update_file`, `delete_file`, `create_pull_request`) when targeting a protected branch

### Files

| File | Action |
|------|--------|
| `.gemini/settings.json` | Created — BeforeTool hook configuration |
| `.ai-policy/scripts/test-gemini-enforcement.sh` | Created — 17 integration tests |
| `.ai-policy/scripts/project-validation.sh` | Modified — added Gemini test to suite |
| `project-spec.md` | Modified — documented new files |

## Validation

All 56 tests pass (39 existing + 17 new Gemini tests):
- Prerequisite & config wiring: 6 tests
- Path 2 MCP blocking: 6 tests
- Path 1 Shell/Bash blocking: 5 tests