### PR TITLE
Rename project-spec to project-context (#99)

### DIFF
--- a/.agents/skills/aiw-project-context-management/SKILL.md
+++ b/.agents/skills/aiw-project-context-management/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: aiw-project-spec-management
-description: "Structured process for initializing and updating `project-spec.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project spec — including phrasings like 'update the spec', 'the architecture summary is out of date', 'document the project structure', or 'the project-spec.md is stale' — and when the agent detects the existing spec has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent specs from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
+name: aiw-project-context-management
+description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context — including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale' — and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 
-# Project Spec Management
+# Project Context Management
 
-Read this file before creating or editing `project-spec.md`.
-`project-spec.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
+Read this file before creating or editing `project-context.md`.
+`project-context.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
 
 ## Required Sections
 
@@ -20,16 +20,16 @@ Use these sections, in order; omit one only when the repository has no reliable 
 - `## Key Dependencies` — each dependency and why it exists.
 - `## Project Structure` — each significant path or module and what it owns.
 - `## Testing Overview` — test framework, coverage, major gaps.
-- `## Maintenance Checklist` — when the spec must be updated.
+- `## Maintenance Checklist` — when the context file must be updated.
 
 ## Base Rules
 
 - Write exactly one sentence per line.
   (Why: per-line facts are easy to diff, quote, and selectively update across future sessions.)
 - Keep the file under 300 lines.
-  (Why: `project-spec.md` loads into agent context on every task; every line competes with task-specific content.)
+  (Why: `project-context.md` loads into agent context on every task; every line competes with task-specific content.)
 - State present-tense facts drawn from the codebase, not planned or aspirational behaviour.
-  (Why: a spec that describes intent diverges quickly and misleads agents into planning against code that does not exist.)
+  (Why: a context file that describes intent diverges quickly and misleads agents into planning against code that does not exist.)
 - Mark a fact as unknown instead of guessing.
 - Keep module, path, and entity names identical to the codebase.
 - Omit rationale unless it is required for correctness.
@@ -37,7 +37,7 @@ Use these sections, in order; omit one only when the repository has no reliable 
 
 ## Scanning the Codebase
 
-Do a systematic pass before writing — fill each section from the scan, not from issues, prior specs, or human descriptions.
+Do a systematic pass before writing — fill each section from the scan, not from issues, prior context files, or human descriptions.
 
 1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. → Product Summary, Key Dependencies.
 2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. → Scope, Architecture Summary.
@@ -48,22 +48,22 @@ Do a systematic pass before writing — fill each section from the scan, not fro
 
 For large codebases, skim at the directory level first and only open files that are surfaced by the scan; do not try to read every file.
 
-## Updating an Existing Spec
+## Updating an Existing Context File
 
 - Rerun the scan above, then compare it to the current file fact by fact.
-- For each line in the spec, find the codebase source that should confirm it; remove lines whose source no longer exists.
-- For each source the scan surfaces, check whether the spec already records it; add missing facts.
+- For each line in the context file, find the codebase source that should confirm it; remove lines whose source no longer exists.
+- For each source the scan surfaces, check whether the context file already records it; add missing facts.
 - Remove lines that no longer match the codebase rather than appending corrections.
   (Why: stale lines next to corrections leave the agent with two conflicting facts.)
 - Merge overlapping bullets when they describe the same fact.
 - If the file approaches 300 lines, drop low-value detail before adding new content.
-- Do not turn the spec into a changelog; recent history belongs in git.
+- Do not turn the context file into a changelog; recent history belongs in git.
 
 ## What Not to Include
 
 - Planned features, future refactors, open questions, issue or PR references.
 - Multi-sentence bullets or prose paragraphs.
-- Workflow or process documentation — the spec records implementation facts, not how the team works.
+- Workflow or process documentation — the context file records implementation facts, not how the team works.
 
 ## Before Handing Off
 

--- a/.claude/skills/aiw-project-context-management/SKILL.md
+++ b/.claude/skills/aiw-project-context-management/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: aiw-project-spec-management
-description: "Structured process for initializing and updating `project-spec.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project spec — including phrasings like 'update the spec', 'the architecture summary is out of date', 'document the project structure', or 'the project-spec.md is stale' — and when the agent detects the existing spec has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent specs from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
+name: aiw-project-context-management
+description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context — including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale' — and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 
-# Project Spec Management
+# Project Context Management
 
-Read this file before creating or editing `project-spec.md`.
-`project-spec.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
+Read this file before creating or editing `project-context.md`.
+`project-context.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
 
 ## Required Sections
 
@@ -20,16 +20,16 @@ Use these sections, in order; omit one only when the repository has no reliable 
 - `## Key Dependencies` — each dependency and why it exists.
 - `## Project Structure` — each significant path or module and what it owns.
 - `## Testing Overview` — test framework, coverage, major gaps.
-- `## Maintenance Checklist` — when the spec must be updated.
+- `## Maintenance Checklist` — when the context file must be updated.
 
 ## Base Rules
 
 - Write exactly one sentence per line.
   (Why: per-line facts are easy to diff, quote, and selectively update across future sessions.)
 - Keep the file under 300 lines.
-  (Why: `project-spec.md` loads into agent context on every task; every line competes with task-specific content.)
+  (Why: `project-context.md` loads into agent context on every task; every line competes with task-specific content.)
 - State present-tense facts drawn from the codebase, not planned or aspirational behaviour.
-  (Why: a spec that describes intent diverges quickly and misleads agents into planning against code that does not exist.)
+  (Why: a context file that describes intent diverges quickly and misleads agents into planning against code that does not exist.)
 - Mark a fact as unknown instead of guessing.
 - Keep module, path, and entity names identical to the codebase.
 - Omit rationale unless it is required for correctness.
@@ -37,7 +37,7 @@ Use these sections, in order; omit one only when the repository has no reliable 
 
 ## Scanning the Codebase
 
-Do a systematic pass before writing — fill each section from the scan, not from issues, prior specs, or human descriptions.
+Do a systematic pass before writing — fill each section from the scan, not from issues, prior context files, or human descriptions.
 
 1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. → Product Summary, Key Dependencies.
 2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. → Scope, Architecture Summary.
@@ -48,22 +48,22 @@ Do a systematic pass before writing — fill each section from the scan, not fro
 
 For large codebases, skim at the directory level first and only open files that are surfaced by the scan; do not try to read every file.
 
-## Updating an Existing Spec
+## Updating an Existing Context File
 
 - Rerun the scan above, then compare it to the current file fact by fact.
-- For each line in the spec, find the codebase source that should confirm it; remove lines whose source no longer exists.
-- For each source the scan surfaces, check whether the spec already records it; add missing facts.
+- For each line in the context file, find the codebase source that should confirm it; remove lines whose source no longer exists.
+- For each source the scan surfaces, check whether the context file already records it; add missing facts.
 - Remove lines that no longer match the codebase rather than appending corrections.
   (Why: stale lines next to corrections leave the agent with two conflicting facts.)
 - Merge overlapping bullets when they describe the same fact.
 - If the file approaches 300 lines, drop low-value detail before adding new content.
-- Do not turn the spec into a changelog; recent history belongs in git.
+- Do not turn the context file into a changelog; recent history belongs in git.
 
 ## What Not to Include
 
 - Planned features, future refactors, open questions, issue or PR references.
 - Multi-sentence bullets or prose paragraphs.
-- Workflow or process documentation — the spec records implementation facts, not how the team works.
+- Workflow or process documentation — the context file records implementation facts, not how the team works.
 
 ## Before Handing Off
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,4 +3,4 @@
 Read the following files before responding to any request in this repository:
 
 - `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
-- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.
+- `project-context.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,4 +3,4 @@
 Read the following files before responding to any request in this repository:
 
 - `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
-- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.
+- `project-context.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,2 @@
 @ai-workflow.md
-@project-spec.md
+@project-context.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,4 +3,4 @@
 Read the following files before responding to any request in this repository:
 
 - `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
-- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.
+- `project-context.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tipping points are a judgement call. They come from real-world usage in other re
 ### Agent-facing files
 
 - `ai-workflow.md` — canonical workflow for AI-assisted coding tasks, including planning, checkpoints, validation, failure analysis, and GitHub handoff rules.
-- `project-spec.md` — factual reference for this repository's implementation state, authored using the `aiw-project-spec-management` skill.
+- `project-context.md` — factual reference for this repository's implementation state, authored using the `aiw-project-context-management` skill.
 - `lite-monolithic/` — single-file version of the workflow with planning and failure analysis inlined, no policy layer, no skills, no multi-agent entry points. See `lite-monolithic/README.md`.
 
 ### Agent instruction entry points
@@ -63,12 +63,12 @@ Tipping points are a judgement call. They come from real-world usage in other re
 ### Maintenance documents
 
 - `ai-workflow-design-decisions/` — scoped maintenance rules and rationale for editing `ai-workflow.md`.
-- `project-spec-design-decisions.md` — maintenance rules for keeping `project-spec.md` factual and concise.
+- `project-context-design-decisions.md` — maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md` — log of concrete failure patterns observed in real AI-agent sessions.
 
 ## Installation by Tool
 
-Copy the relevant files into your target repository. Each agent needs its own instruction entry point, the shared workflow and spec files, and the policy enforcement layer.
+Copy the relevant files into your target repository. Each agent needs its own instruction entry point, the shared workflow and context files, and the policy enforcement layer.
 
 ### Claude Code
 
@@ -78,7 +78,7 @@ CLAUDE.md
 .ai-policy/
 .githooks/
 ai-workflow.md
-project-spec.md          # author via the project-spec-management skill
+project-context.md       # author via the project-context-management skill
 ```
 
 ### VS Code Copilot
@@ -90,7 +90,7 @@ project-spec.md          # author via the project-spec-management skill
 .ai-policy/
 .githooks/
 ai-workflow.md
-project-spec.md          # author via the project-spec-management skill
+project-context.md       # author via the project-context-management skill
 ```
 
 ### Codex
@@ -102,7 +102,7 @@ AGENTS.md
 .ai-policy/
 .githooks/
 ai-workflow.md
-project-spec.md          # author via the project-spec-management skill
+project-context.md       # author via the project-context-management skill
 ```
 
 ### Gemini CLI
@@ -114,7 +114,7 @@ GEMINI.md
 .ai-policy/
 .githooks/
 ai-workflow.md
-project-spec.md          # author via the project-spec-management skill
+project-context.md       # author via the project-context-management skill
 ```
 
 After copying, add the governance files and folders to the target repository's `.gitignore` if they should not be committed there.

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -96,9 +96,9 @@ Note on cross-reference pointers: Throughout the workflow steps, `See [Section N
 
 ### Workflow Step 2: Review project context
 
-> "Review `project-spec.md` for project structure, constraints, and domain context relevant to the task."
+> "Review `project-context.md` for project structure, constraints, and domain context relevant to the task."
 
-Rationale: The project spec provides architectural patterns, structure, and conventions. Reading it before planning prevents the agent from proposing changes that conflict with established patterns.
+Rationale: The project context provides architectural patterns, structure, and conventions. Reading it before planning prevents the agent from proposing changes that conflict with established patterns.
 
 > "Review the code areas the task is likely to touch."
 
@@ -296,9 +296,9 @@ Rationale: Extracts detailed planning rules to an on-demand skill to keep the co
 
 ### Implementation Rules
 
-> "Use `project-spec.md` for initial context on architectural patterns, project structure, and conventions."
+> "Use `project-context.md` for initial context on architectural patterns, project structure, and conventions."
 
-Rationale: The project spec is the starting point for understanding the codebase. It prevents the agent from inventing patterns that conflict with existing ones.
+Rationale: The project context is the starting point for understanding the codebase. It prevents the agent from inventing patterns that conflict with existing ones.
 
 > "Prefer extending current patterns over introducing new ones."
 
@@ -770,7 +770,7 @@ Rationale: The workflow starts from an issue. A missing or poorly formed issue m
 
 > "Ensure the right project context is available."
 
-Rationale: The agent reads what is available. If project-spec.md is missing or stale, the agent's understanding will be wrong.
+Rationale: The agent reads what is available. If project-context.md is missing or stale, the agent's understanding will be wrong.
 
 > "Review and approve the plan before coding starts."
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.5.0
+Version: 2.5.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -36,7 +36,7 @@ After the human merges the pull request, run post-merge cleanup and return to St
 
 2. **Step 2: Review project context.**
 
-   - Review `project-spec.md` for project structure, constraints, and domain context relevant to the task.
+   - Review `project-context.md` for project structure, constraints, and domain context relevant to the task.
    - Review the code areas the task is likely to touch.
    - Extract the intended outcome from the issue.
 
@@ -124,7 +124,7 @@ Load the `aiw-planning` skill.
 
 During implementation:
 
-- Use `project-spec.md` for initial context on architectural patterns, project structure, and conventions.
+- Use `project-context.md` for initial context on architectural patterns, project structure, and conventions.
 - Prefer extending current patterns over introducing new ones. (Why: New patterns increase review surface, reduce predictability, and create maintenance drift.)
 - Keep changes focused and relevant to the approved plan.
 
@@ -226,12 +226,12 @@ Use when existing logging is insufficient to diagnose a failure.
 
 Load the `aiw-logging-and-observability` skill.
 
-## Project Spec Management
+## Project Context Management
 
-Use when creating `project-spec.md` for the first time.
-Use when updating `project-spec.md` after routes, schema, sync rules, dependencies, project structure, or test coverage have changed.
+Use when creating `project-context.md` for the first time.
+Use when updating `project-context.md` after routes, schema, sync rules, dependencies, project structure, or test coverage have changed.
 
-Load the `aiw-project-spec-management` skill.
+Load the `aiw-project-context-management` skill.
 
 ## Command Approval
 

--- a/lite-monolithic/README.md
+++ b/lite-monolithic/README.md
@@ -23,6 +23,6 @@ The full version includes:
 - A policy enforcement layer (`.ai-policy/` scripts and git hooks) that blocks commits and pushes when rules are violated.
 - Separate skill files loaded on demand for planning, failure analysis, logging/observability, and issue creation.
 - Multi-agent entry points for VS Code Copilot, Claude Code, Codex, and Gemini CLI.
-- A project-spec template for documenting implementation truth in target repositories.
+- A project-context template for documenting implementation truth in target repositories.
 
 This lite version strips all of that down to a single file with the essential rules inlined. If you need deterministic enforcement or multi-agent configuration, use the [full version](https://github.com/philippe-ths/ai-coding-workflow).

--- a/project-context-design-decisions.md
+++ b/project-context-design-decisions.md
@@ -1,14 +1,14 @@
-# Project Spec Design Decisions
+# Project Context Design Decisions
 
-This document defines maintenance rules for `project-spec.md` files.
-It is for humans who maintain project specs.
-Use these rules when creating or editing a project spec.
+This document defines maintenance rules for `project-context.md` files.
+It is for humans who maintain project context files.
+Use these rules when creating or editing a project context file.
 
 ## Core Purpose
 
-The project spec records current implementation truth.
-The project spec is a factual reference, not a roadmap.
-The project spec should help an AI agent orient quickly before planning changes.
+The project context records current implementation truth.
+The project context is a factual reference, not a roadmap.
+The project context should help an AI agent orient quickly before planning changes.
 
 ## Base Rules
 
@@ -37,8 +37,8 @@ Update outdated terms when the codebase is renamed or refactored.
 
 ## Maintenance
 
-Update the spec when routes, schema, sync rules, persistence, or provider behavior changes.
-Update the spec when build, runtime, or dependency boundaries change.
+Update the context file when routes, schema, sync rules, persistence, or provider behavior changes.
+Update the context file when build, runtime, or dependency boundaries change.
 During reviews, remove stale lines instead of accumulating historical notes.
 Do not let this file exceed 300 lines.
 If the file approaches 300 lines, merge overlapping facts and remove low-value detail.

--- a/project-context.md
+++ b/project-context.md
@@ -1,15 +1,15 @@
-# Project Spec
+# Project Context
 
-Version: 1.1.0
+Version: 1.1.1
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
 - Primary users are human developers who have an AI coding agent (Copilot, Claude Code, Codex) working in their projects.
-- The core user flow is: copy workflow and spec files into a target repository, configure the agent to read them, then run tasks through the defined workflow with human checkpoints.
+- The core user flow is: copy workflow and context files into a target repository, configure the agent to read them, then run tasks through the defined workflow with human checkpoints.
 
 ## Domain Concepts
 - **AI workflow**: the step-by-step process defined in `ai-workflow.md` that the agent follows for every task.
-- **Project spec**: a factual reference document (`project-spec.md`) describing the target repository's current implementation state, authored using the `aiw-project-spec-management` skill.
+- **Project context**: a factual reference document (`project-context.md`) describing the target repository's current implementation state, authored using the `aiw-project-context-management` skill.
 - **Validation state**: a local runtime artifact (`.ai-policy/state/validation.status`) tracking whether the current validation run has passed.
 - **Policy layer**: the set of shell scripts in `.ai-policy/` that enforce protected-branch and validation-state rules.
 - **Skill**: a domain-specific instruction file loaded on demand by the agent when a workflow step requires it.
@@ -17,10 +17,10 @@ Version: 1.1.0
 
 ## Scope
 - Defines a reusable AI coding workflow (`ai-workflow.md`) with planning, validation, scope-control, failure-analysis, and GitHub handoff rules.
-- Provides a project-spec management skill (`aiw-project-spec-management`) for authoring and maintaining a repository's `project-spec.md`.
+- Provides a project-context management skill (`aiw-project-context-management`) for authoring and maintaining a repository's `project-context.md`.
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
-- Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, and project spec management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
+- Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, and project context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), and Codex (`AGENTS.md`).
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
@@ -29,14 +29,14 @@ Version: 1.1.0
 
 ## Important Constraints
 - Agent-facing files must stay short enough to preserve context budget.
-- `project-spec.md` must stay under 300 lines.
+- `project-context.md` must stay under 300 lines.
 - No work may be done directly on `main` or `master`; the policy layer and git hooks enforce this at commit and push time.
 - Validation must pass before commit or push when hooks are installed.
-- All facts in `project-spec.md` must reflect implementation truth, not planned architecture.
+- All facts in `project-context.md` must reflect implementation truth, not planned architecture.
 
 ## Architecture Summary
 - This is a documentation-only repository with no runtime application.
-- Three layers exist: agent-facing governance files (workflow and spec documents), on-demand skill files loaded at specific workflow steps, and a local policy enforcement layer (scripts and git hooks).
+- Three layers exist: agent-facing governance files (workflow and context documents), on-demand skill files loaded at specific workflow steps, and a local policy enforcement layer (scripts and git hooks).
 - Primary data flow: human copies files to target repository → agent reads them before each task → agent follows the workflow → human reviews checkpoints.
 - No external service dependencies exist at repository runtime; GitHub is used only for issue and PR tracking.
 
@@ -48,11 +48,11 @@ Version: 1.1.0
 ## Project Structure
 - `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent.
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
-- `project-spec-design-decisions.md`: maintenance rules for keeping `project-spec.md` factual and concise.
+- `project-context-design-decisions.md`: maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-spec-management`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-context-management`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
-- `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-spec.md`.
+- `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Renames `project-spec.md` → `project-context.md` and `project-spec-design-decisions.md` → `project-context-design-decisions.md` to clarify the file records current implementation state, not forward-looking specification.
- Renames `aiw-project-spec-management` skill → `aiw-project-context-management` in both `.agents/skills/` and `.claude/skills/` for consistency.
- Updates all references across `ai-workflow.md`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `lite-monolithic/README.md`, and `ai-workflow-design-decisions/line-by-line-rationale.md`. Leaves `observed-ai-failings.md` historical entries intact.
- Patch-bumps `ai-workflow.md` to 2.5.1 and `project-context.md` to 1.1.1 per the versioning rules in `ai-workflow-design-decisions/context-budget-and-maintenance.md` (terminology correction, no new rules/sections/skills).

Closes #99. Follow-up inconsistencies tracked in #106.

## Test plan
- [x] Baseline validation run before changes — all 57 enforcement tests pass across VS Code Copilot (10), Codex (14), Claude (16), Gemini (17).
- [x] Post-change validation run — all 57 tests still pass, matching baseline.
- [x] Grep sweep for `project-spec` / `Project spec` — only remaining matches are intentional historical entries in `observed-ai-failings.md` and the false positive `project-specific` in `context-budget-and-maintenance.md`.
- [x] Manual review of renamed files and every agent entry point to confirm references resolve.