### PR TITLE
Fix Codex CLI config.toml parse errors (#93)

### DIFF
--- a/.ai-policy/hooks/warn-codex-mcp-limitation.sh
+++ b/.ai-policy/hooks/warn-codex-mcp-limitation.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SessionStart hook for Codex CLI.
+# Outputs a warning about the MCP tool-blocking limitation.
+# Plain text on stdout is added as extra developer context by Codex.
+
+cat <<'EOF'
+WARNING — GitHub MCP tool blocking is NOT enforced in Codex.
+Codex hooks (PreToolUse) cannot intercept MCP tool calls.
+If you have GitHub MCP configured, the following tools are NOT blocked:
+  push_files, create_or_update_file, delete_file
+The protected-branch bash hook is the primary safeguard for preventing
+writes to protected branches. Do not rely on MCP tool blocking in Codex.
+EOF

--- a/.ai-policy/scripts/test-codex-enforcement.sh
+++ b/.ai-policy/scripts/test-codex-enforcement.sh
@@ -140,14 +140,32 @@ printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/tes
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "git push on feature/test (simulated)" "$rc"
 
-# ── Path 2: MCP tool blocking via disabled_tools in config.toml ──
+# ── Path 2: MCP tool-blocking limitation warning via SessionStart hook ──
 
-echo "Path 2 — MCP tool blocking (config.toml disabled_tools):"
+echo "Path 2 — MCP tool-blocking limitation (SessionStart warning hook):"
 
 assert_contains "codex_hooks feature flag enabled" "$CONFIG_TOML" "codex_hooks = true"
-assert_contains "push_files disabled" "$CONFIG_TOML" "push_files"
-assert_contains "create_or_update_file disabled" "$CONFIG_TOML" "create_or_update_file"
-assert_contains "delete_file disabled" "$CONFIG_TOML" "delete_file"
+assert_contains "hooks.json references SessionStart" "$HOOKS_JSON" '"SessionStart"'
+
+WARNING_SCRIPT="$ROOT_DIR/.ai-policy/hooks/warn-codex-mcp-limitation.sh"
+assert_contains "hooks.json references MCP warning script" "$HOOKS_JSON" "warn-codex-mcp-limitation.sh"
+
+if [ -f "$WARNING_SCRIPT" ] && [ -x "$WARNING_SCRIPT" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: MCP warning script exists and is executable"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: MCP warning script missing or not executable"
+fi
+
+WARNING_OUTPUT="$(bash "$WARNING_SCRIPT" 2>/dev/null)"
+if echo "$WARNING_OUTPUT" | grep -qF "MCP tool blocking is NOT enforced"; then
+  PASS=$((PASS + 1))
+  echo "  PASS: warning script outputs MCP limitation message"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: warning script does not output expected message"
+fi
 
 # ── Summary ──
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,9 +12,6 @@
 #   "workspace-write"   — writes confined to project + writable_roots
 #   "danger-full-access" — unrestricted (not recommended)
 
-[features]
-codex_hooks = true
-
 # Allow commands to run in sandbox; escalate to user on sandbox failure.
 # This lets safe git/shell reads run without prompts while still gating
 # destructive operations through sandbox restrictions + hooks.
@@ -23,5 +20,5 @@ approval_policy = "on-failure"
 # Allow writes within the project directory (and /tmp).
 sandbox_mode = "workspace-write"
 
-[mcp_servers.github]
-disabled_tools = ["push_files", "create_or_update_file", "delete_file"]
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/warn-codex-mcp-limitation.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
Closes #93

## Problem

`.codex/config.toml` had two schema errors that prevented Codex from parsing the config:

1. `approval_policy` and `sandbox_mode` were placed under `[features]` — these are top-level keys, and `[features]` only accepts booleans.
2. `[mcp_servers.github]` had `disabled_tools` but no transport (`command`/`url`), making it invalid.

## Solution

1. Moved `approval_policy` and `sandbox_mode` to top-level (before any table header).
2. Removed `[mcp_servers.github]` entirely — Codex has no mechanism to block specific MCP tools from project config without defining the full server transport. Added a `SessionStart` hook that warns about this limitation instead.

## Changes

| File | What |
|------|------|
| `.codex/config.toml` | Fixed key placement, removed broken MCP section |
| `.codex/hooks.json` | Added `SessionStart` hook referencing warning script |
| `.ai-policy/hooks/warn-codex-mcp-limitation.sh` | New script — outputs MCP limitation warning on session start |
| `.ai-policy/scripts/test-codex-enforcement.sh` | Replaced `disabled_tools` assertions with warning-hook assertions |

## Validation

- All 57 enforcement tests pass (10 Claude + 14 Codex + 16 VS Code Copilot + 17 Gemini)
- Manual verification: Codex starts without parse errors and shows the MCP limitation warning