### PR TITLE
refactor: namespace core workflow skills with aiw- prefix (#100)

### DIFF
--- a/.agents/skills/aiw-failure-analysis/SKILL.md
+++ b/.agents/skills/aiw-failure-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: failure-analysis
+name: aiw-failure-analysis
 description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
 ---
 
@@ -17,7 +17,7 @@ When tests pass and validation succeeds, you believe the implementation is corre
 This skill works alongside these workflow sections — consult them during investigation:
 
 - **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — load the `logging-and-observability` skill when diagnostic approaches are needed during investigation.
+- **Logging and Observability** — load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.agents/skills/aiw-issue-creation/SKILL.md
+++ b/.agents/skills/aiw-issue-creation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-creation
+name: aiw-issue-creation
 description: "Structured process for creating follow-up or spin-off GitHub issues during a task. Use this skill when the agent discovers work outside the current scope that should be tracked. The skill exists to prevent implementation-heavy issues that bias the implementing agent and peg to stale code."
 ---
 

--- a/.agents/skills/aiw-logging-and-observability/SKILL.md
+++ b/.agents/skills/aiw-logging-and-observability/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: logging-and-observability
+name: aiw-logging-and-observability
 description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
 ---
 

--- a/.agents/skills/aiw-planning/SKILL.md
+++ b/.agents/skills/aiw-planning/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: planning
+name: aiw-planning
 description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 

--- a/.agents/skills/aiw-project-spec-management/SKILL.md
+++ b/.agents/skills/aiw-project-spec-management/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: project-spec-management
+name: aiw-project-spec-management
 description: "Structured process for initializing and updating `project-spec.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project spec — including phrasings like 'update the spec', 'the architecture summary is out of date', 'document the project structure', or 'the project-spec.md is stale' — and when the agent detects the existing spec has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent specs from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 

--- a/.agents/skills/aiw-testing/SKILL.md
+++ b/.agents/skills/aiw-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: testing
+name: aiw-testing
 description: "Test construction rules for writing tests that serve the AI implementation feedback loop. Use this skill when the agent needs to write new tests, improve existing tests, or when Step 6 identifies missing test coverage. The skill exists to prevent common test quality pitfalls that break the feedback loop: tests coupled to implementation details, vague failure messages, shared mutable state, and duplicate coverage."
 ---
 

--- a/.claude/skills/aiw-failure-analysis/SKILL.md
+++ b/.claude/skills/aiw-failure-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: failure-analysis
+name: aiw-failure-analysis
 description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
 ---
 
@@ -17,7 +17,7 @@ When tests pass and validation succeeds, you believe the implementation is corre
 This skill works alongside these workflow sections — consult them during investigation:
 
 - **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — load the `logging-and-observability` skill when diagnostic approaches are needed during investigation.
+- **Logging and Observability** — load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.claude/skills/aiw-issue-creation/SKILL.md
+++ b/.claude/skills/aiw-issue-creation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-creation
+name: aiw-issue-creation
 description: "Structured process for creating follow-up or spin-off GitHub issues during a task. Use this skill when the agent discovers work outside the current scope that should be tracked. The skill exists to prevent implementation-heavy issues that bias the implementing agent and peg to stale code."
 ---
 

--- a/.claude/skills/aiw-logging-and-observability/SKILL.md
+++ b/.claude/skills/aiw-logging-and-observability/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: logging-and-observability
+name: aiw-logging-and-observability
 description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
 ---
 

--- a/.claude/skills/aiw-planning/SKILL.md
+++ b/.claude/skills/aiw-planning/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: planning
+name: aiw-planning
 description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 

--- a/.claude/skills/aiw-project-spec-management/SKILL.md
+++ b/.claude/skills/aiw-project-spec-management/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: project-spec-management
+name: aiw-project-spec-management
 description: "Structured process for initializing and updating `project-spec.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project spec — including phrasings like 'update the spec', 'the architecture summary is out of date', 'document the project structure', or 'the project-spec.md is stale' — and when the agent detects the existing spec has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent specs from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 

--- a/.claude/skills/aiw-testing/SKILL.md
+++ b/.claude/skills/aiw-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: testing
+name: aiw-testing
 description: "Test construction rules for writing tests that serve the AI implementation feedback loop. Use this skill when the agent needs to write new tests, improve existing tests, or when Step 6 identifies missing test coverage. The skill exists to prevent common test quality pitfalls that break the feedback loop: tests coupled to implementation details, vague failure messages, shared mutable state, and duplicate coverage."
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tipping points are a judgement call. They come from real-world usage in other re
 ### Agent-facing files
 
 - `ai-workflow.md` — canonical workflow for AI-assisted coding tasks, including planning, checkpoints, validation, failure analysis, and GitHub handoff rules.
-- `project-spec.md` — factual reference for this repository's implementation state, authored using the `project-spec-management` skill.
+- `project-spec.md` — factual reference for this repository's implementation state, authored using the `aiw-project-spec-management` skill.
 - `lite-monolithic/` — single-file version of the workflow with planning and failure analysis inlined, no policy layer, no skills, no multi-agent entry points. See `lite-monolithic/README.md`.
 
 ### Agent instruction entry points
@@ -46,7 +46,7 @@ Tipping points are a judgement call. They come from real-world usage in other re
 
 ### Skills
 
-- `.agents/skills/` — cross-platform skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`, `testing`). Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/` — cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`). Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/` — Claude Code skill definitions (same skills as `.agents/skills/`).
 
 ### Policy enforcement

--- a/ai-workflow-design-decisions/context-budget-and-maintenance.md
+++ b/ai-workflow-design-decisions/context-budget-and-maintenance.md
@@ -67,9 +67,10 @@ These are context-free and must be in context at all times.
 
 Extracted files live in two skill directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code).
 Both directories contain the same skills. When editing any skill, apply the change to both directories.
