### PR TITLE
Allow create_pull_request targeting protected branches (#84)

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-mcp.sh
+++ b/.ai-policy/hooks/block-protected-branch-mcp.sh
@@ -13,10 +13,14 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 INPUT="$(cat)"
 TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
 
+# Allow create_pull_request — PRs target a branch for review, not a direct write.
+case "$TOOL_NAME" in
+  *create_pull_request) exit 0 ;;
+esac
+
 # Extract the target branch from tool_input.
 # push_files, create_or_update_file, delete_file use "branch".
-# create_pull_request uses "base" (the branch being merged into).
-BRANCH="$(printf '%s' "$INPUT" | jq -r '.tool_input.branch // .tool_input.base // empty')"
+BRANCH="$(printf '%s' "$INPUT" | jq -r '.tool_input.branch // empty')"
 
 if [ -z "$BRANCH" ]; then
   # No branch info available (e.g. merge_pull_request) — cannot check, allow.

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -69,11 +69,11 @@ printf '{"tool_name":"mcp__github__delete_file","tool_input":{"branch":"main","o
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_blocked "delete_file on main" "$rc"
 
-# Test 4: create_pull_request with base=main → blocked
+# Test 4: create_pull_request with base=main → allowed (PRs target a branch for review, not a direct write)
 rc=0
 printf '{"tool_name":"mcp__github__create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_blocked "create_pull_request base=main" "$rc"
+assert_allowed "create_pull_request base=main" "$rc"
 
 # Test 5: push_files targeting non-protected branch → allowed
 rc=0

--- a/.ai-policy/scripts/test-gemini-enforcement.sh
+++ b/.ai-policy/scripts/test-gemini-enforcement.sh
@@ -109,11 +109,11 @@ printf '{"tool_name":"mcp_github_delete_file","tool_input":{"branch":"main","own
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_blocked "delete_file on main" "$rc"
 
-# Test: create_pull_request with base=main → blocked
+# Test: create_pull_request with base=main → allowed (PRs target a branch for review, not a direct write)
 rc=0
 printf '{"tool_name":"mcp_github_create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_blocked "create_pull_request base=main" "$rc"
+assert_allowed "create_pull_request base=main" "$rc"
 
 # Test: push_files targeting non-protected branch → allowed
 rc=0

--- a/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+++ b/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
@@ -108,11 +108,11 @@ printf '{"tool_name":"mcp__github__delete_file","tool_input":{"branch":"main","o
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_blocked "delete_file on main" "$rc"
 
-# Test: create_pull_request with base=main → blocked
+# Test: create_pull_request with base=main → allowed (PRs target a branch for review, not a direct write)
 rc=0
 printf '{"tool_name":"mcp__github__create_pull_request","tool_input":{"base":"main","head":"feature/x","owner":"x","repo":"y","title":"t"}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_blocked "create_pull_request base=main" "$rc"
+assert_allowed "create_pull_request base=main" "$rc"
 
 # Test: push_files targeting non-protected branch → allowed
 rc=0


### PR DESCRIPTION
## Summary

The MCP protected-branch hook was blocking `create_pull_request` when `base` was a protected branch (e.g. `main`). Creating a PR targets a branch for review — it does not write directly to it. This fix allows PR creation while keeping direct write tools (`push_files`, `create_or_update_file`, `delete_file`) blocked.

## Changes

- **`.ai-policy/hooks/block-protected-branch-mcp.sh`** — Added early exit for `create_pull_request` tools before the protected-branch check. Removed `.tool_input.base` from branch extraction since it's no longer needed.
- **Three test scripts** — Updated `create_pull_request base=main` expectation from `assert_blocked` to `assert_allowed` in Claude Code, VS Code Copilot, and Gemini enforcement tests.

## Validation

- 56/56 enforcement tests pass.
- Manual verification: `create_pull_request base=main` → exit 0; `push_files` to `main` → exit 2.

Closes #84