### PR TITLE
fix: allow tag pushes from protected branches (#104)

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-bash.sh
+++ b/.ai-policy/hooks/block-protected-branch-bash.sh
@@ -19,6 +19,63 @@ case "$COMMAND" in
   *) exit 0 ;;
 esac
 
+# Tag-only pushes do not modify a branch and are allowed on protected branches.
+# The authoritative safety net is the pre-push git hook, which inspects the
+# actual refs being pushed. This is a usability-layer heuristic.
+is_tag_push() {
+  local cmd="$1"
+  # git commit never creates a tag push; only applies to push commands.
+  case "$cmd" in
+    git\ push*) ;;
+    *) return 1 ;;
+  esac
+
+  # --tags or --mirror-with-tags flags → tag push if not combined with branch refs.
+  case " $cmd " in
+    *\ --tags\ *|*\ --tags) return 0 ;;
+  esac
+
+  # Explicit refs/tags/ refspec anywhere in the command.
+  case "$cmd" in
+    *refs/tags/*) return 0 ;;
+  esac
+
+  # "git push <remote> tag <name>" form.
+  if printf '%s' "$cmd" | grep -Eq '\bpush\b[^|;&]*\btag\b[[:space:]]+[^[:space:]]+'; then
+    return 0
+  fi
+
+  # "git push <remote> <name>" where <name> is a tag in the current repo.
+  # Strip git/push and known flag-words, then take the last positional token.
+  local args
+  args="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]*git[[:space:]]+push[[:space:]]*//')"
+  # Remove flags (tokens starting with -) to find positional args.
+  local positional last=""
+  for token in $args; do
+    case "$token" in
+      -*) continue ;;
+      *) positional="$token"; last="$token" ;;
+    esac
+  done
+  if [ -n "$last" ] && [ "$last" != "$positional" ]; then
+    : # unreachable; keep shellcheck happy
+  fi
+  if [ -n "$last" ]; then
+    if git tag -l "$last" 2>/dev/null | grep -qx "$last"; then
+      # Also ensure it is not simultaneously a branch name.
+      if ! git rev-parse --verify --quiet "refs/heads/$last" >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+if is_tag_push "$COMMAND"; then
+  exit 0
+fi
+
 CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"
 
 for protected in $PROTECTED_BRANCHES; do

--- a/.ai-policy/hooks/block-protected-branch-mcp.sh
+++ b/.ai-policy/hooks/block-protected-branch-mcp.sh
@@ -18,9 +18,22 @@ case "$TOOL_NAME" in
   *create_pull_request) exit 0 ;;
 esac
 
