### PR TITLE
Add explicit pre-PR readiness check to workflow

### DIFF
--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -148,7 +148,7 @@ Rationale: Prevents the agent from cycling through speculative fixes. Manual ver
 
 ---
 
-### Workflow Step 10: Summarise and prepare handoff
+### Workflow Step 10: Summarise
 
 > "Report what changed."
 
@@ -165,6 +165,14 @@ Rationale: Honest reporting prevents the human from assuming full coverage when 
 > "Report remaining risks and follow-up work."
 
 Rationale: The agent may have discovered problems outside the current scope. These should be surfaced, not silently dropped.
+
+---
+
+### Workflow Step 11: Pre-PR readiness check
+
+> "Complete all readiness checks before proposing the first remote GitHub action."
+
+Rationale: Makes the readiness gate explicit. When readiness checks were embedded in the summary step, agents treated the summary as complete once they had reported what changed and what was tested, then skipped the remaining checks and jumped to proposing a GitHub action.
 
 > "If follow-up issues need to be created, load the `issue-creation` skill."
 
@@ -192,7 +200,7 @@ Rationale: Prepares the handoff. The agent proposes; the human decides.
 
 ---
 
-### Workflow Checkpoint 11: Human approves the next GitHub action
+### Workflow Checkpoint 12: Human approves the next GitHub action
 
 > "Stop after the summary until the human explicitly approves the next GitHub action in the current session."
 
@@ -200,19 +208,19 @@ Rationale: Prevents the agent from pushing code or creating PRs based on momentu
 
 ---
 
-### Workflow Step 12: Run the approved GitHub action and stop
+### Workflow Step 13: Run the approved GitHub action and stop
 
 > "Run only the single GitHub action the human explicitly approved."
 
 Rationale: Prevents chaining (e.g. human approves a push, agent also creates a PR). Each action is a separate approval.
 
-> "If the human approves another GitHub action, return to Step 11."
+> "If the human approves another GitHub action, return to Step 12."
 
 Rationale: Keeps the one-action-at-a-time model. The human can approve sequential actions, but each requires its own approval cycle.
 
 ---
 
-### Workflow Step 13: Post-merge cleanup
+### Workflow Step 14: Post-merge cleanup
 
 > "Check whether the local issue branch has unmerged commits before deleting it."
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.0.1
+Version: 2.1.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -15,7 +15,7 @@ The human reviews and approves at defined checkpoints.
 
 The workflow runs as a loop.
 Steps 5 through 9 form an implementation cycle: implement, validate, and fix until the human approves.
-Steps 10 through 12 form a handoff cycle: summarise, get approval, and run one GitHub action at a time.
+Steps 10 through 13 form a handoff cycle: summarise, check readiness, get approval, and run one GitHub action at a time.
 After the human merges the pull request, run post-merge cleanup and return to Step 1 for the next task.
 
 1. **Step 1: Confirm the task and inputs.**
@@ -72,12 +72,16 @@ After the human merges the pull request, run post-merge cleanup and return to St
    - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
    - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
-10. **Step 10: Summarise and prepare handoff.**
+10. **Step 10: Summarise.**
 
     - Report what changed.
     - Report what was tested.
     - Report what was not tested.
     - Report remaining risks and follow-up work.
+
+11. **Step 11: Pre-PR readiness check.**
+
+    - Complete all readiness checks before proposing the first remote GitHub action.
     - If follow-up issues need to be created, load the `issue-creation` skill.
     - Flag if documentation or README files need updating based on the change.
     - Flag if version numbers need updating.
@@ -87,17 +91,17 @@ After the human merges the pull request, run post-merge cleanup and return to St
     - State which GitHub action would be next if the human wants to publish the work.
     - See [GitHub Workflow](#github-workflow).
 
-11. **Checkpoint 11: human approves the next GitHub action.**
+12. **Checkpoint 12: human approves the next GitHub action.**
 
     - Stop after the summary until the human explicitly approves the next GitHub action in the current session.
 
-12. **Step 12: Run the approved GitHub action and stop.**
+13. **Step 13: Run the approved GitHub action and stop.**
 
     - Run only the single GitHub action the human explicitly approved.
     - See [GitHub Workflow](#github-workflow).
-    - If the human approves another GitHub action, return to Step 11.
+    - If the human approves another GitHub action, return to Step 12.
 
-13. **Step 13: Post-merge cleanup.**
+14. **Step 14: Post-merge cleanup.**
 
     - Check whether the local issue branch has unmerged commits before deleting it.
     - Switch to the main branch.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.0.0
+Version: 2.1.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -65,24 +65,28 @@ The human reviews and approves at defined checkpoints.
    - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
    - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
-10. **Step 10: Summarise and prepare handoff.**
+10. **Step 10: Summarise.**
 
     - Report what changed, what was tested, and what was not tested.
     - Report remaining risks and follow-up work.
+
+11. **Step 11: Pre-PR readiness check.**
+
+    - Complete all readiness checks before proposing the first remote GitHub action.
     - Check parent and sub-issue closure status.
     - See [Handling Parent and Sub-Issues](#handling-parent-and-sub-issues).
     - State which GitHub action would be next if the human wants to publish the work.
     - See [GitHub Workflow](#github-workflow).
 
-11. **Checkpoint 11: human approves the next GitHub action.**
+12. **Checkpoint 12: human approves the next GitHub action.**
 
     - Stop after the summary until the human explicitly approves the next GitHub action in the current session.
 
-12. **Step 12: Run the approved GitHub action and stop.**
+13. **Step 13: Run the approved GitHub action and stop.**
 
     - Run only the single GitHub action the human explicitly approved.
     - See [GitHub Workflow](#github-workflow).
-    - If the human approves another GitHub action, return to Step 11.
+    - If the human approves another GitHub action, return to Step 12.
 
 ## Planning Requirements
 


### PR DESCRIPTION
Closes #81

## What changed

Split Step 10 ("Summarise and prepare handoff") into two steps:
- **Step 10 (Summarise):** report what changed, tested, not tested, and risks
- **Step 11 (Pre-PR readiness check):** visible gate — documentation alignment, version assessment, tagged release, follow-up issue creation, parent/sub-issue closure status

Renumbered Steps 11–13 → 12–14. Updated intro paragraph, internal cross-references, and line-by-line rationale.

Version bumped to 2.1.0.

## Files changed

- `ai-workflow.md` — step split, renumber, version bump
- `lite-monolithic/ai-workflow.md` — matching changes
- `ai-workflow-design-decisions/line-by-line-rationale.md` — rationale for new step, renumbered headings

## Why

Readiness checks embedded inside the summary step were consistently skipped — agents treated the summary as complete after reporting changes and testing, then jumped to proposing a GitHub action. Separating the checks into their own step makes the gate visible and harder to skip.