### PR TITLE
Tag Claude Code sessions with workflow version and ruleset hash (#109)

### DIFF
--- a/.ai-policy/hooks/check-session-tags.sh
+++ b/.ai-policy/hooks/check-session-tags.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+
+# Pre-commit check. Fails if .claude/settings.json's
+# env.OTEL_RESOURCE_ATTRIBUTES does not match the canonical
+# workflow_version + ruleset_hash for the current tree.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+"$ROOT_DIR/.ai-policy/scripts/update-session-tags.sh" --check

--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -7,3 +7,4 @@ bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-vscode-copilot-enforcement.sh
 ./.ai-policy/scripts/test-gemini-enforcement.sh
 ./.ai-policy/scripts/test-changelog-hook.sh
+./.ai-policy/scripts/test-session-tags-hook.sh

--- a/.ai-policy/scripts/test-session-tags-hook.sh
+++ b/.ai-policy/scripts/test-session-tags-hook.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for the session-tags update + drift check.
+# Builds a throwaway repo mirroring the rule-file layout, runs
+# update-session-tags.sh, mutates a rule file, and verifies the
+# --check mode detects drift.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SRC_SCRIPT="$ROOT_DIR/.ai-policy/scripts/update-session-tags.sh"
+SRC_HOOK="$ROOT_DIR/.ai-policy/hooks/check-session-tags.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit $expected, got $actual)"
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+cd "$SANDBOX"
+git init -q .
+git checkout -q -b main 2>/dev/null || git symbolic-ref HEAD refs/heads/main
+git config user.email "test@example.invalid"
+git config user.name "Session Tags Hook Test"
+git config commit.gpgsign false
+
+mkdir -p .claude/skills/sample .ai-policy/hooks .ai-policy/scripts
+
+cp "$SRC_SCRIPT" .ai-policy/scripts/update-session-tags.sh
+cp "$SRC_HOOK" .ai-policy/hooks/check-session-tags.sh
+chmod +x .ai-policy/scripts/update-session-tags.sh .ai-policy/hooks/check-session-tags.sh
+SCRIPT="$SANDBOX/.ai-policy/scripts/update-session-tags.sh"
+HOOK="$SANDBOX/.ai-policy/hooks/check-session-tags.sh"
+
+cat > ai-workflow.md <<'EOF'
+# AI Workflow
+
+Version: 1.0.0
+
+Body.
+EOF
+
+cat > CLAUDE.md <<'EOF'
+Entry.
+EOF
+
+cat > .ai-policy/policy.env <<'EOF'
+PROTECTED_BRANCHES="main"
+EOF
+
+cat > .ai-policy/hooks/sample.sh <<'EOF'
+#!/usr/bin/env bash
+true
+EOF
+
+cat > .claude/skills/sample/SKILL.md <<'EOF'
+sample skill
+EOF
+
+cat > .claude/settings.json <<'EOF'
+{
+  "permissions": { "allow": [], "deny": [] }
+}
+EOF
+
+git add -A
+git commit -q -m "baseline"
+
+echo "Session tags hook tests:"
+
+# Case A: initial run populates OTEL_RESOURCE_ATTRIBUTES.
+rc=0
+"$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit "initial run writes tags" 0 "$rc"
+
+attrs="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES // ""' .claude/settings.json)"
+if [ -n "$attrs" ] && echo "$attrs" | grep -Eq 'workflow_version=1\.0\.0,workflow_repo=ai-coding-workflow,ruleset_hash=[0-9a-f]{8}$'; then
+  PASS=$((PASS + 1))
+  echo "  PASS: tag format is correct ($attrs)"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: tag format is wrong ($attrs)"
+fi
+FIRST_HASH="$(echo "$attrs" | sed -E 's/.*ruleset_hash=([0-9a-f]+)$/\1/')"
+
+# Case B: post-write --check passes.
+rc=0
+"$SCRIPT" --check >/dev/null 2>&1 || rc=$?
+assert_exit "check after write returns 0" 0 "$rc"
+
+# Case C: --check via hook wrapper passes.
+rc=0
+"$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "hook wrapper returns 0 on clean tree" 0 "$rc"
+
+# Case D: mutate a rule file without running update → --check fails.
+cat > .ai-policy/hooks/sample.sh <<'EOF'
+#!/usr/bin/env bash
+# changed
+true
+EOF
+rc=0
+"$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "drift in rule file is blocked" 1 "$rc"
+
+# Case E: re-run update, hash changes, --check passes again.
+"$SCRIPT" >/dev/null 2>&1
+new_attrs="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES' .claude/settings.json)"
+NEW_HASH="$(echo "$new_attrs" | sed -E 's/.*ruleset_hash=([0-9a-f]+)$/\1/')"
+if [ "$NEW_HASH" != "$FIRST_HASH" ] && [ -n "$NEW_HASH" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: hash changed after rule-file change ($FIRST_HASH -> $NEW_HASH)"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: hash did not change after rule-file change"
+fi
+rc=0
+"$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "check after re-run returns 0" 0 "$rc"
+
+# Case F: version bump without running update → --check fails.
+sed -i.bak 's/Version: 1.0.0/Version: 1.1.0/' ai-workflow.md
+rm -f ai-workflow.md.bak
+rc=0
+"$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "version bump without update is blocked" 1 "$rc"
+
+# Case G: missing settings.json → exit 2.
+rm .claude/settings.json
+rc=0
+"$SCRIPT" --check >/dev/null 2>&1 || rc=$?
+assert_exit "missing settings.json returns 2" 2 "$rc"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.ai-policy/scripts/update-session-tags.sh
+++ b/.ai-policy/scripts/update-session-tags.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -eu
+
+# Updates .claude/settings.json's env.OTEL_RESOURCE_ATTRIBUTES to match
+# the current ai-workflow.md version and a ruleset hash computed from
+# the rule-defining files.
+#
+# Usage:
+#   update-session-tags.sh          # writes if drift
+#   update-session-tags.sh --check  # exits 1 on drift, does not write
+#
+# Tag format:
+#   workflow_version=X.Y.Z,workflow_repo=ai-coding-workflow,ruleset_hash=<8hex>
+#
+# Ruleset-hash input (sorted, deterministic):
+#   ai-workflow.md
+#   CLAUDE.md
+#   .ai-policy/policy.env
+#   .ai-policy/hooks/*.sh
+#   .claude/skills/*/SKILL.md
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+WORKFLOW_FILE="ai-workflow.md"
+SETTINGS_FILE=".claude/settings.json"
+REPO_NAME="ai-coding-workflow"
+
+MODE="write"
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+fi
+
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{ print $1 }'
+  else
+    shasum -a 256 | awk '{ print $1 }'
+  fi
+}
+
+collect_rule_files() {
+  {
+    [ -f "$WORKFLOW_FILE" ] && echo "$WORKFLOW_FILE"
+    [ -f "CLAUDE.md" ] && echo "CLAUDE.md"
+    [ -f ".ai-policy/policy.env" ] && echo ".ai-policy/policy.env"
+    for f in .ai-policy/hooks/*.sh; do
+      [ -f "$f" ] && echo "$f"
+    done
+    for f in .claude/skills/*/SKILL.md; do
+      [ -f "$f" ] && echo "$f"
+    done
+  } | LC_ALL=C sort -u
+}
+
+version="$(awk '/^Version:[[:space:]]*/ { print $2; exit }' "$WORKFLOW_FILE" 2>/dev/null || true)"
+if [ -z "$version" ]; then
+  echo "update-session-tags: could not read Version: from $WORKFLOW_FILE" >&2
+  exit 2
+fi
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+  echo "update-session-tags: $SETTINGS_FILE not found" >&2
+  exit 2
+fi
+
+tmp_input="$(mktemp)"
+trap 'rm -f "$tmp_input"' EXIT
+
+while IFS= read -r f; do
+  printf '===%s===\n' "$f" >> "$tmp_input"
+  cat "$f" >> "$tmp_input"
+  printf '\n' >> "$tmp_input"
+done < <(collect_rule_files)
+
+ruleset_hash="$(sha256_hex < "$tmp_input" | cut -c1-8)"
+
+new_attrs="workflow_version=${version},workflow_repo=${REPO_NAME},ruleset_hash=${ruleset_hash}"
+
+current="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES // ""' "$SETTINGS_FILE")"
+
+if [ "$current" = "$new_attrs" ]; then
+  exit 0
+fi
+
+if [ "$MODE" = "check" ]; then
+  echo "update-session-tags: drift detected in $SETTINGS_FILE" >&2
+  echo "  current:  $current" >&2
+  echo "  expected: $new_attrs" >&2
+  echo "  run: ./.ai-policy/scripts/update-session-tags.sh" >&2
+  exit 1
+fi
+
+tmp_out="$(mktemp)"
+jq --arg v "$new_attrs" '.env.OTEL_RESOURCE_ATTRIBUTES = $v' "$SETTINGS_FILE" > "$tmp_out"
+mv "$tmp_out" "$SETTINGS_FILE"
+echo "update-session-tags: wrote $new_attrs to $SETTINGS_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,6 @@
       "Bash(git ls-tree:*)",
       "Bash(git config:*)",
       "Bash(git stash list:*)",
-
       "Bash(git checkout:*)",
       "Bash(git switch:*)",
       "Bash(git add:*)",
@@ -24,15 +23,12 @@
       "Bash(git stash pop:*)",
       "Bash(git stash apply:*)",
       "Bash(git stash drop:*)",
-
       "Bash(git push:*)",
       "Bash(git pull:*)",
-
       "Bash(gh issue:*)",
       "Bash(gh pr:*)",
       "Bash(gh repo:*)",
       "Bash(gh auth:*)",
-
       "Bash(ls:*)",
       "Bash(cat:*)",
       "Bash(head:*)",
@@ -52,12 +48,10 @@
       "Bash(dirname:*)",
       "Bash(basename:*)",
       "Bash(realpath:*)",
-
       "Bash(mkdir:*)",
       "Bash(cp:*)",
       "Bash(mv:*)",
       "Bash(touch:*)",
-
       "Bash(npm test:*)",
       "Bash(npm run:*)",
       "Bash(npm list:*)",
@@ -71,15 +65,12 @@
       "Bash(pytest:*)",
       "Bash(python -m pytest:*)",
       "Bash(make:*)",
-
       "Bash(pip3 list:*)",
       "Bash(node --version)",
       "Bash(npm --version)",
       "Bash(python3 --version)",
-
       "Bash(./.ai-policy/scripts/run-validation.sh)",
       "Bash(./.ai-policy/scripts/install-hooks.sh)",
-
       "mcp__github__get_issue",
       "mcp__github__create_issue",
       "mcp__github__list_issues",
@@ -116,5 +107,8 @@
         ]
       }
     ]
