### PR TITLE
docs: expand version bump rules to cover all user-facing changes

### DIFF
--- a/ai-workflow-design-decisions/context-budget-and-maintenance.md
+++ b/ai-workflow-design-decisions/context-budget-and-maintenance.md
@@ -17,11 +17,28 @@ Prefer fewer, higher-quality rules over comprehensive coverage.
 ## Version Number
 
 **Version number.**
-The workflow file carries a `Version: X.Y.Z` line in the preamble.
-Bump the patch version (Z) for any change that corrects wording, fixes a gap, or removes duplication without altering the workflow's intent.
-Bump the minor version (Y) for any change that adds a new rule, section, or meaningful constraint.
-Bump the major version (X) for a structural overhaul that changes the number or order of workflow steps.
-Update the version on every edit so session logs can be tied to a specific file state.
+The version number in `ai-workflow.md` (`Version: X.Y.Z`) tracks the project's user-facing behaviour, not just the workflow file itself.
+
+A change is user-facing if it can alter how the agent behaves, what the human sees, or what rules are enforced.
+User-facing files include:
+
+- `ai-workflow.md` (workflow steps, rules, reference sections).
+- Skill files in `.agents/skills/` and `.claude/skills/`.
+- Policy scripts and hooks in `.ai-policy/`, `.githooks/`, and agent hook configurations.
+- Agent entry points (`.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`).
+- `project-spec-template.md`.
+- `lite-monolithic/ai-workflow.md`.
+
+Bump the patch version (Z) for any user-facing change that corrects wording, fixes a gap, or removes duplication without altering intent.
+Bump the minor version (Y) for any user-facing change that adds a new rule, section, skill, policy enforcement, or meaningful constraint.
+Bump the major version (X) for a structural overhaul that changes the number or order of workflow steps, or fundamentally restructures the skill or policy layer.
+Update the version on every user-facing edit so session logs can be tied to a specific file state.
+
+Changes to non-user-facing files (design decisions, `observed-ai-failings.md`, `README.md`, test scripts) do not require a version bump.
+
+**Tagged releases.**
+Create a tagged release for any minor or major version bump.
+Patch bumps do not require a tagged release unless they fix a defect that users need to identify by version.
 
 ## Session Logs
 

--- a/project-spec.md
+++ b/project-spec.md
@@ -79,3 +79,4 @@ Version: 1.0.0
 - Update this file when the project structure, key files, or policy rules change.
 - Keep this file aligned with the current codebase, not planned architecture.
 - Keep this file concise and under 300 lines.
+- When a user-facing file changes, bump the version in `ai-workflow.md` following the guidance in `ai-workflow-design-decisions/context-budget-and-maintenance.md`.


### PR DESCRIPTION
Closes #96

## What changed

- **Version Number section** in `ai-workflow-design-decisions/context-budget-and-maintenance.md`: broadened from "the workflow file" to all user-facing files. Added an explicit list of user-facing files (skills, policy scripts/hooks, agent entry points, project-spec template, lite-monolithic variant). Added tagged release guidance (minor/major bumps warrant a release).

- **Maintenance Checklist** in `project-spec.md`: added a pointer to the versioning guidance so maintainers know where to look when deciding whether to bump.

## What was tested

- Full validation suite: 57/57 pass (no regressions from baseline).
- Manual review of the updated section.