-Each skill is self-contained in a `SKILL.md` file within a named subdirectory (e.g. `.agents/skills/planning/SKILL.md`).
+Each skill is self-contained in a `SKILL.md` file within a named subdirectory (e.g. `.agents/skills/aiw-planning/SKILL.md`).
 In the core workflow, use this exact loading instruction pattern: `Load the <name> skill.`
-For example: `Load the planning skill.`
+For example: `Load the aiw-planning skill.`
+Core workflow skills use the `aiw-` prefix to avoid name collisions with project-specific or third-party skills in target repositories.
 The loading instruction names the skill; the agent's native skill system handles discovery.
 
 ## Reusable Prompt

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -200,7 +200,7 @@ Rationale: The agent may have discovered problems outside the current scope. The
 
 Rationale: Makes the readiness gate explicit. When readiness checks were embedded in the summary step, agents treated the summary as complete once they had reported what changed and what was tested, then skipped the remaining checks and jumped to proposing a GitHub action.
 
-> "If follow-up issues need to be created, load the `issue-creation` skill."
+> "If follow-up issues need to be created, load the `aiw-issue-creation` skill."
 
 Rationale: Follow-up work identified during the task should be captured in structured issues rather than lost in conversation. The skill ensures consistent issue quality.
 
@@ -288,7 +288,7 @@ Rationale: Scopes when the planning skill is relevant so the agent does not load
 
 Rationale: The planning skill contains the detailed structure and rules for plans. Without it, the agent produces unstructured plans that are harder to review.
 
-> "Load the `planning` skill."
+> "Load the `aiw-planning` skill."
 
 Rationale: Extracts detailed planning rules to an on-demand skill to keep the core workflow lean and reclaim always-on context budget.
 
@@ -340,7 +340,7 @@ Rationale: Mixing change types in one task makes review harder and makes it impo
 
 Rationale: Silently broadening scope is the most common agent failure mode. Flagging preserves scope while ensuring the problem is not lost.
 