+  },
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.7.0,workflow_repo=ai-coding-workflow,ruleset_hash=cf878b9e"
   }
 }

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,16 @@
+# Example direnv config for enabling Claude Code session telemetry.
+# Copy to `.envrc`, edit the endpoint for your collector, then run `direnv allow`.
+# `.envrc` is gitignored — the three variables below are deliberately not committed.
+# The committed .claude/settings.json provides the workflow_version and ruleset_hash
+# tags; this file decides whether telemetry is on and where it goes.
+
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+
+# Uncomment if your collector is HTTP-only (port 4318 is the OTLP/HTTP default):
+# export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+# export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Uncomment if the downstream collector requires cumulative temporality:
+# export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative

--- a/.envrc.example
+++ b/.envrc.example
@@ -7,8 +7,10 @@
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
-# Uncomment if your collector is HTTP-only (port 4318 is the OTLP/HTTP default):
+# Uncomment if your collector is HTTP-only (port 4318 is the OTLP/HTTP default)
+# and comment out the gRPC endpoint/protocol above:
 # export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
 # export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,4 +12,6 @@ if [ "$REQUIRE_VALIDATION_BEFORE_COMMIT" = "true" ]; then
   "$ROOT_DIR/.ai-policy/scripts/check-validation.sh"
 fi
 
