### PR TITLE
Establish canonical version anchor and changelog discipline (#108)

### DIFF
--- a/.ai-policy/hooks/check-changelog.sh
+++ b/.ai-policy/hooks/check-changelog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -eu
+
+# Pre-push check. Rejects the push if any commit in the push range
+# changes the Version: header in ai-workflow.md without CHANGELOG.md
+# (at HEAD) containing a matching entry for the new version.
+#
+# Reads the standard pre-push stdin format:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# Zero-sha on either side means "no such ref"; we handle new branches
+# and deletions accordingly.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+WORKFLOW_FILE="ai-workflow.md"
+CHANGELOG_FILE="CHANGELOG.md"
+ZERO="0000000000000000000000000000000000000000"
+
+# Fallback base to diff against when the remote ref does not yet exist.
+DEFAULT_BASE="origin/main"
+
+# Collect each (local_sha, remote_sha) pair from stdin. If stdin is empty
+# (hook invoked outside git push), exit 0.
+PAIRS="$(cat || true)"
+if [ -z "$PAIRS" ]; then
+  exit 0
+fi
+
+extract_version_from_blob() {
+  git show "$1:$WORKFLOW_FILE" 2>/dev/null | awk '/^Version:[[:space:]]*/ { print $2; exit }'
+}
+
+changelog_has_entry() {
+  local version="$1"
+  # Accept "## 2.6.0" or "## [2.6.0]" at start of line.
+  git show "HEAD:$CHANGELOG_FILE" 2>/dev/null \
+    | grep -Eq "^##[[:space:]]+\[?${version}\]?([[:space:]]|$)"
+}
+
+fail=0
+
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+
+  # Branch being deleted — nothing to check.
+  if [ "$local_sha" = "$ZERO" ]; then
+    continue
+  fi
+
+  if [ "$remote_sha" = "$ZERO" ]; then
+    if git rev-parse --verify --quiet "$DEFAULT_BASE" >/dev/null; then
+      base="$DEFAULT_BASE"
+    else
+      # No base to compare against — skip.
+      continue
+    fi
+    range="${base}..${local_sha}"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+
+  # Commits in this push that touched the workflow file.
+  commits="$(git rev-list "$range" -- "$WORKFLOW_FILE" 2>/dev/null || true)"
+  [ -z "$commits" ] && continue
+
+  for sha in $commits; do
+    parent="$(git rev-parse "${sha}^" 2>/dev/null || echo "")"
+    [ -z "$parent" ] && continue
+
+    new_version="$(extract_version_from_blob "$sha")"
+    old_version="$(extract_version_from_blob "$parent")"
+
+    if [ -n "$new_version" ] && [ "$new_version" != "$old_version" ]; then
+      if ! changelog_has_entry "$new_version"; then
+        echo "Blocked: commit $sha bumps ${WORKFLOW_FILE} Version to ${new_version}" >&2
+        echo "but ${CHANGELOG_FILE} has no matching '## ${new_version}' entry." >&2
+        echo "Add a Common Changelog entry for ${new_version} and re-push." >&2
+        fail=1
+      fi
+    fi
+  done
+done <<EOF
+$PAIRS
+EOF
+
+exit "$fail"

--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -6,3 +6,4 @@ bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-codex-enforcement.sh
 ./.ai-policy/scripts/test-vscode-copilot-enforcement.sh
 ./.ai-policy/scripts/test-gemini-enforcement.sh
+./.ai-policy/scripts/test-changelog-hook.sh

--- a/.ai-policy/scripts/test-changelog-hook.sh
+++ b/.ai-policy/scripts/test-changelog-hook.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for the pre-push changelog-discipline hook.
+# Builds a throwaway git repository, stages commits that do and do not
+# bump ai-workflow.md's Version header, and invokes check-changelog.sh
+# via the standard pre-push stdin contract.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HOOK="$ROOT_DIR/.ai-policy/hooks/check-changelog.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit $expected, got $actual)"
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+cd "$SANDBOX"
+git init -q .
+git checkout -q -b main 2>/dev/null || git symbolic-ref HEAD refs/heads/main
+git config user.email "test@example.invalid"
+git config user.name "Changelog Hook Test"
+git config commit.gpgsign false
+
+# Baseline commit: Version 1.0.0 + matching CHANGELOG.
+cat > ai-workflow.md <<'EOF'
+# AI Workflow
+
+Version: 1.0.0
+
+Body.
+EOF
+cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## 1.0.0 - 2026-01-01
+
+### Added
+
+- Initial.
+EOF
+git add ai-workflow.md CHANGELOG.md
+git commit -q -m "baseline 1.0.0"
+BASE="$(git rev-parse HEAD)"
+ZERO="0000000000000000000000000000000000000000"
+
+echo "Changelog hook tests:"
+
+# Case A: version bump WITH matching entry → allowed.
+cat > ai-workflow.md <<'EOF'
+# AI Workflow
+
+Version: 1.1.0
+
+Body.
+EOF
+cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## 1.1.0 - 2026-02-01
+
+### Added
+
+- Thing.
+
+## 1.0.0 - 2026-01-01
+
+### Added
+
+- Initial.
+EOF
+git add ai-workflow.md CHANGELOG.md
+git commit -q -m "bump 1.1.0 with entry"
+HEAD_OK="$(git rev-parse HEAD)"
+
+rc=0
+printf 'refs/heads/main %s refs/heads/main %s\n' "$HEAD_OK" "$BASE" \
+  | "$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "bump with matching entry is allowed" 0 "$rc"
+
+# Case B: version bump WITHOUT matching entry → blocked.
+# Rewrite CHANGELOG on HEAD to drop the 1.1.0 entry.
+cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## 1.0.0 - 2026-01-01
+
+### Added
+
+- Initial.
+EOF
+git add CHANGELOG.md
+git commit -q -m "drop 1.1.0 entry"
+HEAD_BAD="$(git rev-parse HEAD)"
+
+rc=0
+printf 'refs/heads/main %s refs/heads/main %s\n' "$HEAD_BAD" "$BASE" \
+  | "$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "bump without matching entry is blocked" 1 "$rc"
+
+# Case C: no version change at all → allowed.
+echo "unrelated" > other.txt
+git add other.txt
+git commit -q -m "unrelated change"
+HEAD_NOOP="$(git rev-parse HEAD)"
+
+rc=0
+printf 'refs/heads/main %s refs/heads/main %s\n' "$HEAD_NOOP" "$HEAD_BAD" \
+  | "$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "no version change is allowed" 0 "$rc"
+
+# Case D: new branch push (remote_sha = zero) with a clean-state bump → allowed.
+# Reset the sandbox back to the known-good HEAD_OK for this case.
+git checkout -q "$HEAD_OK"
+git checkout -q -b feature/x
+NEW_SHA="$(git rev-parse HEAD)"
+
+rc=0
+printf 'refs/heads/feature/x %s refs/heads/feature/x %s\n' "$NEW_SHA" "$ZERO" \
+  | "$HOOK" >/dev/null 2>&1 || rc=$?
+# No DEFAULT_BASE (origin/main) exists in the sandbox, so the hook skips.
+assert_exit "new-branch push with no base skips cleanly" 0 "$rc"
+
+# Case E: bracketed '## [1.2.0]' heading style is accepted.
+git checkout -q main
+cat > ai-workflow.md <<'EOF'
+# AI Workflow
+
+Version: 1.2.0
+
+Body.
+EOF
+cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## [1.2.0] - 2026-03-01
+
+### Added
+
+- Thing.
+
+## 1.0.0 - 2026-01-01
+
+### Added
+
+- Initial.
+EOF
+git add ai-workflow.md CHANGELOG.md
+git commit -q -m "bump 1.2.0 bracketed heading"
+HEAD_BRK="$(git rev-parse HEAD)"
+
+rc=0
+printf 'refs/heads/main %s refs/heads/main %s\n' "$HEAD_BRK" "$HEAD_OK" \
+  | "$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "bracketed heading style is accepted" 0 "$rc"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,4 +12,6 @@ if [ "$REQUIRE_VALIDATION_BEFORE_PUSH" = "true" ]; then
   "$ROOT_DIR/.ai-policy/scripts/check-validation.sh"
 fi
 
+"$ROOT_DIR/.ai-policy/hooks/check-changelog.sh"
+
 exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+This changelog follows [Common Changelog](https://common-changelog.org/).
+
+The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
+
+## 2.6.0 - 2026-04-19
+
+### Added
+
+- `CHANGELOG.md` at repo root with backfilled entries for 2.0.0 through 2.5.1.
+- `.ai-policy/hooks/check-changelog.sh` pre-push hook rejecting version bumps without a matching changelog entry.
+- `.ai-policy/scripts/test-changelog-hook.sh` enforcement test, wired into `project-validation.sh`.
+
+### Changed
+
+- `ai-workflow-design-decisions/context-budget-and-maintenance.md` names `ai-workflow.md`'s `Version:` header as the canonical version source and requires a changelog entry for every bump.
+- `lite-monolithic/ai-workflow.md` version header aligned to the canonical version.
+
+## 2.5.1 - 2026-04-19
+
+### Changed
+
+- Renamed `project-spec` to `project-context` across workflow, skills, and agent entry points ([#99], [#107]).
+
+## 2.5.0 - 2026-04-18
+
+### Changed
+
+- Namespaced core workflow skills with the `aiw-` prefix to avoid collisions with project-specific or third-party skills ([#100], [#105]).
+
+## 2.4.0 - 2026-04-18
+
+### Added
+
+- `project-spec-management` skill, replacing the static `project-spec-template.md` ([#103]).
+
+## 2.3.0 - 2026-04-13
+
+### Changed
+
+- Condensed the Validation Requirements, GitHub Workflow, and Boundary Rules sections ([#87], [#88]).
+
+## 2.2.0 - 2026-04-13
+
+### Added
+
+- Test readiness checks in Step 1, feedback loop rules, and the `testing` skill ([#85], [#86]).
+
+## 2.1.0 - 2026-04-13
+
+### Added
+
+- Explicit pre-PR readiness check as Step 11 ([#81], [#83]).
+
+## 2.0.1 - 2026-04-13
+
+### Fixed
+
+- Audit-driven quick fixes across workflow wording and consistency ([#78], [#82]).
+
+## 2.0.0 - 2026-04-12
+
+### Changed
+
+- Rewrote `ai-workflow.md` for writing quality, rule placement, and structural cleanup ([#77]).
+
+[#77]: https://github.com/philippe-ths/ai-coding-workflow/pull/77
+[#78]: https://github.com/philippe-ths/ai-coding-workflow/issues/78
+[#81]: https://github.com/philippe-ths/ai-coding-workflow/issues/81
+[#82]: https://github.com/philippe-ths/ai-coding-workflow/pull/82
+[#83]: https://github.com/philippe-ths/ai-coding-workflow/pull/83
+[#85]: https://github.com/philippe-ths/ai-coding-workflow/issues/85
+[#86]: https://github.com/philippe-ths/ai-coding-workflow/pull/86
+[#87]: https://github.com/philippe-ths/ai-coding-workflow/issues/87
+[#88]: https://github.com/philippe-ths/ai-coding-workflow/pull/88
+[#99]: https://github.com/philippe-ths/ai-coding-workflow/issues/99
+[#100]: https://github.com/philippe-ths/ai-coding-workflow/issues/100
+[#103]: https://github.com/philippe-ths/ai-coding-workflow/pull/103
+[#105]: https://github.com/philippe-ths/ai-coding-workflow/pull/105
+[#107]: https://github.com/philippe-ths/ai-coding-workflow/pull/107

--- a/ai-workflow-design-decisions/context-budget-and-maintenance.md
+++ b/ai-workflow-design-decisions/context-budget-and-maintenance.md
@@ -17,7 +17,8 @@ Prefer fewer, higher-quality rules over comprehensive coverage.
 ## Version Number
 
 **Version number.**
-The version number in `ai-workflow.md` (`Version: X.Y.Z`) tracks the project's user-facing behaviour, not just the workflow file itself.
+The `Version:` header in `ai-workflow.md` is the canonical version for the project. It tracks the project's user-facing behaviour, not just the workflow file itself.
+No other file holds a release-level version number; subordinate files (for example `lite-monolithic/ai-workflow.md`) carry this same version so they can be identified against the canonical anchor, but they are not independent sources of truth.
 
 A change is user-facing if it can alter how the agent behaves, what the human sees, or what rules are enforced.
 User-facing files include:
@@ -32,6 +33,8 @@ Bump the patch version (Z) for any user-facing change that corrects wording, fix
 Bump the minor version (Y) for any user-facing change that adds a new rule, section, skill, policy enforcement, or meaningful constraint.
 Bump the major version (X) for a structural overhaul that changes the number or order of workflow steps, or fundamentally restructures the skill or policy layer.
 Update the version on every user-facing edit so session logs can be tied to a specific file state.
+
+Every change to the `Version:` header requires a matching entry in `CHANGELOG.md` at the repo root. The pre-push hook (`.ai-policy/hooks/check-changelog.sh`) rejects pushes that bump the version without adding a matching entry. The changelog follows [Common Changelog](https://common-changelog.org/).
 
 Changes to non-user-facing files (design decisions, `observed-ai-failings.md`, `README.md`, test scripts) do not require a version bump.
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.5.1
+Version: 2.6.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.1.0
+Version: 2.5.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.1.1
+Version: 1.1.2
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -25,7 +25,7 @@ Version: 1.1.1
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
 - Does not contain any runtime application code.
-- Does not include a test framework beyond shell-script syntax checks and two enforcement integration tests.
+- Does not include a test framework beyond shell-script syntax checks and five enforcement integration tests.
 
 ## Important Constraints
 - Agent-facing files must stay short enough to preserve context budget.
@@ -46,7 +46,8 @@ Version: 1.1.1
 - `jq`: hook scripts and one enforcement test parse JSON with `jq`.
 
 ## Project Structure
-- `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent.
+- `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent. Its `Version:` header is the canonical project version.
+- `CHANGELOG.md`: Common Changelog record of every version bump; enforced by the pre-push changelog hook.
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
 - `project-context-design-decisions.md`: maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
@@ -58,7 +59,7 @@ Version: 1.1.1
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`.
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`. Includes `check-changelog.sh`, a pre-push check rejecting `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.
@@ -70,7 +71,7 @@ Version: 1.1.1
 
 ## Testing Overview
 - Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`.
-- Validation also runs four enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, and `test-gemini-enforcement.sh`.
+- Validation also runs five enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, and `test-changelog-hook.sh`.
 - No unit test framework exists; there are no automated tests for documentation content.
 - Manual verification is the primary check for documentation changes.
 


### PR DESCRIPTION
Closes #108.

## Summary
- Add `CHANGELOG.md` at repo root (Common Changelog) with backfilled entries for 2.0.0 through 2.5.1 plus this change's 2.6.0 entry.
- Add `.ai-policy/hooks/check-changelog.sh` pre-push hook rejecting `ai-workflow.md` `Version:` bumps without a matching changelog entry.
- Add `.ai-policy/scripts/test-changelog-hook.sh` (5 cases) and wire into `project-validation.sh`.
- Amend `ai-workflow-design-decisions/context-budget-and-maintenance.md` to name `ai-workflow.md`'s `Version:` header as canonical and require a changelog entry per bump.
- Align `lite-monolithic/ai-workflow.md` header 2.1.0 → 2.5.1. Content-drift reconciliation tracked separately in #114.
- Bump `ai-workflow.md` 2.5.1 → 2.6.0.
- Create retroactive minor-version tags `v2.2.0` (at e0d56db) and `v2.5.0` (at 480dff9); patch bumps intentionally not tagged per existing policy.
- Bump `project-context.md` 1.1.1 → 1.1.2.

## Why
Sub-issue A of #101 (eval framework). Subsequent sub-issues (B–E) depend on a single, reliable workflow-version anchor for telemetry tagging. Without a canonical version plus enforced changelog, downstream comparisons across workflow versions have no common reference point.

## Test plan
- [x] Full `./.ai-policy/scripts/project-validation.sh` passes (60 enforcement test cases across 5 scripts, plus `bash -n` across all hooks/scripts).
- [x] New `test-changelog-hook.sh` covers: bump-with-entry (allow), bump-without-entry (block), no-op push (allow), new-branch-no-base (skip cleanly), bracketed heading style (allow).
- [ ] Reviewer: run a simulated pre-push to confirm the hook blocks a bump without an entry. From repo root:
  ```
  printf 'refs/heads/chore/108-versioning-cleanup %s refs/heads/chore/108-versioning-cleanup %s\n' "$(git rev-parse HEAD)" "$(git rev-parse origin/main)" | ./.ai-policy/hooks/check-changelog.sh; echo "exit=$?"
  ```
  Expect `exit=0`. Then temporarily delete the `## 2.6.0` heading from `CHANGELOG.md`, re-run, expect nonzero with a message naming 2.6.0. Restore the heading.

## Follow-up
- #114 — Lite-monolithic `ai-workflow.md` content drift since v2.1.0.

## Tag release
After merge, tag `v2.6.0` on the merge commit — this is a minor bump (new policy enforcement).