### PR TITLE
Add test readiness checks, feedback loop rules, and testing skill (#85)

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: testing
+description: "Test construction rules for writing tests that serve the AI implementation feedback loop. Use this skill when the agent needs to write new tests, improve existing tests, or when Step 6 identifies missing test coverage. The skill exists to prevent common test quality pitfalls that break the feedback loop: tests coupled to implementation details, vague failure messages, shared mutable state, and duplicate coverage."
+---
+
+# Writing Tests
+
+Read this file when writing new tests or improving existing tests.
+This file contains rules for test construction that serve the implementation feedback loop.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when writing tests:
+
+- **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
+- **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+
+## Test Construction Rules
+
+1. Test behaviour, not implementation.
+   Assert on outputs, side effects, and observable state.
+   Do not assert on internal method calls, private state, or code structure.
+
+2. Each test must be independent.
+   No shared mutable state between tests.
+   No ordering dependencies.
+
+3. Assertions must be specific.
+   "Assert the response status is 404" not "assert the response is truthy."
+
+4. Failure messages must identify what went wrong.
+   Include expected value, actual value, and which behaviour was being tested.
+
+5. Prefer the testing patterns already established in the project.
+   Do not introduce a new test framework or convention without asking.
+
+6. Match test granularity to risk.
+   High-risk paths (payments, auth, data mutations) get more tests.
+   Low-risk paths (formatting, display) get fewer.
+
+7. Do not write tests that duplicate existing coverage without adding new signal.
+
+8. Do not write tests that require external services, network access, or manual setup unless the project already has that pattern.
+
+9. When writing tests for a bug fix, write the test first, confirm it fails, then fix the code.
+   This verifies the test actually catches the bug.

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: testing
+description: "Test construction rules for writing tests that serve the AI implementation feedback loop. Use this skill when the agent needs to write new tests, improve existing tests, or when Step 6 identifies missing test coverage. The skill exists to prevent common test quality pitfalls that break the feedback loop: tests coupled to implementation details, vague failure messages, shared mutable state, and duplicate coverage."
+---
+
+# Writing Tests
+
+Read this file when writing new tests or improving existing tests.
+This file contains rules for test construction that serve the implementation feedback loop.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when writing tests:
+
+- **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
+- **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+
+## Test Construction Rules
+
+1. Test behaviour, not implementation.
+   Assert on outputs, side effects, and observable state.
+   Do not assert on internal method calls, private state, or code structure.
+
+2. Each test must be independent.
+   No shared mutable state between tests.
+   No ordering dependencies.
+
+3. Assertions must be specific.
+   "Assert the response status is 404" not "assert the response is truthy."
+
+4. Failure messages must identify what went wrong.
+   Include expected value, actual value, and which behaviour was being tested.
+
+5. Prefer the testing patterns already established in the project.
+   Do not introduce a new test framework or convention without asking.
+
+6. Match test granularity to risk.
+   High-risk paths (payments, auth, data mutations) get more tests.
+   Low-risk paths (formatting, display) get fewer.
+
+7. Do not write tests that duplicate existing coverage without adding new signal.
+
+8. Do not write tests that require external services, network access, or manual setup unless the project already has that pattern.
+
+9. When writing tests for a bug fix, write the test first, confirm it fails, then fix the code.
+   This verifies the test actually catches the bug.

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -390,14 +390,6 @@ Rationale: Honest reporting. The human should know that the changed area has no 
 
 Rationale: New behaviour without tests will have no safety net for future changes.
 
-> "Write tests that verify observable behaviour, not implementation details."
-
-Rationale: Tests coupled to internal structure break when the agent refactors, producing false negatives that waste implementation cycles and erode trust in the test suite.
-
-> "Write tests that produce clear pass/fail output with failure messages that identify what went wrong."
-
-Rationale: The agent reads test output to decide what to fix next. Tests that produce vague or unparseable output break the feedback loop and force speculative fixes.
-
 > "Run the new tests."
 
 Rationale: Writing tests that are never run provides no validation signal. The explicit instruction ensures the agent executes them and confirms they pass.
@@ -494,9 +486,9 @@ Rationale: When the task is to create tests, flagging their absence is redundant
 
 ### Writing Tests
 
-> "Use when the plan includes writing new tests, when Step 6 identifies missing test coverage, or when the task is specifically about creating tests."
+> "Use when the plan includes writing new tests." / "Use when Step 6 identifies missing test coverage." / "Use when the task is specifically about creating tests."
 
-Rationale: Defines the three activation conditions. The skill is not needed when the agent is only running existing tests.
+Rationale: Defines the three activation conditions. The skill is not needed when only running existing tests.
 
 > "Load the `testing` skill."
 

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -58,6 +58,10 @@ Rationale: Working on a stale branch means writing code against an outdated stat
 
 Rationale: The rule "if a previously passing test fails after the change, treat the change as wrong" is unenforceable without a known-good baseline. The baseline distinguishes regressions from pre-existing failures.
 
+> "Check test readiness."
+
+Rationale: Baseline validation only catches regressions if meaningful tests exist. A project with no smoke tests or no test suite has no safety net, and this should be surfaced before starting work rather than discovered during validation.
+
 > "Confirm the task is a bounded change."
 
 Rationale: Unbounded tasks lead to scope drift. Confirming boundaries early forces the agent to flag multi-objective issues or overly broad tasks before starting.
@@ -386,9 +390,21 @@ Rationale: Honest reporting. The human should know that the changed area has no 
 
 Rationale: New behaviour without tests will have no safety net for future changes.
 
+> "Write tests that verify observable behaviour, not implementation details."
+
+Rationale: Tests coupled to internal structure break when the agent refactors, producing false negatives that waste implementation cycles and erode trust in the test suite.
+
+> "Write tests that produce clear pass/fail output with failure messages that identify what went wrong."
+
+Rationale: The agent reads test output to decide what to fix next. Tests that produce vague or unparseable output break the feedback loop and force speculative fixes.
+
 > "Run the new tests."
 
 Rationale: Writing tests that are never run provides no validation signal. The explicit instruction ensures the agent executes them and confirms they pass.
+
+> "If a new test fails, use the failure output to guide the next implementation change before rerunning."
+
+Rationale: Makes the feedback loop explicit. Without this instruction, the agent tends to treat a failing new test as a problem with the test rather than a signal about the implementation.
 
 > "Do not modify smoke tests or the global test suite unless the task explicitly requires it."
 
@@ -409,6 +425,10 @@ Rationale: Existing tests may not cover the new behaviour. Passing tests only pr
 > "Treat existing passing tests as evidence of stability."
 
 Rationale: Passing tests confirm the change did not break existing behaviour. They are not proof that new behaviour is correct.
+
+> "Use test results to guide implementation decisions during the Step 5-9 cycle."
+
+Rationale: Frames tests as a steering mechanism for implementation, not just a gate at the end. Tests exist to tell the agent whether it is on track, not just whether it finished correctly.
 
 > "If the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path."
 
@@ -441,6 +461,46 @@ Rationale: False claims of testing are worse than no testing because they suppre
 > "Do not ignore failing tests and continue as if the task is complete."
 
 Rationale: Ignoring failures and declaring success is a critical trust violation.
+
+---
+
+### Test Readiness
+
+> "Check whether the project has smoke tests that confirm the app builds and starts."
+
+Rationale: Smoke tests are the minimum safety net. Without them, the baseline comparison model cannot detect build-breaking regressions.
+
+> "Check whether the project has a test suite with at least one passing test."
+
+Rationale: A project with no tests at all has no regression detection. This should be surfaced rather than silently proceeding with zero coverage.
+
+> "Check whether tests exist for the code area the task will touch."
+
+Rationale: Targeted test coverage for the affected area is what gives the implementation feedback loop its signal. Without it, the agent can only rely on smoke tests and manual verification.
+
+> "If any of these are missing, flag the gap to the human before proceeding."
+
+Rationale: The human decides whether to address the gap now or accept the risk. The agent should not make this decision silently.
+
+> "Do not write tests to fill the gap unless the human approves."
+
+Rationale: Writing foundational tests is a scoping decision. It changes the task and should go through the same approval flow as any scope expansion.
+
+> "If the task is specifically about writing tests, skip this check."
+
+Rationale: When the task is to create tests, flagging their absence is redundant.
+
+---
+
+### Writing Tests
+
+> "Use when the plan includes writing new tests, when Step 6 identifies missing test coverage, or when the task is specifically about creating tests."
+
+Rationale: Defines the three activation conditions. The skill is not needed when the agent is only running existing tests.
+
+> "Load the `testing` skill."
+
+Rationale: Defers detailed test-writing guidance to a skill that loads on demand. This keeps the core workflow lean while providing test construction rules when needed.
 
 ---
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -175,10 +175,7 @@ Run the following checks in order:
 
 4. **New tests.**
    - Add tests if the change introduces behaviour that existing tests do not cover.
-   - Write tests that verify observable behaviour, not implementation details.
-     (Why: Tests coupled to internal structure break on refactor and give false failure signals that waste implementation cycles.)
-   - Write tests that produce clear pass/fail output with failure messages that identify what went wrong.
-     (Why: The agent uses test output to decide what to fix next. Vague failures force guesswork instead of targeted fixes.)
+   - See [Writing Tests](#writing-tests).
    - Run the new tests.
    - If a new test fails, use the failure output to guide the next implementation change before rerunning.
 
@@ -217,7 +214,9 @@ If the task is specifically about writing tests, skip this check.
 
 ## Writing Tests
 
-Use when the plan includes writing new tests, when Step 6 identifies missing test coverage, or when the task is specifically about creating tests.
+Use when the plan includes writing new tests.
+Use when Step 6 identifies missing test coverage.
+Use when the task is specifically about creating tests.
 
 Load the `testing` skill.
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.1.0
+Version: 2.2.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -28,6 +28,8 @@ After the human merges the pull request, run post-merge cleanup and return to St
    - See [GitHub Workflow](#github-workflow).
    - Run baseline validation.
    - See [Validation Requirements](#validation-requirements).
+   - Check test readiness.
+   - See [Test Readiness](#test-readiness).
    - Confirm the task is a bounded change.
    - See [Scope Control](#scope-control).
    - If the GitHub issue number, issue context, active branch, or baseline validation state is missing or unclear, stop and resolve before proceeding.
@@ -173,7 +175,12 @@ Run the following checks in order:
 
 4. **New tests.**
    - Add tests if the change introduces behaviour that existing tests do not cover.
+   - Write tests that verify observable behaviour, not implementation details.
+     (Why: Tests coupled to internal structure break on refactor and give false failure signals that waste implementation cycles.)
+   - Write tests that produce clear pass/fail output with failure messages that identify what went wrong.
+     (Why: The agent uses test output to decide what to fix next. Vague failures force guesswork instead of targeted fixes.)
    - Run the new tests.
+   - If a new test fails, use the failure output to guide the next implementation change before rerunning.
 
 When running validation:
 
@@ -182,6 +189,8 @@ When running validation:
 - Run smoke tests and the global test suite after each meaningful implementation pass.
 - Do not treat passing smoke tests and the global test suite as proof that the requested behaviour works.
 - Treat existing passing tests as evidence of stability.
+- Use test results to guide implementation decisions during the Step 5-9 cycle.
+  (Why: Tests are the primary feedback mechanism for the implementation loop. Treating them only as a final gate misses their value as a steering signal.)
 - If the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path.
 - If no automated test exercises the real user path, say so explicitly.
 
@@ -192,6 +201,25 @@ When reporting validation:
 - Report what was not tested and why.
 - Do not claim code is tested when it is not.
 - Do not ignore failing tests and continue as if the task is complete.
+
+## Test Readiness
+
+Check test readiness during Step 1, after baseline validation.
+
+1. Check whether the project has smoke tests that confirm the app builds and starts.
+2. Check whether the project has a test suite with at least one passing test.
+3. Check whether tests exist for the code area the task will touch.
+
+If any of these are missing, flag the gap to the human before proceeding.
+Do not write tests to fill the gap unless the human approves.
+
+If the task is specifically about writing tests, skip this check.
+
+## Writing Tests
+
+Use when the plan includes writing new tests, when Step 6 identifies missing test coverage, or when the task is specifically about creating tests.
+
+Load the `testing` skill.
 
 ## Manual Verification Requirements
 

--- a/project-spec.md
+++ b/project-spec.md
@@ -20,7 +20,7 @@ Version: 1.0.0
 - Provides a project-spec template (`project-spec-template.md`) for documenting implementation truth in any target repository.
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
-- Provides agent skills for code-aware planning, failure analysis, and issue creation, located in agent-specific directories (`.claude/skills/` for Claude Code, `.github/skills/` for Copilot).
+- Provides agent skills for code-aware planning, failure analysis, issue creation, and test construction, located in agent-specific directories (`.claude/skills/` for Claude Code, `.github/skills/` for Copilot).
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), and Codex (`AGENTS.md`).
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
@@ -51,9 +51,9 @@ Version: 1.0.0
 - `project-spec-template.md`: template for creating `project-spec.md` in a target repository.
 - `project-spec-design-decisions.md`: maintenance rules for keeping `project-spec.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`), each self-contained in a `SKILL.md` file.
+- `.claude/skills/`: Claude Code skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`, `testing`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-spec.md`.
-- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`), each self-contained in a `SKILL.md` file.
+- `.github/skills/`: VS Code Copilot skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`, `testing`), each self-contained in a `SKILL.md` file.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.


### PR DESCRIPTION
## Summary

- Add test readiness check to Step 1 (after baseline validation) with a new Test Readiness reference section that checks for smoke tests, a test suite, and targeted test coverage before starting work.
- Add feedback loop rule in Validation Requirements: use test failure output to guide the next implementation change, and frame tests as a steering signal during the Step 5-9 cycle.
- Add Writing Tests section that loads a new `testing` skill on demand when the agent needs to write tests.
- Create `testing` skill in `.claude/skills/` and `.github/skills/` with 9 test construction rules covering behaviour-based testing, independent tests, specific assertions, actionable failure messages, and bug-fix test-first workflow.
- Add rationale entries to `line-by-line-rationale.md` for all new lines.
- Update `project-spec.md` to list the testing skill.
- Bump ai-workflow version from 2.1.0 to 2.2.0.

Closes #85

## Test plan

- [x] All 56 validation tests pass (no regressions from baseline)
- [x] Review section ordering: Validation Requirements → Test Readiness → Writing Tests → Manual Verification Requirements
- [x] Review writing style consistency (imperative mood, one sentence per line, inline Why only where justified)
- [ ] Confirm `.claude/skills/testing/SKILL.md` and `.github/skills/testing/SKILL.md` are identical and follow existing skill patterns