+# Tag refs do not modify a branch. Allow when tool_input.ref is a tag ref.
+REF="$(printf '%s' "$INPUT" | jq -r '.tool_input.ref // empty')"
+case "$REF" in
+  refs/tags/*) exit 0 ;;
+esac
+
 # Extract the target branch from tool_input.
 # push_files, create_or_update_file, delete_file use "branch".
 BRANCH="$(printf '%s' "$INPUT" | jq -r '.tool_input.branch // empty')"
+
+# If the tool names a branch ref explicitly via "ref", derive the branch name.
+if [ -z "$BRANCH" ]; then
+  case "$REF" in
+    refs/heads/*) BRANCH="${REF#refs/heads/}" ;;
+  esac
+fi
 
 if [ -z "$BRANCH" ]; then
   # No branch info available (e.g. merge_pull_request) — cannot check, allow.

--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -8,3 +8,4 @@ bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 ./.ai-policy/scripts/test-gemini-enforcement.sh
 ./.ai-policy/scripts/test-changelog-hook.sh
 ./.ai-policy/scripts/test-session-tags-hook.sh
+./.ai-policy/scripts/test-pre-push-hook.sh

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -87,6 +87,18 @@ printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x"
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
 
+# Test 6a: create_ref with tag ref → allowed (tags do not modify a branch)
+rc=0
+printf '{"tool_name":"mcp__github__create_ref","tool_input":{"ref":"refs/tags/v1.0.0","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "create_ref refs/tags/v1.0.0" "$rc"
+
+# Test 6b: create_ref with branch ref pointing to protected branch → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_ref","tool_input":{"ref":"refs/heads/main","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_ref refs/heads/main" "$rc"
+
 # ── Path 1: Shell/Bash blocking ──
 
 echo "Path 1 — Shell/Bash blocking:"
@@ -154,6 +166,36 @@ printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 
 assert_blocked "git commit when current-branch returns main (simulated)" "$rc"
+
+# ── Tag-push cases (simulated main branch still active) ──
+
+echo "Tag-push cases on simulated main:"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push --tags"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push --tags on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin --tags"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin --tags on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin refs/tags/v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin refs/tags/v1.0.0 on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin tag v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin tag v1.0.0 on main" "$rc"
+
+# Branch-push via explicit refspec to protected branch must still block.
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD:main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin HEAD:main on main" "$rc"
 
 # ── Summary ──
 

--- a/.ai-policy/scripts/test-codex-enforcement.sh
+++ b/.ai-policy/scripts/test-codex-enforcement.sh
@@ -127,6 +127,27 @@ printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "ls on main (simulated)" "$rc"
 
+# --- Tag-push cases on protected branch (still simulated main) ---
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push --tags"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push --tags on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin refs/tags/v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin refs/tags/v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin tag v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin tag v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD:main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin HEAD:main on main (simulated)" "$rc"
+
 # --- Tests on feature branch ---
 cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"
 

--- a/.ai-policy/scripts/test-gemini-enforcement.sh
+++ b/.ai-policy/scripts/test-gemini-enforcement.sh
@@ -127,6 +127,18 @@ printf '{"tool_name":"mcp_github_merge_pull_request","tool_input":{"owner":"x","
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
 
+# Test: create_ref with tag ref → allowed (tags do not modify a branch)
+rc=0
+printf '{"tool_name":"mcp_github_create_ref","tool_input":{"ref":"refs/tags/v1.0.0","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "create_ref refs/tags/v1.0.0" "$rc"
+
+# Test: create_ref with refs/heads/main → blocked
+rc=0
+printf '{"tool_name":"mcp_github_create_ref","tool_input":{"ref":"refs/heads/main","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_ref refs/heads/main" "$rc"
+
 # ── Path 1: Shell/Bash blocking via BeforeTool → bash hook ──
 
 echo "Path 1 — Shell/Bash blocking (Gemini BeforeTool → bash hook):"
@@ -169,6 +181,27 @@ rc=0
 printf '{"tool_name":"run_shell_command","tool_input":{"command":"ls -la"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "ls on main (simulated)" "$rc"
+
+# --- Tag-push cases on protected branch (still simulated main) ---
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push --tags"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push --tags on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin refs/tags/v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin refs/tags/v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin tag v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin tag v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"git push origin HEAD:main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin HEAD:main on main (simulated)" "$rc"
 
 # --- Tests on feature branch ---
 cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"

--- a/.ai-policy/scripts/test-pre-push-hook.sh
+++ b/.ai-policy/scripts/test-pre-push-hook.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for the git-level pre-push hook's tag-vs-branch discrimination.
+# Sets up a sandbox with stub dependency scripts so only .githooks/pre-push's
+# own logic is exercised.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SRC_PRE_PUSH="$ROOT_DIR/.githooks/pre-push"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit $expected, got $actual)"
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+cd "$SANDBOX"
+git init -q .
+
+mkdir -p .githooks .ai-policy/scripts .ai-policy/hooks
+
+cp "$SRC_PRE_PUSH" .githooks/pre-push
+chmod +x .githooks/pre-push
+
+# Stub: check-protected-branch.sh simulates "on protected branch" by exiting 2.
+# The pre-push hook MUST NOT invoke this for tag-only pushes.
+cat > .ai-policy/scripts/check-protected-branch.sh <<'STUB'
+#!/usr/bin/env bash
+echo "STUB: check-protected-branch invoked" >&2
+exit 2
+STUB
+chmod +x .ai-policy/scripts/check-protected-branch.sh
+
+# Stub: check-validation.sh — not invoked because REQUIRE_VALIDATION_BEFORE_PUSH=false.
+cat > .ai-policy/scripts/check-validation.sh <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x .ai-policy/scripts/check-validation.sh
+
+# Stub: check-changelog.sh — always exits 0 for these tests.
+cat > .ai-policy/hooks/check-changelog.sh <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+STUB
+chmod +x .ai-policy/hooks/check-changelog.sh
+
+cat > .ai-policy/policy.env <<'ENV'
+PROTECTED_BRANCHES="main master"
+VALIDATION_STATE_FILE=".ai-policy/state/validation.status"
+REQUIRE_VALIDATION_BEFORE_PUSH=false
+VALIDATION_COMMAND="./.ai-policy/scripts/run-validation.sh"
+ENV
+
+HOOK="$SANDBOX/.githooks/pre-push"
+
+echo "Pre-push hook tag vs branch tests:"
+
+# 1. Tag-only push — must skip protected-branch check → exit 0.
+rc=0
+printf 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000000000\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "tag-only push skips branch check" 0 "$rc"
+
+# 2. Multiple tag refs — still tag-only → exit 0.
+rc=0
+{
+  printf 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000000000\n'
+  printf 'refs/tags/v1.1.0 def refs/tags/v1.1.0 0000000000000000000000000000000000000000\n'
+} | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "multiple tag refs skip branch check" 0 "$rc"
+
+# 3. Branch push — must invoke branch check (stub exits 2) → exit 2.
+rc=0
+printf 'refs/heads/main abc refs/heads/main def\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "branch push invokes branch check" 2 "$rc"
+
+# 4. Mixed tag and branch refs — must invoke branch check → exit 2.
+rc=0
+{
+  printf 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000000000\n'
+  printf 'refs/heads/main abc refs/heads/main def\n'
+} | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "mixed refs invoke branch check" 2 "$rc"
+
+# 5. HEAD:refs/heads/main style refspec — treated as branch ref → exit 2.
+rc=0
+printf 'HEAD abc refs/heads/main def\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "HEAD:refs/heads/main invokes branch check" 2 "$rc"
+
+# 6. Delete a tag remotely (local_ref empty, remote_ref is tag) — still tag-only.
+rc=0
+printf '(delete) 0000000000000000000000000000000000000000 refs/tags/v1.0.0 abc\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "tag deletion skips branch check" 0 "$rc"
+
+# 7. Empty stdin — no refs → falls through to branch check → exit 2.
+rc=0
+printf '' | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "empty stdin invokes branch check" 2 "$rc"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+++ b/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
@@ -126,6 +126,18 @@ printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x"
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
 
+# Test: create_ref with tag ref → allowed (tags do not modify a branch)
+rc=0
+printf '{"tool_name":"mcp__github__create_ref","tool_input":{"ref":"refs/tags/v1.0.0","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "create_ref refs/tags/v1.0.0" "$rc"
+
+# Test: create_ref with refs/heads/main → blocked
+rc=0
+printf '{"tool_name":"mcp__github__create_ref","tool_input":{"ref":"refs/heads/main","sha":"abc","owner":"x","repo":"y"}}' \
+  | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "create_ref refs/heads/main" "$rc"
+
 # ── Path 1: Shell/Bash blocking via PreToolUse → bash hook ──
 
 echo "Path 1 — Shell/Bash blocking (PreToolUse → bash hook):"
@@ -165,6 +177,27 @@ rc=0
 printf '{"tool_name":"run_in_terminal","tool_input":{"command":"ls -la"}}' \
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "ls on main (simulated)" "$rc"
+
+# --- Tag-push cases on protected branch (still simulated main) ---
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push --tags"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push --tags on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin refs/tags/v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin refs/tags/v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin tag v1.0.0"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin tag v1.0.0 on main (simulated)" "$rc"
+
+rc=0
+printf '{"tool_name":"run_in_terminal","tool_input":{"command":"git push origin HEAD:main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin HEAD:main on main (simulated)" "$rc"
 
 # --- Tests on feature branch ---
 cp "$TMPDIR_TEST/current-branch-fake-feature.sh" "$REAL_SCRIPT"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.7.0,workflow_repo=ai-coding-workflow,ruleset_hash=cf878b9e"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.7.1,workflow_repo=ai-coding-workflow,ruleset_hash=128c05dd"
   }
 }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,7 +3,29 @@ set -eu
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-"$ROOT_DIR/.ai-policy/scripts/check-protected-branch.sh"
+# Pre-push receives one line per ref being pushed on stdin:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# If every remote_ref is under refs/tags/, this is a tag-only push and
+# the protected-branch check does not apply (no branch is being modified).
+# Otherwise run the protected-branch check.
+PUSH_REFS="$(cat || true)"
+TAG_ONLY=true
+HAS_ANY_REF=false
+
+while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
+  [ -z "${remote_ref:-}" ] && continue
+  HAS_ANY_REF=true
+  case "$remote_ref" in
+    refs/tags/*) ;;
+    *) TAG_ONLY=false ;;
+  esac
+done <<EOF
+$PUSH_REFS
+EOF
+
+if [ "$HAS_ANY_REF" = "false" ] || [ "$TAG_ONLY" = "false" ]; then
+  "$ROOT_DIR/.ai-policy/scripts/check-protected-branch.sh"
+fi
 
 # shellcheck disable=SC1091
 . "$ROOT_DIR/.ai-policy/policy.env"
@@ -12,6 +34,6 @@ if [ "$REQUIRE_VALIDATION_BEFORE_PUSH" = "true" ]; then
   "$ROOT_DIR/.ai-policy/scripts/check-validation.sh"
 fi
 
-"$ROOT_DIR/.ai-policy/hooks/check-changelog.sh"
+printf '%s\n' "$PUSH_REFS" | "$ROOT_DIR/.ai-policy/hooks/check-changelog.sh"
 
 exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.7.1 - 2026-04-19
+
+### Fixed
+
+- Pre-push hook and agent PreToolUse hooks no longer block tag pushes from protected branches; `git push <tag>`, `git push --tags`, and MCP `create_ref` for `refs/tags/*` now succeed from `main` while branch pushes remain blocked ([#104]).
+
+### Added
+
+- `.ai-policy/scripts/test-pre-push-hook.sh` covering tag-vs-branch discrimination in the git-level pre-push hook, wired into `project-validation.sh` ([#104]).
+
 ## 2.7.0 - 2026-04-19
 
 ### Added
@@ -92,4 +102,5 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 [#103]: https://github.com/philippe-ths/ai-coding-workflow/pull/103
 [#105]: https://github.com/philippe-ths/ai-coding-workflow/pull/105
 [#107]: https://github.com/philippe-ths/ai-coding-workflow/pull/107
+[#104]: https://github.com/philippe-ths/ai-coding-workflow/issues/104
 [#109]: https://github.com/philippe-ths/ai-coding-workflow/issues/109

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.7.0
+Version: 2.7.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.7.0
+Version: 2.7.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.1.3
+Version: 1.1.4
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -25,7 +25,7 @@ Version: 1.1.3
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
 - Does not contain any runtime application code.
-- Does not include a test framework beyond shell-script syntax checks and six enforcement integration tests.
+- Does not include a test framework beyond shell-script syntax checks and seven enforcement integration tests.
 
 ## Important Constraints
 - Agent-facing files must stay short enough to preserve context budget.
@@ -71,7 +71,7 @@ Version: 1.1.3
 
 ## Testing Overview
 - Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`.
-- Validation also runs six enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, `test-changelog-hook.sh`, and `test-session-tags-hook.sh`.
+- Validation also runs seven enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, `test-changelog-hook.sh`, `test-session-tags-hook.sh`, and `test-pre-push-hook.sh`.
 - No unit test framework exists; there are no automated tests for documentation content.
 - Manual verification is the primary check for documentation changes.
 


### PR DESCRIPTION
Closes #104.

## Summary

- Pre-push hook now reads stdin refs and skips the protected-branch check when every `remote_ref` is under `refs/tags/`; branch pushes (including `HEAD:main`, `--all`, `--mirror`) still block.
- Bash hook (`block-protected-branch-bash.sh`, shared by Claude Code / Codex / Gemini / VS Code) detects `--tags`, `refs/tags/*` refspecs, `git push origin tag <name>` form, and positional tag names via `git tag -l`.
- MCP hook (`block-protected-branch-mcp.sh`) allows `tool_input.ref` starting with `refs/tags/` and derives branch name from `refs/heads/*` for tools like `create_ref`.
- Adds `test-pre-push-hook.sh` (7 cases) covering tag-only, multi-tag, branch, mixed, `HEAD:refs/heads/main`, tag deletion, and empty stdin. Wired into `project-validation.sh`.
- Extends all four agent enforcement tests with tag-allow and `HEAD:main` block cases plus MCP `create_ref` tests.
- Version bump `2.7.0 → 2.7.1`, CHANGELOG entry, refreshed `OTEL_RESOURCE_ATTRIBUTES`.

## Test plan

- [x] Full `project-validation.sh` green (101 tests across 7 scripts).
- [x] Bash hook with simulated `current-branch = main`: 4 tag-push forms allowed, 5 branch-push forms blocked.
- [x] MCP hook: `refs/tags/*` allowed, `refs/heads/main` blocked, feature branch allowed.
- [x] Real `git push --dry-run origin <tag>` accepted by modified pre-push hook.
- [ ] After merge: tag `v2.7.1` on the squash commit and push from `main` without the throwaway-branch workaround.