### PR TITLE
AI workflow v2.0.0: writing quality, rule placement, and structural cleanup

### DIFF
--- a/.claude/skills/failure-analysis/SKILL.md
+++ b/.claude/skills/failure-analysis/SKILL.md
@@ -6,11 +6,11 @@ description: "Structured investigation process for when the user reports that so
 # Failure Analysis Mode
 
 Read this file when entering failure analysis mode.
-This file contains the full process for investigating and resolving contradictions between the agent's expectations and user-observed reality.
+This file contains the full process for investigating and resolving contradictions between your expectations and user-observed reality.
 
 ## Why This Mode Exists
 
-When tests pass and validation succeeds, the agent believes the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between the agent's understanding and reality. The agent's natural response is to jump to the nearest quick fix — but if the agent's understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix — but if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
 
 ## Related Workflow Sections
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: issue-creation
+description: "Structured process for creating follow-up or spin-off GitHub issues during a task. Use this skill when the agent discovers work outside the current scope that should be tracked. The skill exists to prevent implementation-heavy issues that bias the implementing agent and peg to stale code."
+---
+
+# Issue Creation
+
+Read this file when creating a follow-up or spin-off GitHub issue.
+
+## What the Issue Must Contain
+
+- State what needs to change from the user's perspective.
+- State why the change is needed and what triggered the discovery.
+- State acceptance criteria if they are clear.
+
+## What the Issue Must Not Contain
+
+- Do not include file paths, code snippets, or implementation approaches.
+- Do not reference specific functions, variables, or line numbers.
+- Do not prescribe how the implementing agent should solve the problem.
+  (Why: Implementation details peg to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
+
+## Keeping Issues Concise
+
+- Keep the issue short.
+- State intent, not process.
+- One issue per concern.

--- a/.claude/skills/logging-and-observability/SKILL.md
+++ b/.claude/skills/logging-and-observability/SKILL.md
@@ -6,7 +6,7 @@ description: "Ensures the agent has enough runtime observability to validate its
 # Logging and Observability
 
 Read this file when the change requires runtime observability to validate correctness.
-This skill ensures the agent has enough runtime visibility to prove its changes work.
+This skill ensures you have enough runtime visibility to prove your changes work.
 
 ## Changes That Typically Need Observability
 

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -5,8 +5,8 @@ description: "Structured planning process for producing a code-aware implementat
 
 # Code-Aware Planning
 
-Read this file when producing a code-aware plan before implementation.
-This file contains the full requirements for a valid plan.
+Read this file when producing or revising a code-aware plan.
+This file contains the full requirements for a valid plan and for handling human feedback at review.
 
 ## Related Workflow Sections
 
@@ -63,3 +63,10 @@ If a codebase-confirmed assumption turns out to be wrong during implementation, 
 - Do not include implementation detail that belongs in the code.
 - Do not restate the issue verbatim.
 - One sentence per item where possible.
+
+## Handling Human Feedback at Plan Review
+
+- If the human partially approves, update only the unapproved parts and present the revised plan.
+- If the human adds new requirements, assess whether they change the scope and flag if they do.
+- If the human's feedback contradicts the issue, flag the contradiction.
+- After updating the plan, present the revised plan for re-approval before proceeding.

--- a/.github/skills/failure-analysis/SKILL.md
+++ b/.github/skills/failure-analysis/SKILL.md
@@ -6,11 +6,11 @@ description: "Structured investigation process for when the user reports that so
 # Failure Analysis Mode
 
 Read this file when entering failure analysis mode.
-This file contains the full process for investigating and resolving contradictions between the agent's expectations and user-observed reality.
+This file contains the full process for investigating and resolving contradictions between your expectations and user-observed reality.
 
 ## Why This Mode Exists
 
-When tests pass and validation succeeds, the agent believes the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between the agent's understanding and reality. The agent's natural response is to jump to the nearest quick fix — but if the agent's understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix — but if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
 
 ## Related Workflow Sections
 

--- a/.github/skills/issue-creation/SKILL.md
+++ b/.github/skills/issue-creation/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: issue-creation
+description: "Structured process for creating follow-up or spin-off GitHub issues during a task. Use this skill when the agent discovers work outside the current scope that should be tracked. The skill exists to prevent implementation-heavy issues that bias the implementing agent and peg to stale code."
+---
+
+# Issue Creation
+
+Read this file when creating a follow-up or spin-off GitHub issue.
+
+## What the Issue Must Contain
+
+- State what needs to change from the user's perspective.
+- State why the change is needed and what triggered the discovery.
+- State acceptance criteria if they are clear.
+
+## What the Issue Must Not Contain
+
+- Do not include file paths, code snippets, or implementation approaches.
+- Do not reference specific functions, variables, or line numbers.
+- Do not prescribe how the implementing agent should solve the problem.
+  (Why: Implementation details peg to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
+
+## Keeping Issues Concise
+
+- Keep the issue short.
+- State intent, not process.
+- One issue per concern.

--- a/.github/skills/logging-and-observability/SKILL.md
+++ b/.github/skills/logging-and-observability/SKILL.md
@@ -6,7 +6,7 @@ description: "Ensures the agent has enough runtime observability to validate its
 # Logging and Observability
 
 Read this file when the change requires runtime observability to validate correctness.
-This skill ensures the agent has enough runtime visibility to prove its changes work.
+This skill ensures you have enough runtime visibility to prove your changes work.
 
 ## Changes That Typically Need Observability
 

--- a/.github/skills/planning/SKILL.md
+++ b/.github/skills/planning/SKILL.md
@@ -5,8 +5,8 @@ description: "Structured planning process for producing a code-aware implementat
 
 # Code-Aware Planning
 
-Read this file when producing a code-aware plan before implementation.
-This file contains the full requirements for a valid plan.
+Read this file when producing or revising a code-aware plan.
+This file contains the full requirements for a valid plan and for handling human feedback at review.
 
 ## Related Workflow Sections
 
@@ -63,3 +63,10 @@ If a codebase-confirmed assumption turns out to be wrong during implementation, 
 - Do not include implementation detail that belongs in the code.
 - Do not restate the issue verbatim.
 - One sentence per item where possible.
+
+## Handling Human Feedback at Plan Review
+
+- If the human partially approves, update only the unapproved parts and present the revised plan.
+- If the human adds new requirements, assess whether they change the scope and flag if they do.
+- If the human's feedback contradicts the issue, flag the contradiction.
+- After updating the plan, present the revised plan for re-approval before proceeding.

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -42,19 +42,15 @@ Rationale: If the code says one thing and runtime says another, runtime wins. Pr
 
 Rationale: Links every task to a trackable artifact. Without an issue number, there is no scope boundary and no audit trail.
 
-> "Read the issue and its comments."
+> "Read the issue."
 
-Rationale: Comments often contain clarifications, scope changes, or constraints not in the original issue body. Skipping them leads to stale assumptions.
-
-> "Check parent and sub-issue structure."
-
-Rationale: Prevents the agent from accidentally implementing an entire parent issue when only a sub-issue was intended.
+Rationale: The agent must understand what the task requires before doing any work. The issue is the primary input.
 
 > "Check branch state."
 
 Rationale: The agent must not work on a protected branch. Checking early prevents wasted work that has to be moved later.
 
-> "Rebase onto the target branch."
+> "Check the branch is up to date with the target branch."
 
 Rationale: Working on a stale branch means writing code against an outdated state. Files may have moved, APIs may have changed, or new conflicts may have accumulated.
 
@@ -66,15 +62,15 @@ Rationale: The rule "if a previously passing test fails after the change, treat 
 
 Rationale: Unbounded tasks lead to scope drift. Confirming boundaries early forces the agent to flag multi-objective issues or overly broad tasks before starting.
 
-> "Complete this step before analysing implementation details."
+> "If the GitHub issue number, issue context, active branch, or baseline validation state is missing or unclear, stop and resolve before proceeding."
 
-Rationale: Prevents the agent from jumping into code analysis before confirming the task inputs are correct. Premature analysis wastes context on the wrong problem.
+Rationale: Prevents the agent from jumping into code analysis before confirming the task inputs are correct. Proceeding with missing inputs leads to wasted work on the wrong problem.
 
 ---
 
 ### Workflow Step 2: Review project context
 
-> "Read `project-spec.md` and relevant files."
+> "Review `project-spec.md` for project structure, constraints, and domain context relevant to the task."
 
 Rationale: The project spec provides architectural patterns, structure, and conventions. Reading it before planning prevents the agent from proposing changes that conflict with established patterns.
 
@@ -82,21 +78,19 @@ Rationale: The project spec provides architectural patterns, structure, and conv
 
 Rationale: The agent must verify that the code matches what the issue assumes. Issues are written against the author's mental model, which may be stale.
 
-> "Extract the intended outcome from the issue before using implementation suggestions."
+> "Extract the intended outcome from the issue."
 
-Rationale: Separates the goal (what should change) from the means (how to change it). The goal is authoritative; the implementation suggestions need verification against the current codebase.
+Rationale: Separates the goal (what should change) from the means (how to change it). The detailed rule about handling implementation suggestions lives in Scope Control.
 
 ---
 
 ### Workflow Step 3: Produce a code-aware plan
 
-> "Write the plan."
-
-Rationale: The plan exists as a checkpoint artifact that gives the human a concrete, reviewable description of what the agent intends to do before any code changes happen.
+Rationale: The plan exists as a checkpoint artifact that gives the human a concrete, reviewable description of what the agent intends to do before any code changes happen. The pointer to Planning Requirements keeps the workflow step lean.
 
 ---
 
-### Workflow Step 4: Checkpoint - human reviews the plan
+### Workflow Checkpoint 4: Human reviews the plan
 
 > "Update the plan if the human requests changes."
 
@@ -128,7 +122,7 @@ Rationale: Automated tests cannot cover every user-facing path. The agent should
 
 ---
 
-### Workflow Step 8: Checkpoint - human reviews validation and manual verification
+### Workflow Checkpoint 8: Human reviews validation and manual verification
 
 Rationale: Gate before the agent proceeds to fixes. The human may have observations the agent cannot detect.
 
@@ -144,11 +138,11 @@ Rationale: Directs the agent to address what the human identified during the che
 
 Rationale: A fix can introduce new regressions. Re-validating after each fix prevents error compounding.
 
-> "Repeat until no issues remain."
+> "Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed."
 
-Rationale: Sets an explicit termination condition. Without it the agent may stop after one pass even when multiple issues were reported.
+Rationale: Provides explicit routing for the fix loop. Without it, the agent may not know whether to re-implement or just re-validate, or may stop after one pass even when multiple issues were reported.
 
-> "Enter Failure Analysis Mode if a fix fails." / "Enter Failure Analysis Mode if manual verification fails."
+> "If a fix fails or manual verification fails, enter Failure Analysis Mode."
 
 Rationale: Prevents the agent from cycling through speculative fixes. Manual verification failure means runtime contradicts the implementation. Forces structured reasoning before more code changes.
 
@@ -172,6 +166,22 @@ Rationale: Honest reporting prevents the human from assuming full coverage when 
 
 Rationale: The agent may have discovered problems outside the current scope. These should be surfaced, not silently dropped.
 
+> "If follow-up issues need to be created, load the `issue-creation` skill."
+
+Rationale: Follow-up work identified during the task should be captured in structured issues rather than lost in conversation. The skill ensures consistent issue quality.
+
+> "Flag if documentation or README files need updating based on the change."
+
+Rationale: Code changes can make existing documentation inaccurate. Flagging this prevents documentation drift.
+
+> "Flag if version numbers need updating."
+
+Rationale: Some changes require version bumps. The agent should surface this for the human to decide.
+
+> "Flag if a tagged release is needed."
+
+Rationale: Release decisions belong to the human, but the agent should flag when a change warrants one.
+
 > "Check parent and sub-issue closure status."
 
 Rationale: Lets the human know whether completing this sub-issue closes the parent.
@@ -182,7 +192,7 @@ Rationale: Prepares the handoff. The agent proposes; the human decides.
 
 ---
 
-### Workflow Step 11: Checkpoint - human approves the next GitHub action
+### Workflow Checkpoint 11: Human approves the next GitHub action
 
 > "Stop after the summary until the human explicitly approves the next GitHub action in the current session."
 
@@ -196,89 +206,57 @@ Rationale: Prevents the agent from pushing code or creating PRs based on momentu
 
 Rationale: Prevents chaining (e.g. human approves a push, agent also creates a PR). Each action is a separate approval.
 
+> "If the human approves another GitHub action, return to Step 11."
+
+Rationale: Keeps the one-action-at-a-time model. The human can approve sequential actions, but each requires its own approval cycle.
+
+---
+
+### Workflow Step 13: Post-merge cleanup
+
+> "Check whether the local issue branch has unmerged commits before deleting it."
+
+Rationale: Prevents accidental loss of work that was not included in the merge.
+
+> "Switch to the main branch."
+
+Rationale: Returns the working tree to the shared branch so the next task starts from the correct base.
+
+> "Pull latest changes from remote."
+
+Rationale: Ensures the local main branch includes the just-merged changes and any other recent commits.
+
+> "Close the GitHub issue."
+
+Rationale: Marks the task as complete in the tracking system. Open issues with merged work create false signals about remaining work.
+
+> "If the issue uses checkboxes, check off completed items."
+
+Rationale: Keeps the issue's progress indicators accurate for anyone reviewing the issue history.
+
+> "Comment on the issue with key findings or direction changes."
+
+Rationale: Captures context that would otherwise be lost in the conversation. Future readers of the issue benefit from knowing what was discovered during implementation.
+
+> "Return to Step 1 for the next task, or end the session."
+
+Rationale: Closes the loop. The workflow is continuous until the human decides to stop.
+
 ---
 
 ### Planning Requirements
 
-> "State the branch the work will be implemented on."
+> "Use when executing Step 3 (Produce a code-aware plan) or Checkpoint 4 (human reviews the plan)."
 
-Rationale: Makes the branch explicit in the plan so the human can verify it before coding starts.
+Rationale: Scopes when the planning skill is relevant so the agent does not load it at other workflow steps.
 
-> "State the goal of the change in one or two sentences."
+> "Do not produce a plan without loading this skill first."
 
-Rationale: Forces the agent to articulate the goal concisely. A plan without a clear goal cannot be reviewed.
+Rationale: The planning skill contains the detailed structure and rules for plans. Without it, the agent produces unstructured plans that are harder to review.
 
-> "State the user-visible behaviour that must change."
+> "Load the `planning` skill."
 
-Rationale: Keeps the plan grounded in outcomes, not just code changes. The human can verify whether the right thing is being changed.
-
-> "State the files and code areas the change will touch."
-
-Rationale: Gives the human a scope preview and forces the agent to verify these files exist and are the right targets.
-
-> "State the proposed implementation approach."
-
-Rationale: The reviewable core of the plan. The human can catch wrong approaches before they become wrong code.
-
-> "State any assumptions the plan depends on."
-
-Rationale: Makes hidden assumptions explicit so the human can validate or challenge them.
-
-> "Separate issue assumptions from codebase-confirmed assumptions."
-
-Rationale: Forces the agent to be explicit about what it knows versus what it is guessing. The human can spot wrong assumptions before they become wrong code.
-
-> "State how each critical assumption will be verified."
-
-Rationale: An assumption without a verification plan is a guess that will not be caught until it fails in production.
-
-> "State any remaining uncertainties or ambiguities."
-
-Rationale: Honest uncertainty reporting lets the human resolve ambiguities before coding starts, when it is cheapest.
-
-> "State the risks and edge cases."
-
-Rationale: Forces proactive risk identification rather than discovering edge cases during implementation or review.
-
-> "Mark the change as higher-risk if it affects routing, persistence, sync, caching, reactive subscriptions, or state transitions."
-
-Rationale: These areas have non-local effects. A bug can appear correct locally but break a different screen or surface only after a delay.
-
-> "Include at least one runtime validation step for higher-risk changes."
-
-Rationale: Higher-risk areas cannot be validated by unit tests alone. Runtime validation catches problems that only manifest in the full execution context.
-
-> "State the validation approach."
-
-Rationale: Commits the plan to a specific validation strategy that the human can review.
-
-> "State any logging or observability changes needed."
-
-Rationale: Logging decisions should be deliberate and planned, not afterthoughts during implementation.
-
-> "Treat the issue goal as authoritative."
-
-Rationale: The goal (what should change) comes from the human who filed the issue. The agent should not second-guess the goal itself.
-
-> "Treat issue-suggested implementation details as provisional until the current codebase confirms them."
-
-Rationale: Issues are written against the author's mental model, which may be stale or wrong. The agent must verify before trusting.
-
-> "Do not assume the files, data flow, or control points named in the issue are the real execution path."
-
-Rationale: The issue may reference files that no longer exist or logic that has moved.
-
-> "If the issue and the current codebase disagree, prioritise the codebase and flag the mismatch to the human."
-
-Rationale: First principle: the codebase provides implementation truth. The agent should not silently follow stale issue instructions.
-
-> "If the issue suggests a structure that the current codebase does not follow, plan against the real structure and flag the mismatch to the human."
-
-Rationale: Planning against a structure that does not exist produces code that does not work.
-
-> "Keep the plan concise."
-
-Rationale: Long plans waste context tokens and are harder for the human to review. Brevity forces precision.
+Rationale: Extracts detailed planning rules to an on-demand skill to keep the core workflow lean and reclaim always-on context budget.
 
 ---
 
@@ -308,6 +286,10 @@ Rationale: Agents tend to pick the easiest objective and declare progress, leavi
 
 Rationale: Cross-cutting changes are harder to review, harder to test, and more likely to introduce regressions.
 
+> "Extract the intended outcome from the issue before using implementation suggestions."
+
+Rationale: Separates the goal (what should change) from the means (how to change it). The goal is authoritative; the implementation suggestions need verification against the current codebase. Issues are often stale or speculative.
+
 > "Do only the work required to complete the task."
 
 Rationale: The fundamental scope rule. Everything else in this section is a specific application of this principle.
@@ -323,6 +305,14 @@ Rationale: Mixing change types in one task makes review harder and makes it impo
 > "If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation."
 
 Rationale: Silently broadening scope is the most common agent failure mode. Flagging preserves scope while ensuring the problem is not lost.
+
+> "If the human approves, load the `issue-creation` skill to create the follow-up issue."
+
+Rationale: Provides the action path for flagged follow-up work. The skill ensures follow-up issues are well-formed rather than hastily written.
+
+> "If the task changes significantly during implementation, update the issue or flag the mismatch to the human."
+
+Rationale: The issue is the scope contract. If implementation diverges, the issue must be updated or the human must be informed so the scope contract stays accurate.
 
 ---
 
@@ -410,11 +400,7 @@ Rationale: Existing tests may not cover the new behaviour. Passing tests only pr
 
 > "Treat existing passing tests as evidence of stability."
 
-Rationale: Passing tests confirm the change did not break existing behaviour.
-
-> "Do not treat existing passing tests as proof of correctness for new behaviour."
-
-Rationale: New behaviour needs its own tests. Existing tests were not written to validate it.
+Rationale: Passing tests confirm the change did not break existing behaviour. They are not proof that new behaviour is correct.
 
 > "If the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path."
 
@@ -423,10 +409,6 @@ Rationale: These areas have non-local effects that unit tests cannot catch. The 
 > "If no automated test exercises the real user path, say so explicitly."
 
 Rationale: Honest reporting. The human needs to know when automated coverage is insufficient.
-
-> "If manual verification fails, stop implementation mode and enter Failure Analysis Mode before making more code changes."
-
-Rationale: Prevents speculative fix cycles. Forces structured diagnosis first.
 
 ---
 
@@ -444,10 +426,6 @@ Rationale: Distinguishing change-caused failures from pre-existing ones prevents
 
 Rationale: Gaps in testing should be transparent so the human can decide whether additional verification is needed.
 
-> "Report failures honestly, including failures unrelated to the change."
-
-Rationale: Hiding failures undermines trust and prevents the human from tracking codebase health.
-
 > "Do not claim code is tested when it is not."
 
 Rationale: False claims of testing are worse than no testing because they suppress the human's review instinct.
@@ -460,9 +438,17 @@ Rationale: Ignoring failures and declaring success is a critical trust violation
 
 ### Manual Verification Requirements
 
-> "Suggest specific manual checks based on the change."
+> "Manual verification covers what only a human can verify."
 
-Rationale: Generic "test the feature" is not actionable. Specific checks tell the human exactly what to verify.
+Rationale: Scopes the section to human-only checks, preventing the agent from suggesting automated verifications here.
+
+> "Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses."
+
+Rationale: Concrete examples prevent the agent from suggesting vague "test the feature" checks. Each category represents something the agent cannot observe.
+
+> "Do not suggest checks that can be verified through automated tests or tool output."
+
+Rationale: Manual verification is expensive. Wasting the human's time on checks the agent could automate undermines the workflow's efficiency.
 
 > "State the success signal for each check."
 
@@ -474,7 +460,7 @@ Rationale: The human needs to know what "broken" looks like to catch regressions
 
 ---
 
-### Failure Analysis Mode: Entry conditions
+### Failure Analysis Mode
 
 > "Enter failure analysis mode when manual verification fails."
 
@@ -488,189 +474,21 @@ Rationale: The contradiction itself is the signal, regardless of how it was disc
 
 Rationale: Tests saying one thing and observation saying another indicates a deeper problem that fix attempts will not resolve.
 
----
+> "Stop implementation and do not make further code changes until failure analysis is complete."
 
-### Failure Analysis Mode: Procedure
+Rationale: Prevents the agent from making speculative fixes while the problem is still undiagnosed. Code changes before diagnosis compound the problem.
 
-> "Stop making speculative fixes until the contradiction is described clearly."
+> "Before proceeding in failure analysis mode, load the `failure-analysis` skill."
 
-Rationale: The default agent behaviour is to immediately attempt fixes, making the problem worse. Stopping forces reasoning first.
-
-> "State the observed behaviour in user terms." / "State the expected behaviour in user terms."
-
-Rationale: Framing in user terms prevents the agent from describing the problem in code terms that obscure the actual failure.
-
-> "Restate the contradiction in one short block before any reasoning."
-
-Rationale: Forces the agent to articulate the problem clearly before attempting to solve it.
-
-> "Use this format: observed behaviour, expected behaviour, strongest conflicting evidence, and what remains unknown."
-
-Rationale: Structured format prevents the agent from skipping steps or burying contradictions in prose.
-
-> "List the assumptions the implementation relied on." / "Mark each assumption as verified, unverified, or disproved."
-
-Rationale: Makes hidden assumptions explicit and forces the agent to check which ones still hold.
-
-> "List plausible failure causes across issue interpretation, code path selection, persistence, sync, caching, routing, UI binding, environment, test coverage, and observability."
-
-Rationale: The checklist prevents tunnel vision. Without it, agents fixate on the first hypothesis and ignore alternatives.
-
-> "Identify the cheapest next observation that can eliminate one or more hypotheses."
-
-Rationale: Directs the agent toward the single observation that would eliminate the most hypotheses rather than cycling through random fixes.
-
-> "If multiple hypotheses exist, prefer the next observation that distinguishes between wrong code path, wrong write, later overwrite, sync overwrite, and stale runtime."
-
-Rationale: These are the most common competing explanations for state-related bugs. Distinguishing between them early saves debugging time.
-
-> "Name the single leading hypothesis before proposing the next step."
-
-Rationale: Forces commitment to a hypothesis, making the reasoning testable and the next step purposeful.
-
-> "State the evidence that currently supports the leading hypothesis."
-
-Rationale: Evidence-backed hypotheses are more likely correct than guesses. If the evidence is thin, that itself is useful information.
-
-> "If repeated fixes under different hypotheses are not converging, state this clearly."
-
-Rationale: Non-convergence is a signal that the approach is fundamentally wrong, not that the agent needs to try harder.
-
-> "If investigation reveals that the plan was based on incorrect assumptions about the codebase, state this clearly."
-
-Rationale: Admitting the plan was wrong is necessary to course-correct. Without this rule, agents try to preserve wrong plans.
-
-> "Report what the plan assumed." / "Report what the codebase actually does." / "Report what a revised approach would need to account for."
-
-Rationale: Structured disclosure of the gap between plan and reality, enabling the human to approve a revised approach.
-
-> "If the contradiction involves a write, state transition, sync boundary, or reactive screen, prefer temporary diagnostics or direct observation over a retry request."
-
-Rationale: Agents frequently ask the human to "try again" as a substitute for understanding what went wrong. Diagnostics produce evidence; retries often do not.
-
-> "Gather evidence before proposing another fix."
-
-Rationale: Prevents fix-without-diagnosis cycles.
-
-> "Test at least one concrete hypothesis before asking the human to retry the flow, refresh the app, clear cache, restart the dev server, or repeat manual verification."
-
-Rationale: Retry requests shift debugging effort to the human and often do not resolve the issue.
-
-> "Prioritise code path, persistence, sync, routing, and UI binding explanations over environment or caching unless evidence shows otherwise."
-
-Rationale: Environment and caching are convenient scapegoats but rarely the actual cause. Code-level explanations are more often correct.
-
-> "Do not signal a flawed approach based on difficulty alone."
-
-Rationale: Difficulty is not evidence of a wrong approach. Premature pivoting wastes the work already done.
-
-> "Signal a flawed approach only when evidence shows the assumptions were wrong."
-
-Rationale: The trigger for changing approaches should be evidence, not frustration.
+Rationale: Extracts detailed failure analysis procedure to an on-demand skill to keep the core workflow lean. The skill provides the structured reasoning framework.
 
 ---
 
-### Logging and Observability: Loading instruction
+### Logging and Observability
 
-> "Load the `logging-and-observability` skill when the change requires runtime observability to validate correctness."
+> "When the change requires runtime observability to validate correctness, load the `logging-and-observability` skill."
 
-Rationale: The skill provides runtime visibility so the agent can prove its changes work. The specific scenarios that need observability live inside the skill to keep the core workflow lean. Extracting the detailed rules to an on-demand skill reclaims always-on context budget.
-
----
-
-### Logging and Observability skill: Adding logging
-
-> "Use the project's existing logging approach."
-
-Rationale: Consistency. Introducing a new logging pattern is scope drift.
-
-> "If no logging approach exists, flag this in the plan."
-
-Rationale: Negative rules need a positive alternative. Flagging it lets the human decide rather than leaving the agent stuck.
-
-> "Log the action, relevant identifiers, and outcome."
-
-Rationale: The minimum useful log entry: action plus identifiers plus outcome is enough to trace a problem.
-
-> "Include enough context to trace a problem without a debugger."
-
-Rationale: If the log requires a debugger to interpret, it has not saved any time.
-
-> "Do not add logging for trivial operations."
-
-Rationale: Verbose logging obscures the meaningful entries and wastes output.
-
-> "Do not add logging that would expose sensitive user data."
-
-Rationale: Security boundary. Logs can be leaked through terminals, commits, or monitoring systems.
-
-> "Do not log full data payloads unless explicitly needed."
-
-Rationale: Full payloads bloat logs and may contain sensitive data. Log identifiers and outcomes instead.
-
-> "If a change affects writes, sync behaviour, state transitions, or reactive screens, decide whether temporary diagnostic logging is needed to verify the runtime path."
-
-Rationale: During development, the agent may need to prove which code path executed before the human can verify the feature works.
-
-> "Prefer logs or probes that confirm which code path executed." / "Prefer logs or probes that confirm which identifiers were used." / "Prefer logs or probes that confirm which state transition occurred."
-
-Rationale: These three pieces of information resolve the most common debugging questions for state-related bugs.
-
-> "If observability is too weak to distinguish between competing hypotheses, flag this before continuing."
-
-Rationale: Continuing without sufficient observability means the next failure will be equally hard to diagnose.
-
-> "Remove temporary diagnostics before completion unless the human approves keeping them."
-
-Rationale: Prevents debug logging from accumulating in the codebase across tasks.
-
-> "If a higher-risk change fails manual verification before the runtime path is proven, decide whether temporary diagnostics or another direct observation method is needed before asking the human to retry."
-
-Rationale: Asking the human to retry without diagnostics produces no new information.
-
----
-
-### Logging and Observability skill: Investigation
-
-> "Prefer automated diagnostics over asking the human to observe and report."
-
-Rationale: Automated diagnostics are reproducible, structured, and do not burden the human with observation tasks the agent could handle.
-
-> "Write diagnostics that capture structured, non-sensitive output."
-
-Rationale: Structured output is parseable by the agent. Non-sensitive output is safe to capture.
-
-> "Capture event types, state changes, control flow decisions, and timestamps when relevant."
-
-Rationale: These are the data points that resolve most debugging questions.
-
-> "Run the diagnostic." / "Read the results." / "Use the results to drive the next step."
-
-Rationale: Explicit sequencing prevents the agent from writing a diagnostic and then ignoring its output.
-
-> "If a diagnostic cannot avoid capturing sensitive data, do not write it."
-
-Rationale: Security boundary. No diagnostic is worth a data leak.
-
-> "Describe what to look for." / "Let the human observe it directly."
-
-Rationale: The fallback when automated diagnostics cannot be made safe. The human observes; the agent does not capture sensitive data.
-
-> "Only ask the human to provide logs or reproduce behaviour when automated observation is not possible."
-
-Rationale: Automated observation is preferred because it is cheaper and more reliable. Human observation is the fallback.
-
-> "If only the human can trigger the condition, ask the human to trigger it and provide the raw output."
-
-Rationale: Some conditions require human interaction. The agent should ask for raw output, not interpreted results.
-
-> "Do not ask the human to interpret the results."
-
-Rationale: Interpretation is the agent's job. Asking the human to interpret shifts cognitive burden without adding value.
-
-> "Do not write diagnostics that output sensitive data, including tokens, credentials, PII, full payloads, or anything that could identify a real user."
-
-Rationale: Comprehensive security boundary. The list is explicit to prevent the agent from rationalising exceptions.
+Rationale: The skill provides runtime visibility so the agent can prove its changes work. Extracting the detailed rules to an on-demand skill reclaims always-on context budget.
 
 ---
 
@@ -728,21 +546,29 @@ Rationale: Ensures CI runs against the current target state, not a stale snapsho
 
 Rationale: Staleness can accumulate during implementation. The rebase must be fresh at the point of the remote action.
 
-> "Before rebasing, compare tracked files between the branch and target and check whether gitignored or untracked local files exist at paths the target state tracks."
+> "Before any operation that moves the working tree to a different branch state (rebase, checkout, switch), compare tracked files between the current branch and the target."
 
-Rationale: Catches two classes of problem before the rebase starts: junk files committed on the branch that would be carried forward, and local gitignored files at paths the target tracks that git would overwrite or delete.
+Rationale: Catches files committed on the branch that would be carried forward or that conflict with the target state.
+
+> "Before the same operation, check whether gitignored or untracked local files exist at paths the target state tracks."
+
+Rationale: Git overwrites or deletes local files at conflicting paths regardless of gitignore status. Checking first prevents silent data loss.
 
 > "If either check reveals unexpected files or path overlap, stop and report before proceeding."
 
-Rationale: Stopping before the rebase gives the human the information needed to decide whether to proceed, clean up the branch, or back up local files. Proceeding blindly leads to cleanup operations that risk destroying local files.
+Rationale: Stopping before the operation gives the human the information needed to decide whether to proceed, clean up, or back up files. Proceeding blindly leads to cleanup operations that risk destroying local files.
+
+> "If the human approves proceeding after a path-overlap report, create a local filesystem backup of the working tree (excluding `.git/`) before running the branch-changing operation."
+
+Rationale: The backup is a safety net against silent file loss during branch operations. No git-native operation preserves gitignored files that are tracked on another branch.
+
+> "Delete the backup only after confirming on the new branch that no expected files were lost."
+
+Rationale: Premature deletion of the backup removes the safety net before the agent has verified the operation was safe.
 
 > "If a rebase produces modify/delete conflicts, stop and discuss with the human before resolving."
 
-Rationale: Modify/delete conflicts signal divergent branch history that may require dropping commits or restructuring rather than mechanical resolution. Mechanical resolution without understanding the divergence can carry forward files that should have been dropped.
-
-> "If the task changes significantly during implementation, update the issue or flag the mismatch to the human."
-
-Rationale: The issue is the scope contract. If implementation diverges, the issue must be updated or the human must be informed.
+Rationale: Modify/delete conflicts signal divergent branch history that may require dropping commits or restructuring rather than mechanical resolution.
 
 > "Treat commit creation, push to remote, and pull request creation as separate GitHub actions."
 
@@ -764,13 +590,9 @@ Rationale: Informs the agent that deterministic enforcement exists so it does no
 
 Rationale: Prevents chaining. Approval for a commit does not imply approval for a push.
 
-> "Do not push to remote without explicit human confirmation in the current session."
+> "Do not push to remote or create a pull request without explicit human confirmation in the current session."
 
-Rationale: Push affects shared state and is hard to reverse. Requires explicit, per-session consent.
-
-> "Do not create a pull request without explicit human confirmation in the current session."
-
-Rationale: PR creation affects shared state and triggers notifications. Requires explicit consent.
+Rationale: Push and PR creation affect shared state, trigger notifications, and are hard to reverse. Each requires explicit, per-session consent.
 
 > "If deterministic policy blocks an action, fix the blocked condition before retrying."
 
@@ -788,43 +610,39 @@ Rationale: Prevents the agent from chaining further actions after completing one
 
 ### Handling Parent and Sub-Issues
 
-> "Treat a parent issue as broader context that may list sub-issues."
+> "Read the issue comments for clarifications, scope changes, and constraints not in the original body."
 
-Rationale: Frames the parent as context, not as a task to implement directly.
+Rationale: Comments often contain clarifications, scope changes, or constraints not in the original issue body. Skipping them leads to stale assumptions. This applies to every issue regardless of hierarchy.
 
-> "Treat a sub-issue as a single bounded work item."
+> "Treat the parent issue as broader context, not as a work item."
 
-Rationale: Sub-issues are the unit of work. Each one should be implementable in a single task.
+Rationale: Frames the parent as context, not as a task to implement directly. Prevents the agent from treating the parent as the work scope.
 
-> "If the provided issue is a parent issue with sub-issues, do not implement the full parent scope."
+> "Do not implement the full parent scope."
 
-Rationale: Implementing the full parent scope would violate scope control. The parent may span multiple tasks.
+Rationale: Implementing the full parent scope would violate scope control. The parent may span multiple tasks across multiple sub-issues.
 
-> "If the provided issue is a parent issue with sub-issues, stop and ask which sub-issue to work on."
+> "Stop and ask which sub-issue to work on."
 
-Rationale: Prevents the agent from picking a sub-issue arbitrarily. The human should choose.
+Rationale: Prevents the agent from picking a sub-issue arbitrarily. The human should choose which sub-issue to work on.
 
-> "If the provided issue is a sub-issue, read the parent issue and its comments for context."
+> "Read the direct parent issue and its comments for context."
 
-Rationale: The parent provides broader context that may inform the sub-issue implementation.
+Rationale: The parent provides broader context that may inform the sub-issue implementation. Comments on the parent may contain constraints relevant to all sub-issues.
 
-> "If the provided issue is a sub-issue, do not read further up the hierarchy."
+> "Do not read further up the hierarchy."
 
 Rationale: Prevents the agent from spending context window on distant ancestors that provide diminishing context.
 
-> "If the provided issue is a sub-issue, implement only the sub-issue scope."
+> "Implement only the sub-issue scope."
 
-Rationale: Scope control. The sub-issue defines the boundary.
+Rationale: Scope control. The sub-issue defines the boundary, not the parent.
 
-> "If the provided issue has no sub-issues, treat it as a standalone work item."
-
-Rationale: Handles the common case where issues are flat, not hierarchical.
-
-> "When completing a sub-issue, check whether it is the last open sub-issue under the parent."
+> "When completing the sub-issue, check whether it is the last open sub-issue under the parent."
 
 Rationale: Convenience signal so the human knows when a larger piece of work is done.
 
-> "If the completed sub-issue is the last open sub-issue under the parent, flag this to the human."
+> "If it is the last open sub-issue, flag this to the human."
 
 Rationale: The human may want to close the parent or review the full body of work.
 
@@ -832,19 +650,19 @@ Rationale: The human may want to close the parent or review the full body of wor
 
 ### Boundary Rules: Always Do
 
-> "Follow the workflow steps in order."
+> "ALWAYS follow the workflow steps in order."
 
 Rationale: The workflow is a sequence, not a menu. Skipping steps leads to missing inputs or unvalidated output.
 
-> "Stop and ask when anything is unclear, risky, or out of scope."
+> "ALWAYS stop and ask when anything is unclear, risky, or out of scope."
 
 Rationale: The agent should not guess through ambiguity. Guessing introduces errors that are caught late at review rather than early at planning.
 
-> "Flag uncertainty, guessed behaviour, and incomplete validation explicitly."
+> "ALWAYS flag uncertainty, guessed behaviour, and incomplete validation explicitly."
 
 Rationale: Honest reporting. The human cannot compensate for problems they do not know about.
 
-> "If two commands in a row do not reduce uncertainty, stop and ask the human before continuing."
+> "ALWAYS stop and ask the human before continuing if two commands in a row do not reduce uncertainty."
 
 Rationale: Non-converging investigation is a signal that the agent is stuck and needs human input rather than more random attempts.
 
@@ -852,51 +670,51 @@ Rationale: Non-converging investigation is a signal that the agent is stuck and 
 
 ### Boundary Rules: Ask First
 
-> "Adding a new dependency."
+> "ASK before adding a new dependency."
 
 Rationale: Dependencies are hard to remove, affect build size and security surface, and may conflict with project constraints.
 
-> "Changing architecture or established patterns."
+> "ASK before changing architecture or established patterns."
 
 Rationale: Architecture changes affect the entire codebase and require deliberate human decision-making.
 
-> "Changing database schema or sync-related behaviour."
+> "ASK before changing database schema or sync-related behaviour."
 
 Rationale: Schema changes are among the hardest to reverse and can break data integrity.
 
-> "Changing public interfaces or shared contracts."
+> "ASK before changing public interfaces or shared contracts."
 
 Rationale: Public interfaces affect consumers who may not be visible to the agent.
 
-> "Making broad refactors."
+> "ASK before making broad refactors."
 
 Rationale: Broad refactors touch many files, increase review burden, and risk regressions across the codebase.
 
-> "Deleting files or removing significant code paths."
+> "ASK before deleting files or removing significant code paths."
 
 Rationale: Deletion is hard to reverse and may remove functionality that is not obviously referenced.
 
-> "Running `git reset --hard` or any command that discards uncommitted working-tree state."
+> "ASK before running `git reset --hard` or any command that discards uncommitted working-tree state."
 
 Rationale: These commands destroy uncommitted changes including gitignored files at conflicting paths. The damage is irreversible and often invisible until the files are needed.
 
-> "Weakening, skipping, or removing tests."
+> "ASK before weakening, skipping, or removing tests."
 
 Rationale: Tests are a safety net. Weakening them to make the change pass is a dangerous shortcut.
 
-> "Introducing new conventions or changing existing ones."
+> "ASK before introducing new conventions or changing existing ones."
 
 Rationale: Conventions affect every future change and should be deliberate human decisions.
 
-> "Introducing a new logging library or pattern."
+> "ASK before introducing a new logging library or pattern."
 
 Rationale: Logging patterns should be consistent across the codebase. A new one fragments the approach.
 
-> "Making assumptions where the task or expected behaviour is unclear."
+> "ASK before making assumptions where the task or expected behaviour is unclear."
 
 Rationale: An assumption made silently becomes wrong code. An assumption made explicitly becomes a question.
 
-> "Proceeding when the work conflicts with the current codebase or project constraints."
+> "ASK before proceeding when the work conflicts with the current codebase or project constraints."
 
 Rationale: Conflicts should be surfaced, not overridden. The human may have context the agent lacks.
 
@@ -904,23 +722,23 @@ Rationale: Conflicts should be surfaced, not overridden. The human may have cont
 
 ### Boundary Rules: Never Do
 
-> "Invent requirements not present in the task or project context."
+> "NEVER invent requirements not present in the task or project context."
 
 Rationale: Invented requirements are scope drift by definition. The agent should implement what was asked, not what it thinks should be asked.
 
-> "Silently expand scope or introduce unrelated changes."
+> "NEVER silently expand scope or introduce unrelated changes."
 
 Rationale: The most common agent failure mode. Silent expansion undermines the human's ability to review and control the work.
 
-> "Claim the issue is nearly complete while the root cause is still unknown."
+> "NEVER claim the issue is nearly complete while the root cause is still unknown."
 
 Rationale: False progress signals prevent the human from intervening when intervention is needed.
 
-> "Hardcode sensitive values."
+> "NEVER hardcode sensitive values."
 
 Rationale: Hardcoded secrets in code are a security vulnerability that persists in version history.
 
-> "Bypass deterministic policy checks or treat them as optional."
+> "NEVER bypass deterministic policy checks or treat them as optional."
 
 Rationale: Deterministic policy exists because instruction-following alone is unreliable. Bypassing it defeats the safety net.
 
@@ -959,6 +777,14 @@ Rationale: Some behaviour can only be verified by a human observing the running 
 > "Report issues found during review or testing."
 
 Rationale: The agent cannot see what the human sees during manual verification. Reported issues drive the fix-and-revalidate loop.
+
+> "Merge pull requests."
+
+Rationale: Merging is a human decision that affects the shared branch. The agent should not merge its own work.
+
+> "Communicate the intent of issues clearly when delegating issue creation."
+
+Rationale: When the agent creates follow-up issues on behalf of the human, the quality depends on the human communicating what they want captured.
 
 > "Decide when the work is complete."
 

--- a/ai-workflow-design-decisions/rule-placement.md
+++ b/ai-workflow-design-decisions/rule-placement.md
@@ -26,7 +26,7 @@ If a line in a workflow step reads like a rule rather than a sequenced action, i
 
 **Human responsibilities do not belong in workflow steps.**
 Lines describing what the human does (e.g. "Human reviews the results") should not appear inline in workflow steps.
-Human checkpoints are expressed as explicit numbered steps (e.g. "Checkpoint: human reviews the plan.").
+Human checkpoints are expressed as explicit numbered steps (e.g. "Checkpoint 4: human reviews the plan.").
 Detailed human responsibilities live in the "The Human is Responsible For" section.
 
 **Boundary rules are context-free. Reference section rules are context-dependent.**

--- a/ai-workflow-design-decisions/writing-rules.md
+++ b/ai-workflow-design-decisions/writing-rules.md
@@ -26,6 +26,11 @@ Every rationale line consumes tokens that compete with the actual task, so each 
 A rule that only says "Do not do X" leaves the agent guessing what to do instead.
 Where possible, pair it with the correct action: "Do not add logging for trivial operations" is fine because the alternative is obvious (do nothing). "Do not use console.log" is incomplete without "Use the project logger instead."
 
+**No third-person self-reference in agent-facing text.**
+In instruction text (workflow steps, skill bodies), use second-person imperative voice.
+Do not refer to the agent in third person: "the agent should", "the agent's expectations", "causes the agent to."
+Third person is acceptable in metadata (skill frontmatter descriptions) and in sections that describe human responsibilities.
+
 **Concrete over abstract.**
 Prefer concrete actions over abstract goals.
 "Run the full test suite" over "Ensure adequate test coverage."

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 1.3.0
+Version: 2.0.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -13,86 +13,103 @@ The human reviews and approves at defined checkpoints.
 
 ## Workflow
 
-1. **Confirm the task and inputs.**
+The workflow runs as a loop.
+Steps 5 through 9 form an implementation cycle: implement, validate, and fix until the human approves.
+Steps 10 through 12 form a handoff cycle: summarise, get approval, and run one GitHub action at a time.
+After the human merges the pull request, run post-merge cleanup and return to Step 1 for the next task.
+
+1. **Step 1: Confirm the task and inputs.**
 
    - Confirm the GitHub issue number.
-   - Read the issue and its comments.
-   - Check parent and sub-issue structure.
+   - Read the issue.
    - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
    - Check branch state.
+   - Check the branch is up to date with the target branch.
    - See [GitHub Workflow](#github-workflow).
-   - Rebase onto the target branch.
    - Run baseline validation.
    - See [Validation Requirements](#validation-requirements).
    - Confirm the task is a bounded change.
    - See [Scope Control](#scope-control).
-   - Complete this step before analysing implementation details.
+   - If the GitHub issue number, issue context, active branch, or baseline validation state is missing or unclear, stop and resolve before proceeding.
 
-2. **Review project context.**
+2. **Step 2: Review project context.**
 
-   - Read `project-spec.md` and relevant files.
+   - Review `project-spec.md` for project structure, constraints, and domain context relevant to the task.
    - Review the code areas the task is likely to touch.
-   - Extract the intended outcome from the issue before using implementation suggestions. (Why: Issue text is often stale or speculative; treating implementation suggestions as authoritative causes the agent to implement the wrong thing.)
+   - Extract the intended outcome from the issue.
+
+3. **Step 3: Produce a code-aware plan.**
+
    - See [Planning Requirements](#planning-requirements).
 
-3. **Produce a code-aware plan.**
-
-   - See [Planning Requirements](#planning-requirements).
-
-4. **Checkpoint: human reviews the plan.**
+4. **Checkpoint 4: human reviews the plan.**
 
    - Update the plan if the human requests changes.
+   - See [Planning Requirements](#planning-requirements) for handling human feedback.
 
-5. **Implement the approved scope.**
+5. **Step 5: Implement the approved scope.**
 
    - Implement the work defined in the approved plan.
    - See [Implementation Rules](#implementation-rules).
    - See [Scope Control](#scope-control).
 
-6. **Run validation.**
+6. **Step 6: Run validation.**
 
    - Run validation checks.
    - See [Validation Requirements](#validation-requirements).
 
-7. **Support manual verification.**
+7. **Step 7: Support manual verification.**
 
    - Suggest manual checks for the human.
    - See [Manual Verification Requirements](#manual-verification-requirements).
 
-8. **Checkpoint: human reviews validation results and manual verification.**
+8. **Checkpoint 8: human reviews validation results and manual verification.**
 
-9. **Fix and revalidate.**
+9. **Step 9: If the human reports issues, fix and revalidate.**
 
    - Fix reported issues.
    - Rerun relevant validation checks after each fix.
-   - Repeat until no issues remain.
-   - Enter [Failure Analysis Mode](#failure-analysis-mode) if a fix fails.
-   - Enter [Failure Analysis Mode](#failure-analysis-mode) if manual verification fails.
+   - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
+   - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
+10. **Step 10: Summarise and prepare handoff.**
 
-10. **Summarise and prepare handoff.**
+    - Report what changed.
+    - Report what was tested.
+    - Report what was not tested.
+    - Report remaining risks and follow-up work.
+    - If follow-up issues need to be created, load the `issue-creation` skill.
+    - Flag if documentation or README files need updating based on the change.
+    - Flag if version numbers need updating.
+    - Flag if a tagged release is needed.
+    - Check parent and sub-issue closure status.
+    - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
+    - State which GitHub action would be next if the human wants to publish the work.
+    - See [GitHub Workflow](#github-workflow).
 
-   - Report what changed.
-   - Report what was tested.
-   - Report what was not tested.
-   - Report remaining risks and follow-up work.
-   - Check parent and sub-issue closure status.
-   - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
-   - State which GitHub action would be next if the human wants to publish the work.
-   - See [GitHub Workflow](#github-workflow).
+11. **Checkpoint 11: human approves the next GitHub action.**
 
-11. **Checkpoint: human approves the next GitHub action.**
+    - Stop after the summary until the human explicitly approves the next GitHub action in the current session.
 
-   - Stop after the summary until the human explicitly approves the next GitHub action in the current session.
+12. **Step 12: Run the approved GitHub action and stop.**
 
-12. **Run the approved GitHub action and stop.**
+    - Run only the single GitHub action the human explicitly approved.
+    - See [GitHub Workflow](#github-workflow).
+    - If the human approves another GitHub action, return to Step 11.
 
-   - Run only the single GitHub action the human explicitly approved.
-   - See [GitHub Workflow](#github-workflow).
+13. **Step 13: Post-merge cleanup.**
+
+    - Check whether the local issue branch has unmerged commits before deleting it.
+    - Switch to the main branch.
+    - Pull latest changes from remote.
+    - Close the GitHub issue.
+    - If the issue uses checkboxes, check off completed items.
+    - Comment on the issue with key findings or direction changes.
+    - Return to Step 1 for the next task, or end the session.
 
 ## Planning Requirements
 
-Use when executing Step 3 of the workflow (Produce a code-aware plan).
+Use when executing Step 3 (Produce a code-aware plan) or Checkpoint 4 (human reviews the plan).
 Do not produce a plan without loading this skill first.
 
 Load the `planning` skill.
@@ -111,10 +128,14 @@ Keep the change focused on the approved task:
 
 - If the issue contains multiple unrelated objectives, flag this and ask the human whether to split them into separate tasks.
 - If the task would require changes across many unrelated areas of the codebase, flag the risk and suggest decomposition.
+- Extract the intended outcome from the issue before using implementation suggestions.
+  (Why: Issue text is often stale or speculative; treating implementation suggestions as authoritative leads to implementing the wrong thing.)
 - Do only the work required to complete the task.
 - Do not treat "while I am here" changes as free. (Why: Each unplanned change introduces untested risk and dilutes commit traceability.)
 - Separate fixes, refactors, and feature work unless the task clearly requires them together. (Why: Mixing change types obscures the commit's intent and makes review harder.)
 - If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation. (Why: Unreviewed scope expansions break the human approval model and introduce unvalidated changes.)
+- If the human approves, load the `issue-creation` skill to create the follow-up issue.
+- If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 
 ## Validation Requirements
 
@@ -157,25 +178,23 @@ When running validation:
 - Run smoke tests and the global test suite after each meaningful implementation pass.
 - Do not treat passing smoke tests and the global test suite as proof that the requested behaviour works.
 - Treat existing passing tests as evidence of stability.
-- Do not treat existing passing tests as proof of correctness for new behaviour.
 - If the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path.
 - If no automated test exercises the real user path, say so explicitly.
-- If manual verification fails, stop implementation mode and enter [Failure Analysis Mode](#failure-analysis-mode) before making more code changes.
 
 When reporting validation:
 
 - Report what was tested and what passed.
 - Report what failed and whether the failure is related to the change.
 - Report what was not tested and why.
-- Report failures honestly, including failures unrelated to the change.
 - Do not claim code is tested when it is not.
 - Do not ignore failing tests and continue as if the task is complete.
 
 ## Manual Verification Requirements
 
-When supporting manual verification:
+Manual verification covers what only a human can verify.
 
-- Suggest specific manual checks based on the change.
+- Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses.
+- Do not suggest checks that can be verified through automated tests or tool output.
 - State the success signal for each check.
 - State the failure signal for each check.
 
@@ -184,12 +203,13 @@ When supporting manual verification:
 Enter failure analysis mode when manual verification fails.
 Enter failure analysis mode when runtime behaviour contradicts the implementation.
 Enter failure analysis mode when test results conflict with observed behaviour.
+Stop implementation and do not make further code changes until failure analysis is complete.
 
 Before proceeding in failure analysis mode, load the `failure-analysis` skill.
 
 ## Logging and Observability
 
-Load the `logging-and-observability` skill when the change requires runtime observability to validate correctness.
+When the change requires runtime observability to validate correctness, load the `logging-and-observability` skill.
 
 ## Command Approval
 
@@ -222,33 +242,35 @@ Every task must follow the GitHub branching workflow:
 - Delete the backup only after confirming on the new branch that no expected files were lost.
   (Why: No git-native operation, including `git stash`, preserves gitignored files that are tracked on another branch during a branch switch.)
 - If a rebase produces modify/delete conflicts, stop and discuss with the human before resolving.
-- If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 - Treat commit creation, push to remote, and pull request creation as separate GitHub actions.
 - Confirm repo-local deterministic policy is active before relying on protected-branch or validation enforcement.
 - If Git `core.hooksPath` is not `.githooks`, run `./.ai-policy/scripts/install-hooks.sh`.
 - Repo-local deterministic policy may block protected-branch Git actions and commit or push without passed validation.
 - Do not infer approval for one GitHub action from approval for another GitHub action.
-- Do not push to remote without explicit human confirmation in the current session.
-- Do not create a pull request without explicit human confirmation in the current session.
+- Do not push to remote or create a pull request without explicit human confirmation in the current session.
 - If deterministic policy blocks an action, fix the blocked condition before retrying.
 - If new commits are added after approval, stop and ask again before the next remote GitHub action.
 - After running an approved GitHub action, stop and report the result.
 
 ## Handling Parent and Sub-Issues
 
-Some work may be organised into parent issues and sub-issues in GitHub.
-When this structure is used:
+For every issue:
 
-- Treat a parent issue as broader context that may list sub-issues.
-- Treat a sub-issue as a single bounded work item.
-- If the provided issue is a parent issue with sub-issues, do not implement the full parent scope.
-- If the provided issue is a parent issue with sub-issues, stop and ask which sub-issue to work on.
-- If the provided issue is a sub-issue, read the parent issue and its comments for context.
-- If the provided issue is a sub-issue, do not read further up the hierarchy.
-- If the provided issue is a sub-issue, implement only the sub-issue scope.
-- If the provided issue has no sub-issues, treat it as a standalone work item.
-- When completing a sub-issue, check whether it is the last open sub-issue under the parent.
-- If the completed sub-issue is the last open sub-issue under the parent, flag this to the human.
+- Read the issue comments for clarifications, scope changes, and constraints not in the original body.
+
+When the issue has sub-issues (it is a parent):
+
+- Treat the parent issue as broader context, not as a work item.
+- Do not implement the full parent scope.
+- Stop and ask which sub-issue to work on.
+
+When the issue is a sub-issue:
+
+- Read the direct parent issue and its comments for context.
+- Do not read further up the hierarchy.
+- Implement only the sub-issue scope.
+- When completing the sub-issue, check whether it is the last open sub-issue under the parent.
+- If it is the last open sub-issue, flag this to the human.
 
 ## Boundary Rules
 
@@ -291,7 +313,7 @@ Do not do any of the following under any circumstances:
 ## The Human is Responsible For
 
 The AI cannot perform these tasks.
-They must be completed by the human.
+The human must complete them.
 
 - Define and scope the task before it reaches the AI.
 - Decompose larger work into sub-issues and provide a sub-issue rather than the parent as the starting input.
@@ -301,4 +323,6 @@ They must be completed by the human.
 - Monitor for scope drift during implementation.
 - Perform manual verification where automated tests are not sufficient.
 - Report issues found during review or testing.
+- Merge pull requests.
+- Communicate the intent of issues clearly when delegating issue creation.
 - Decide when the work is complete.

--- a/lite-monolithic/README.md
+++ b/lite-monolithic/README.md
@@ -21,9 +21,8 @@ Developers who want lightweight AI coding guardrails they can drop into any repo
 The full version includes:
 
 - A policy enforcement layer (`.ai-policy/` scripts and git hooks) that blocks commits and pushes when rules are violated.
-- Separate skill files loaded on demand for planning, failure analysis, and logging/observability.
+- Separate skill files loaded on demand for planning, failure analysis, logging/observability, and issue creation.
 - Multi-agent entry points for VS Code Copilot, Claude Code, Codex, and Gemini CLI.
 - A project-spec template for documenting implementation truth in target repositories.
-- Parent and sub-issue handling for decomposed GitHub work.
 
 This lite version strips all of that down to a single file with the essential rules inlined. If you need deterministic enforcement or multi-agent configuration, use the [full version](https://github.com/philippe-ths/ai-coding-workflow).

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 1.0.0
+Version: 2.0.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -13,84 +13,83 @@ The human reviews and approves at defined checkpoints.
 
 ## Workflow
 
-1. **Confirm the task and inputs.**
+1. **Step 1: Confirm the task and inputs.**
 
    - Confirm the GitHub issue number.
-   - Read the issue and its comments.
-   - Check branch state.
+   - Read the issue.
+   - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
+   - Check branch state and confirm the branch is up to date with the target branch.
    - See [GitHub Workflow](#github-workflow).
-   - Rebase onto the target branch.
    - Run baseline validation.
    - See [Validation Requirements](#validation-requirements).
    - Confirm the task is a bounded change.
    - See [Scope Control](#scope-control).
-   - Complete this step before analysing implementation details.
+   - If the GitHub issue number, issue context, active branch, or baseline validation state is missing or unclear, stop and resolve before proceeding.
 
-2. **Review project context.**
+2. **Step 2: Review project context.**
 
-   - Read relevant project files.
+   - Review relevant project files for structure, constraints, and domain context.
    - Review the code areas the task is likely to touch.
-   - Extract the intended outcome from the issue before using implementation suggestions. (Why: Issue text is often stale or speculative; treating implementation suggestions as authoritative causes the agent to implement the wrong thing.)
+   - Extract the intended outcome from the issue.
 
-3. **Produce a code-aware plan.**
+3. **Step 3: Produce a code-aware plan.**
 
    - See [Planning Requirements](#planning-requirements).
 
-4. **Checkpoint: human reviews the plan.**
+4. **Checkpoint 4: human reviews the plan.**
 
    - Update the plan if the human requests changes.
 
-5. **Implement the approved scope.**
+5. **Step 5: Implement the approved scope.**
 
    - Implement the work defined in the approved plan.
    - See [Implementation Rules](#implementation-rules).
    - See [Scope Control](#scope-control).
 
-6. **Run validation.**
+6. **Step 6: Run validation.**
 
    - Run validation checks.
    - See [Validation Requirements](#validation-requirements).
 
-7. **Support manual verification.**
+7. **Step 7: Support manual verification.**
 
    - Suggest manual checks for the human.
    - See [Manual Verification Requirements](#manual-verification-requirements).
 
-8. **Checkpoint: human reviews validation results and manual verification.**
+8. **Checkpoint 8: human reviews validation results and manual verification.**
 
-9. **Fix and revalidate.**
+9. **Step 9: If the human reports issues, fix and revalidate.**
 
    - Fix reported issues.
    - Rerun relevant validation checks after each fix.
-   - Repeat until no issues remain.
-   - Enter [Failure Analysis Mode](#failure-analysis-mode) if a fix fails.
-   - Enter [Failure Analysis Mode](#failure-analysis-mode) if manual verification fails.
+   - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
+   - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
-10. **Summarise and prepare handoff.**
+10. **Step 10: Summarise and prepare handoff.**
 
-    - Report what changed.
-    - Report what was tested.
-    - Report what was not tested.
+    - Report what changed, what was tested, and what was not tested.
     - Report remaining risks and follow-up work.
+    - Check parent and sub-issue closure status.
+    - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
     - State which GitHub action would be next if the human wants to publish the work.
     - See [GitHub Workflow](#github-workflow).
 
-11. **Checkpoint: human approves the next GitHub action.**
+11. **Checkpoint 11: human approves the next GitHub action.**
 
     - Stop after the summary until the human explicitly approves the next GitHub action in the current session.
 
-12. **Run the approved GitHub action and stop.**
+12. **Step 12: Run the approved GitHub action and stop.**
 
     - Run only the single GitHub action the human explicitly approved.
     - See [GitHub Workflow](#github-workflow).
+    - If the human approves another GitHub action, return to Step 11.
 
 ## Planning Requirements
 
 When producing a plan:
 
 - State the branch the work will be implemented on.
-- State the goal of the change in one or two sentences.
-- State the user-visible behaviour that must change.
+- State the goal and the user-visible behaviour that must change.
 - State the files and code areas the change will touch.
 - State the proposed implementation approach.
 - State assumptions and classify each as issue-sourced (unverified) or codebase-confirmed (verified by reading the code).
@@ -100,9 +99,7 @@ When producing a plan:
 - Mark the change as higher-risk if it affects routing, persistence, sync, caching, reactive subscriptions, or state transitions.
 - Include at least one runtime validation step for higher-risk changes.
 - State the validation approach.
-- Keep the plan concise.
-- Do not include implementation detail that belongs in the code.
-- Do not restate the issue verbatim.
+- Do not include implementation detail that belongs in the code or restate the issue verbatim.
 - Treat the issue goal as authoritative but treat implementation suggestions as provisional until the codebase confirms them.
 - If the issue and the current codebase disagree, prioritise the codebase and flag the mismatch to the human.
 
@@ -110,19 +107,25 @@ When producing a plan:
 
 During implementation:
 
-- Prefer extending current patterns over introducing new ones. (Why: New patterns increase review surface, reduce predictability, and create maintenance drift.)
+- Prefer extending current patterns over introducing new ones.
+  (Why: New patterns increase review surface, reduce predictability, and create maintenance drift.)
 - Keep changes focused and relevant to the approved plan.
 
 ## Scope Control
 
 Keep the change focused on the approved task:
 
-- If the issue contains multiple unrelated objectives, flag this and ask the human whether to split them into separate tasks.
-- If the task would require changes across many unrelated areas of the codebase, flag the risk and suggest decomposition.
+- If the issue contains multiple unrelated objectives or would require changes across many unrelated areas, flag this and suggest decomposition.
+- Extract the intended outcome from the issue before using implementation suggestions.
+  (Why: Issue text is often stale or speculative; treating implementation suggestions as authoritative leads to implementing the wrong thing.)
 - Do only the work required to complete the task.
-- Do not treat "while I am here" changes as free. (Why: Each unplanned change introduces untested risk and dilutes commit traceability.)
-- Separate fixes, refactors, and feature work unless the task clearly requires them together. (Why: Mixing change types obscures the commit's intent and makes review harder.)
-- If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation. (Why: Unreviewed scope expansions break the human approval model and introduce unvalidated changes.)
+- Do not treat "while I am here" changes as free.
+  (Why: Each unplanned change introduces untested risk and dilutes commit traceability.)
+- Separate fixes, refactors, and feature work unless the task clearly requires them together.
+  (Why: Mixing change types obscures the commit's intent and makes review harder.)
+- If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation.
+  (Why: Unreviewed scope expansions break the human approval model and introduce unvalidated changes.)
+- If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 
 ## Validation Requirements
 
@@ -160,23 +163,24 @@ Run the following checks in order:
 When running validation:
 
 - Do not modify smoke tests or the global test suite unless the task explicitly requires it.
-- Run smoke tests and the global test suite after each meaningful implementation pass.
-- Treat existing passing tests as evidence of stability, not proof of correctness for new behaviour.
+- Do not treat passing smoke tests and the global test suite as proof that the requested behaviour works.
+- Treat existing passing tests as evidence of stability.
 - If the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path.
 - If no automated test exercises the real user path, say so explicitly.
+
 When reporting validation:
 
 - Report what was tested and what passed.
 - Report what failed and whether the failure is related to the change.
 - Report what was not tested and why.
-- Do not claim code is tested when it is not.
-- Do not ignore failing tests and continue as if the task is complete.
+- Do not claim code is tested when it is not or ignore failing tests and continue as if the task is complete.
 
 ## Manual Verification Requirements
 
-When supporting manual verification:
+Manual verification covers what only a human can verify.
 
-- Suggest specific manual checks based on the change.
+- Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses.
+- Do not suggest checks that can be verified through automated tests or tool output.
 - State the success signal for each check.
 - State the failure signal for each check.
 
@@ -185,6 +189,7 @@ When supporting manual verification:
 Enter failure analysis mode when manual verification fails.
 Enter failure analysis mode when runtime behaviour contradicts the implementation.
 Enter failure analysis mode when test results conflict with observed behaviour.
+Stop implementation and do not make further code changes until failure analysis is complete.
 
 When in failure analysis mode:
 
@@ -196,9 +201,25 @@ When in failure analysis mode:
 - Name the single leading hypothesis and its supporting evidence before proposing the next step.
 - Gather evidence before proposing another fix.
 - Test at least one concrete hypothesis before asking the human to retry.
-- Prioritise code path, persistence, sync, routing, and UI binding explanations over environment or caching unless evidence shows otherwise.
-- If investigation reveals the plan was based on incorrect assumptions, state what the plan assumed, what the codebase actually does, and what a revised approach needs.
-- Signal a flawed approach only when evidence shows the assumptions were wrong, not based on difficulty alone.
+- If the plan was based on incorrect assumptions, state what was assumed versus what the codebase does and what a revised approach needs.
+
+## Handling Parent and Sub-Issues
+
+For every issue:
+
+- Read the issue comments for clarifications, scope changes, and constraints not in the original body.
+
+When the issue has sub-issues (it is a parent):
+
+- Treat the parent as broader context and do not implement the full parent scope.
+- Stop and ask which sub-issue to work on.
+
+When the issue is a sub-issue:
+
+- Read the direct parent issue and its comments for context.
+- Do not read further up the hierarchy.
+- Implement only the sub-issue scope.
+- When completing the sub-issue, check whether it is the last open sub-issue under the parent and flag this to the human.
 
 ## GitHub Workflow
 
@@ -214,12 +235,9 @@ Every task must follow the GitHub branching workflow:
 - Rebase the issue branch onto the target branch before creating a pull request.
 - If new commits have landed on the target branch since the last rebase, rebase again before the next remote GitHub action.
 - If a rebase produces modify/delete conflicts, stop and discuss with the human before resolving.
-- If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 - Treat commit creation, push to remote, and pull request creation as separate GitHub actions.
-- Do not push to remote without explicit human confirmation in the current session.
-- Do not create a pull request without explicit human confirmation in the current session.
 - Do not infer approval for one GitHub action from approval for another.
-- After running an approved GitHub action, stop and report the result.
+- Do not push to remote or create a pull request without explicit human confirmation in the current session.
 
 ## Boundary Rules
 
@@ -238,17 +256,15 @@ The following apply to every task without exception:
 Stop and ask the human before doing any of the following:
 
 - ASK before adding a new dependency.
-- ASK before changing architecture or established patterns.
+- ASK before changing architecture, established patterns, or conventions.
 - ASK before changing database schema or sync-related behaviour.
 - ASK before changing public interfaces or shared contracts.
 - ASK before making broad refactors.
 - ASK before deleting files or removing significant code paths.
 - ASK before running `git reset --hard` or any command that discards uncommitted working-tree state.
 - ASK before weakening, skipping, or removing tests.
-- ASK before introducing new conventions or changing existing ones.
 - ASK before introducing a new logging library or pattern.
-- ASK before making assumptions where the task or expected behaviour is unclear.
-- ASK before proceeding when the work conflicts with the current codebase or project constraints.
+- ASK before making assumptions or proceeding when the task, expected behaviour, or project constraints are unclear.
 
 ### Never Do
 

--- a/project-spec.md
+++ b/project-spec.md
@@ -20,7 +20,7 @@ Version: 1.0.0
 - Provides a project-spec template (`project-spec-template.md`) for documenting implementation truth in any target repository.
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
-- Provides agent skills for code-aware planning and failure analysis, located in agent-specific directories (`.claude/skills/` for Claude Code, `.github/skills/` for Copilot).
+- Provides agent skills for code-aware planning, failure analysis, and issue creation, located in agent-specific directories (`.claude/skills/` for Claude Code, `.github/skills/` for Copilot).
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), and Codex (`AGENTS.md`).
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
@@ -50,9 +50,9 @@ Version: 1.0.0
 - `project-spec-template.md`: template for creating `project-spec.md` in a target repository.
 - `project-spec-design-decisions.md`: maintenance rules for keeping `project-spec.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`, `logging-and-observability`), each self-contained in a `SKILL.md` file.
+- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-spec.md`.
-- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`, `logging-and-observability`), each self-contained in a `SKILL.md` file.
+- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`), each self-contained in a `SKILL.md` file.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.


### PR DESCRIPTION
## Summary

- Apply writing rules, rule placement, and review taxonomy from the design decisions folder across `ai-workflow.md`, lite version, skills, and supporting files.
- Add issue-creation skill, fix third-person voice in skills, add planning feedback section.
- Rewrite line-by-line rationale to match the updated workflow.

## Detail

See #76 for the full change breakdown.

## Commits

1. **Skills and supporting files** — issue-creation skill, voice fixes, planning feedback section, writing-rules addition, project-spec update.
2. **ai-workflow.md v2.0.0** — structural changes (loop preamble, Step 13, step numbering, checkpoint numbering), writing rule fixes, rule placement fixes, new lines.
3. **Lite version sync** — full sync to v2.0.0, trimmed to 129 rules, README update.
4. **Design decisions** — line-by-line rationale rewrite, rule-placement checkpoint example fix.

Closes #76