### PR TITLE
Housekeeping: audit-driven quick fixes (#78)

### DIFF
--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -5,6 +5,18 @@ set -eu
 # Covers Path 1 (Shell/Bash) and Path 2 (MCP).
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+TMPDIR_TEST=""
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+
+cleanup() {
+  if [ -n "$TMPDIR_TEST" ] && [ -f "$TMPDIR_TEST/current-branch-backup.sh" ]; then
+    cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+  fi
+  if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+trap cleanup EXIT
 PASS=0
 FAIL=0
 
@@ -134,17 +146,12 @@ FAKE
 chmod +x "$TMPDIR_TEST/current-branch.sh"
 
 # Temporarily replace the real script with the fake one.
-REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
 cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
 cp "$TMPDIR_TEST/current-branch.sh" "$REAL_SCRIPT"
 
 rc=0
 printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
-
-# Restore immediately.
-cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
-rm -rf "$TMPDIR_TEST"
 
 assert_blocked "git commit when current-branch returns main (simulated)" "$rc"
 

--- a/.ai-policy/scripts/test-codex-enforcement.sh
+++ b/.ai-policy/scripts/test-codex-enforcement.sh
@@ -6,6 +6,18 @@ set -eu
 # Path 2 (MCP via disabled_tools in config.toml).
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+TMPDIR_TEST=""
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+
+cleanup() {
+  if [ -n "$TMPDIR_TEST" ] && [ -f "$TMPDIR_TEST/current-branch-backup.sh" ]; then
+    cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+  fi
+  if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+trap cleanup EXIT
 PASS=0
 FAIL=0
 
@@ -81,7 +93,6 @@ assert_contains "hooks.json references bash hook script" "$HOOKS_JSON" "block-pr
 # Test the bash hook directly with Codex-format payloads.
 # Simulate being on a protected branch by overriding current-branch.sh.
 TMPDIR_TEST="$(mktemp -d)"
-REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
 cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
 
 # Override to return "main".
@@ -128,10 +139,6 @@ rc=0
 printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/test"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "git push on feature/test (simulated)" "$rc"
-
-# Restore real script.
-cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
-rm -rf "$TMPDIR_TEST"
 
 # ── Path 2: MCP tool blocking via disabled_tools in config.toml ──
 

--- a/.ai-policy/scripts/test-gemini-enforcement.sh
+++ b/.ai-policy/scripts/test-gemini-enforcement.sh
@@ -6,6 +6,18 @@ set -eu
 # Path 2 (MCP via hooks.BeforeTool → mcp hook).
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+TMPDIR_TEST=""
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+
+cleanup() {
+  if [ -n "$TMPDIR_TEST" ] && [ -f "$TMPDIR_TEST/current-branch-backup.sh" ]; then
+    cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+  fi
+  if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+trap cleanup EXIT
 PASS=0
 FAIL=0
 
@@ -124,7 +136,6 @@ echo "Path 1 — Shell/Bash blocking (Gemini BeforeTool → bash hook):"
 
 # Simulate being on a protected branch by overriding current-branch.sh.
 TMPDIR_TEST="$(mktemp -d)"
-REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
 cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
 
 # Override to return "main".
@@ -171,10 +182,6 @@ rc=0
 printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin feature/test"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "git push on feature/test (simulated)" "$rc"
-
-# Restore real script.
-cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
-rm -rf "$TMPDIR_TEST"
 
 # ── Summary ──
 

--- a/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+++ b/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
@@ -6,6 +6,18 @@ set -eu
 # Path 2 (MCP via PreToolUse → mcp hook).
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+TMPDIR_TEST=""
+REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
+
+cleanup() {
+  if [ -n "$TMPDIR_TEST" ] && [ -f "$TMPDIR_TEST/current-branch-backup.sh" ]; then
+    cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
+  fi
+  if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+trap cleanup EXIT
 PASS=0
 FAIL=0
 
@@ -120,7 +132,6 @@ echo "Path 1 — Shell/Bash blocking (PreToolUse → bash hook):"
 
 # Use simulated branch to test both protected and non-protected scenarios.
 TMPDIR_TEST="$(mktemp -d)"
-REAL_SCRIPT="$ROOT_DIR/.ai-policy/scripts/current-branch.sh"
 cp "$REAL_SCRIPT" "$TMPDIR_TEST/current-branch-backup.sh"
 
 # Override to return "main".
@@ -167,10 +178,6 @@ rc=0
 printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin feature/test"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "git push on feature/test (simulated)" "$rc"
-
-# Restore real script.
-cp "$TMPDIR_TEST/current-branch-backup.sh" "$REAL_SCRIPT"
-rm -rf "$TMPDIR_TEST"
 
 # ── Summary ──
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Runtime state
 .ai-policy/state/validation.status
 
-# Local settings TODO: update to all '.local' files
-.claude/settings.local.json
+# Local settings
+*.local.json
 
 # OS artifacts
 .DS_Store

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -200,16 +200,17 @@ Manual verification covers what only a human can verify.
 
 ## Failure Analysis Mode
 
-Enter failure analysis mode when manual verification fails.
-Enter failure analysis mode when runtime behaviour contradicts the implementation.
-Enter failure analysis mode when test results conflict with observed behaviour.
-Stop implementation and do not make further code changes until failure analysis is complete.
+Enter failure analysis mode when manual verification fails, runtime behaviour contradicts the implementation, or test results conflict with observed behaviour.
+Do not make further code changes until failure analysis is complete.
 
-Before proceeding in failure analysis mode, load the `failure-analysis` skill.
+Load the `failure-analysis` skill.
 
 ## Logging and Observability
 
-When the change requires runtime observability to validate correctness, load the `logging-and-observability` skill.
+Use when the change modifies runtime behaviour that automated tests cannot fully validate.
+Use when existing logging is insufficient to diagnose a failure.
+
+Load the `logging-and-observability` skill.
 
 ## Command Approval
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.0.0
+Version: 2.0.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-spec.md
+++ b/project-spec.md
@@ -43,6 +43,7 @@ Version: 1.0.0
 ## Key Dependencies
 - `bash`: all policy scripts and git hooks are written in bash and validated with `bash -n`.
 - `git`: hooks integrate with the git commit and push lifecycle via `core.hooksPath .githooks`.
+- `jq`: hook scripts and one enforcement test parse JSON with `jq`.
 
 ## Project Structure
 - `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent.


### PR DESCRIPTION
## Summary

Resolves four low-effort gaps surfaced by a repository audit (#78).

## Changes

- **Declare `jq` dependency** — Added `jq` to Key Dependencies in `project-spec.md` alongside `bash` and `git`.
- **Add cleanup traps to test scripts** — All four enforcement test scripts now use `trap cleanup EXIT` to restore `current-branch.sh` and remove temp dirs on interruption.
- **Resolve stale `.gitignore` TODO** — Replaced specific `.claude/settings.local.json` entry with `*.local.json` glob; removed TODO comment.
- **Align skill-loading sections** — Rewrote Failure Analysis Mode and Logging and Observability sections to follow a consistent structure (triggers → constraint → load) matching Planning Requirements.
- **Version bump** — `ai-workflow.md` bumped from 2.0.0 to 2.0.1.

## Validation

- `bash -n` syntax checks pass on all four test scripts.
- Full validation suite: 56/56 tests pass (matches baseline).

## Follow-up

- #81 — Add explicit pre-PR readiness check to the workflow (discovered during this task).

Closes #78