-> "If the human approves, load the `issue-creation` skill to create the follow-up issue."
+> "If the human approves, load the `aiw-issue-creation` skill to create the follow-up issue."
 
 Rationale: Provides the action path for flagged follow-up work. The skill ensures follow-up issues are well-formed rather than hastily written.
 
@@ -484,7 +484,7 @@ Rationale: When the task is to create tests, flagging their absence is redundant
 
 Rationale: Defines the three activation conditions. The skill is not needed when only running existing tests.
 
-> "Load the `testing` skill."
+> "Load the `aiw-testing` skill."
 
 Rationale: Defers detailed test-writing guidance to a skill that loads on demand. This keeps the core workflow lean while providing test construction rules when needed.
 
@@ -524,7 +524,7 @@ Rationale: Lists the three trigger conditions in a single line. Manual verificat
 
 Rationale: Prevents the agent from making speculative fixes while the problem is still undiagnosed. Code changes before diagnosis compound the problem.
 
-> "Load the `failure-analysis` skill."
+> "Load the `aiw-failure-analysis` skill."
 
 Rationale: Extracts detailed failure analysis procedure to an on-demand skill to keep the core workflow lean. The skill provides the structured reasoning framework.
 
@@ -540,7 +540,7 @@ Rationale: Defines the primary activation condition. If automated tests can full
 
 Rationale: Defines the secondary activation condition. Insufficient logging during failure analysis blocks diagnosis.
 
-> "Load the `logging-and-observability` skill."
+> "Load the `aiw-logging-and-observability` skill."
 
 Rationale: Extracts detailed logging and observability rules to an on-demand skill to keep the core workflow lean and reclaim always-on context budget.
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.4.0
+Version: 2.5.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -84,7 +84,7 @@ After the human merges the pull request, run post-merge cleanup and return to St
 11. **Step 11: Pre-PR readiness check.**
 
     - Complete all readiness checks before proposing the first remote GitHub action.
-    - If follow-up issues need to be created, load the `issue-creation` skill.
+    - If follow-up issues need to be created, load the `aiw-issue-creation` skill.
     - Flag if documentation or README files need updating based on the change.
     - Flag if version numbers need updating.
     - Flag if a tagged release is needed.
@@ -118,7 +118,7 @@ After the human merges the pull request, run post-merge cleanup and return to St
 Use when executing Step 3 (Produce a code-aware plan) or Checkpoint 4 (human reviews the plan).
 Do not produce a plan without loading this skill first.
 
-Load the `planning` skill.
+Load the `aiw-planning` skill.
 
 ## Implementation Rules
 