+"$ROOT_DIR/.ai-policy/hooks/check-session-tags.sh"
+
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Local settings
 *.local.json
 
+# direnv (per-repo shell env, e.g. telemetry enablement)
+.envrc
+
 # OS artifacts
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.7.0 - 2026-04-19
+
+### Added
+
+- `.ai-policy/scripts/update-session-tags.sh` computing `workflow_version` and an 8-hex `ruleset_hash` across rule-defining files and writing them into `.claude/settings.json`'s `env.OTEL_RESOURCE_ATTRIBUTES` ([#109]).
+- `.ai-policy/hooks/check-session-tags.sh` pre-commit check that blocks commits when the tag fragment drifts from the current ruleset ([#109]).
+- `.ai-policy/scripts/test-session-tags-hook.sh` enforcement test, wired into `project-validation.sh` ([#109]).
+- README section describing the three maintainer-side telemetry shell variables and the OTEL temporality gotcha ([#109]).
+
+### Changed
+
+- `.claude/settings.json` carries a committed `env.OTEL_RESOURCE_ATTRIBUTES` value so Claude Code sessions emit tagged telemetry when the maintainer enables it.
+
 ## 2.6.0 - 2026-04-19
 
 ### Added
@@ -79,3 +92,4 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 [#103]: https://github.com/philippe-ths/ai-coding-workflow/pull/103
 [#105]: https://github.com/philippe-ths/ai-coding-workflow/pull/105
 [#107]: https://github.com/philippe-ths/ai-coding-workflow/pull/107
+[#109]: https://github.com/philippe-ths/ai-coding-workflow/issues/109

--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ The three exported variables are:
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
+
+`OTEL_EXPORTER_OTLP_PROTOCOL` must be set explicitly; Claude Code's OTEL SDK does not infer it from the endpoint and fails init without it. Use `grpc` with port 4317, or `http/protobuf` with port 4318.
 
 `.envrc` is gitignored so these values stay on your machine. You can also export them in `~/.zshrc` or the current shell instead of using direnv.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,35 @@ Run validation:
 ./.ai-policy/scripts/run-validation.sh
 ```
 
+## Session Telemetry (Claude Code)
+
+Every Claude Code session started in this repository emits OTEL events tagged with the current workflow version and an 8-character ruleset hash. The tag fragment lives in `.claude/settings.json`'s `env.OTEL_RESOURCE_ATTRIBUTES` block and is kept in sync with the rule files by `.ai-policy/scripts/update-session-tags.sh`. A pre-commit check blocks commits when the fragment drifts.
+
+The repository file declares **what the tags mean**. The maintainer's shell declares **whether telemetry is enabled and where it goes**. The three enablement variables are intentionally not committed, so cloning the repo does not start emitting telemetry.
+
+To enable telemetry locally, copy the example direnv config and allow it:
+
+```bash
+cp .envrc.example .envrc
+direnv allow
+```
+
+The three exported variables are:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+```
+
+`.envrc` is gitignored so these values stay on your machine. You can also export them in `~/.zshrc` or the current shell instead of using direnv.
+
+Caveats:
+
+- Some downstream collectors require `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`.
+- Claude Code's `-p` one-shot mode may not flush telemetry reliably before exit; use an interactive session to verify emission.
+- After bumping the `Version:` header in `ai-workflow.md` or editing any rule file, run `./.ai-policy/scripts/update-session-tags.sh` to refresh the tag fragment.
+
 ## What This Repository Optimizes For
 
 - Clear human checkpoints before risky transitions.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.6.0
+Version: 2.7.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.5.1
+Version: 2.7.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.1.2
+Version: 1.1.3
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -25,7 +25,7 @@ Version: 1.1.2
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
 - Does not contain any runtime application code.
-- Does not include a test framework beyond shell-script syntax checks and five enforcement integration tests.
+- Does not include a test framework beyond shell-script syntax checks and six enforcement integration tests.
 
 ## Important Constraints
 - Agent-facing files must stay short enough to preserve context budget.
@@ -58,8 +58,8 @@ Version: 1.1.2
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
-- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`. Includes `check-changelog.sh`, a pre-push check rejecting `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry.
+- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, testing enforcement, and keeping Claude Code session tags in sync via `update-session-tags.sh`.
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`. Includes `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry) and `check-session-tags.sh` (pre-commit, rejects drift between `.claude/settings.json`'s `env.OTEL_RESOURCE_ATTRIBUTES` and the current ruleset).
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.
@@ -71,7 +71,7 @@ Version: 1.1.2
 
 ## Testing Overview
 - Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`.
-- Validation also runs five enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, and `test-changelog-hook.sh`.
+- Validation also runs six enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, `test-changelog-hook.sh`, and `test-session-tags-hook.sh`.
 - No unit test framework exists; there are no automated tests for documentation content.
 - Manual verification is the primary check for documentation changes.
 


### PR DESCRIPTION
## Summary

Closes #109 (Sub-issue B of #101 "Objective Evaluation Framework for the AI Coding Workflow").

- Adds a committed `env.OTEL_RESOURCE_ATTRIBUTES` block to `.claude/settings.json` carrying `workflow_version`, `workflow_repo`, and an 8-hex `ruleset_hash` computed from the rule-defining files.
- Adds `.ai-policy/scripts/update-session-tags.sh` to keep the tag fragment in sync with the current version and ruleset.
- Adds `.ai-policy/hooks/check-session-tags.sh` pre-commit check that blocks commits when the fragment drifts.
- Adds `.ai-policy/scripts/test-session-tags-hook.sh` enforcement test (9 cases), wired into `project-validation.sh`.
- Adds `.envrc.example` (direnv) with the three maintainer-side shell variables; `.envrc` is gitignored so enablement values stay off the repo.
- README gains a "Session Telemetry (Claude Code)" section covering the variables, the `OTEL_EXPORTER_OTLP_PROTOCOL` requirement discovered during verification, the cumulative-temporality gotcha, and the `-p`-mode flush caveat.
- Version bumped to 2.7.0; `CHANGELOG.md` and `project-context.md` updated; `lite-monolithic/ai-workflow.md` header aligned.

## Ruleset hash input set

Deterministic, sorted. Includes: `ai-workflow.md`, `CLAUDE.md`, `.ai-policy/policy.env`, `.ai-policy/hooks/*.sh`, `.claude/skills/*/SKILL.md`. Excludes factual context, design-decisions, cross-agent entry points, and script machinery.

## Test plan

- [x] `./.ai-policy/scripts/project-validation.sh` — all six enforcement suites pass.
- [x] New `test-session-tags-hook.sh` — 9/9 pass (initial write, tag format, post-write check, hook wrapper, drift block, hash-change on rule-file mutation, post-refresh check, version-bump-without-refresh block, missing-settings returns 2).
- [x] Runtime drift test: injected a wrong `OTEL_RESOURCE_ATTRIBUTES`, staged, attempted `git commit` — blocked with the remediation message. Restored clean.
- [x] Runtime refresh test: mutated `.ai-policy/policy.env`, ran `update-session-tags.sh` — hash changed as expected. Reverted.
- [x] Claude Code debug-log verification (Step 1 pre-collector): `CLAUDE_CODE_ENABLE_TELEMETRY=1` read, `getOtlpLogExporters: protocol=grpc, endpoint=http://localhost:4317` emitted, `PeriodicExportingMetricReader` alive and receiving `ECONNREFUSED 127.0.0.1:4317` (expected, no collector).
- [ ] Full end-to-end tag verification pending a running collector (Sub-issue C).

## Out of scope

- Running collector + dashboard stack (that is Sub-issue C).
- Baseline task suite (D) and periodic meta-review (E).
- Codex / Gemini / Copilot parity.