@@ -140,7 +140,7 @@ Keep the change focused on the approved task:
 - Do not treat "while I am here" changes as free. (Why: Each unplanned change introduces untested risk and dilutes commit traceability.)
 - Separate fixes, refactors, and feature work unless the task clearly requires them together. (Why: Mixing change types obscures the commit's intent and makes review harder.)
 - If a larger problem is discovered, flag it as follow-up work instead of silently broadening the implementation. (Why: Unreviewed scope expansions break the human approval model and introduce unvalidated changes.)
-- If the human approves, load the `issue-creation` skill to create the follow-up issue.
+- If the human approves, load the `aiw-issue-creation` skill to create the follow-up issue.
 - If the task changes significantly during implementation, update the issue or flag the mismatch to the human.
 
 ## Validation Requirements
@@ -201,7 +201,7 @@ Use when the plan includes writing new tests.
 Use when Step 6 identifies missing test coverage.
 Use when the task is specifically about creating tests.
 
-Load the `testing` skill.
+Load the `aiw-testing` skill.
 
 ## Manual Verification Requirements
 
@@ -217,21 +217,21 @@ Manual verification covers what only a human can verify.
 Enter failure analysis mode when manual verification fails, runtime behaviour contradicts the implementation, or test results conflict with observed behaviour.
 Do not make further code changes until failure analysis is complete.
 
-Load the `failure-analysis` skill.
+Load the `aiw-failure-analysis` skill.
 
 ## Logging and Observability
 
 Use when the change modifies runtime behaviour that automated tests cannot fully validate.
 Use when existing logging is insufficient to diagnose a failure.
 
-Load the `logging-and-observability` skill.
+Load the `aiw-logging-and-observability` skill.
 
 ## Project Spec Management
 
 Use when creating `project-spec.md` for the first time.
 Use when updating `project-spec.md` after routes, schema, sync rules, dependencies, project structure, or test coverage have changed.
 
-Load the `project-spec-management` skill.
+Load the `aiw-project-spec-management` skill.
 
 ## Command Approval
 

--- a/project-spec.md
+++ b/project-spec.md
@@ -1,6 +1,6 @@
 # Project Spec
 
-Version: 1.0.0
+Version: 1.1.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -9,7 +9,7 @@ Version: 1.0.0
 
 ## Domain Concepts
 - **AI workflow**: the step-by-step process defined in `ai-workflow.md` that the agent follows for every task.
-- **Project spec**: a factual reference document (`project-spec.md`) describing the target repository's current implementation state, authored using the `project-spec-management` skill.
+- **Project spec**: a factual reference document (`project-spec.md`) describing the target repository's current implementation state, authored using the `aiw-project-spec-management` skill.
 - **Validation state**: a local runtime artifact (`.ai-policy/state/validation.status`) tracking whether the current validation run has passed.
 - **Policy layer**: the set of shell scripts in `.ai-policy/` that enforce protected-branch and validation-state rules.
 - **Skill**: a domain-specific instruction file loaded on demand by the agent when a workflow step requires it.
@@ -17,7 +17,7 @@ Version: 1.0.0
 
 ## Scope
 - Defines a reusable AI coding workflow (`ai-workflow.md`) with planning, validation, scope-control, failure-analysis, and GitHub handoff rules.
-- Provides a project-spec management skill (`project-spec-management`) for authoring and maintaining a repository's `project-spec.md`.
+- Provides a project-spec management skill (`aiw-project-spec-management`) for authoring and maintaining a repository's `project-spec.md`.
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
 - Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, and project spec management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
@@ -50,7 +50,7 @@ Version: 1.0.0
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
 - `project-spec-design-decisions.md`: maintenance rules for keeping `project-spec.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.agents/skills/`: cross-platform skill definitions (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`, `testing`, `project-spec-management`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-spec-management`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-spec.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
## Summary
- Renames the six core AI-workflow skills (`planning`, `failure-analysis`, `logging-and-observability`, `issue-creation`, `testing`, `project-spec-management`) to an `aiw-` prefix, so they do not collide with project-specific or third-party skills when these governance files are copied into target repositories.
- Updates all skill-identifier references in `ai-workflow.md`, `project-spec.md`, `README.md`, and the design-decisions docs.
- Bumps `ai-workflow.md` 2.4.0 → 2.5.0 and `project-spec.md` 1.0.0 → 1.1.0. Minor bump warrants a tagged release (`v2.5.0`) after merge.

Closes #100.

## Test plan
- [x] `./.ai-policy/scripts/project-validation.sh` passes all four suites (10/14/16/17 — same as baseline).
- [x] Grep confirms no remaining bare old-name references in `*.md`.
- [x] Claude Code skill list (session reminder) surfaces `aiw-*` names after the directory rename.
- [ ] Spot-check in VS Code Copilot / Codex / Gemini that the renamed skills load correctly (not exercised by automated validation).
- [ ] Confirm a fresh Claude Code session still resolves the new names after cache clears.

## Notes for reviewer
- Git's rename detection shows some cross-directory pairings (e.g. `.agents/skills/planning` → `.claude/skills/aiw-planning`) because the `.agents/` and `.claude/` copies share identical content. Tree state is correct: both trees contain all six `aiw-*` skills.
- Two pre-existing documentation omissions were noticed during this work and left in place to keep scope tight: `README.md:49` and `project-spec.md:23` each list skills incompletely. Worth a small follow-up issue.