### PR TITLE
Sub-issue E: periodic review cadence (#113)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.9.0,workflow_repo=ai-coding-workflow,ruleset_hash=b5bbce97"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.10.0,workflow_repo=ai-coding-workflow,ruleset_hash=9224610d"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.10.0 - 2026-04-19
+
+### Added
+
+- `workflow-review.md` at repo root — calendar-driven periodic review process executed outside the per-task workflow. Defines a minimum-data gate (≥ 2 versions of baseline data, ≥ 20 real Claude Code sessions per version, paired task coverage, consistent ruleset hash within each version), the inputs read (baseline JSONs, Loki session logs, Prometheus aggregates, sampled transcripts, `observed-ai-failings.md`), the analyses run (`scripts/compare-versions.py` for pass^k / McNemar / metric deltas, event-cluster scans on `tool_decision` and `fix_cycles`, LLM-as-judge on transcripts with required snippet citations), the proposal output format with five classifications (`hook`, `skill`, `rule`, `step`, `multi`), the disqualifying conditions (single-session evidence, sub-gate quantitative data, no specific surface, uncited LLM-judge claims, vague proposed change, missing rollback plan), and the approval workflow that funnels accepted proposals into `aiw-issue-creation` ([#113]).
+- `docs/workflow-review-example-2026-04-19.md` — first worked example produced under the periodic review process; demonstrates the gate refusing on quantitative thinness (only `2.9.0` mock-agent baseline data on disk, zero captured Claude Code sessions) and includes one illustrative qualitative-only proposal that would itself be rejected under the disqualifying conditions ([#113]).
+
+### Changed
+
+- `project-context.md` Scope and Project Structure sections updated to list the new periodic review process and worked example; `Version:` header bumped to `1.3.0` ([#113]).
+- `README.md` Maintenance documents section updated with a one-line pointer to `workflow-review.md` and the first worked example ([#113]).
+
 ## 2.9.0 - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Tipping points are a judgement call. They come from real-world usage in other re
 - `ai-workflow-design-decisions/` — scoped maintenance rules and rationale for editing `ai-workflow.md`.
 - `project-context-design-decisions.md` — maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md` — log of concrete failure patterns observed in real AI-agent sessions.
+- `workflow-review.md` — calendar-driven periodic review process: defines how an agent analyses accumulated telemetry plus baseline results to produce classified workflow improvement proposals. Runs outside the per-task workflow. See `docs/workflow-review-example-2026-04-19.md` for the first worked example.
 
 ## Installation by Tool
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.9.0
+Version: 2.10.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/docs/workflow-review-example-2026-04-19.md
+++ b/docs/workflow-review-example-2026-04-19.md
@@ -1,0 +1,53 @@
+# Workflow Review — 2026-04-19 (worked example)
+
+This is the first worked example produced under the periodic review process defined in `workflow-review.md`.
+It runs the process against the data on disk as of 2026-04-19.
+
+## Minimum-data gate result
+
+**Gate not met.** This review does not produce binding proposals. The illustrative proposal below demonstrates the format only; it would itself be rejected under the disqualifying conditions.
+
+| Condition | Required | Observed | Met? |
+|---|---|---|---|
+| Workflow versions with baseline data | ≥ 2 | 1 (`2.9.0`) | No |
+| Real Claude Code sessions per version in Loki | ≥ 20 | 0 (data dir empty; no sessions captured to disk) | No |
+| Same task set across versions | yes | n/a (only one version on disk) | No |
+| Consistent `ruleset_hash` within each version | yes | yes for `2.9.0` (`b5bbce97`), but irrelevant under the other failures | Pass for that version |
+
+**Earliest date the gate could pass.** When at least one further workflow version has shipped *and* at least 20 real Claude Code sessions have accumulated in Loki for each of those versions. With no live capture currently retained in the repo's data directory, this is not achievable today and depends on the maintainer running tagged sessions.
+
+## Quantitative evidence available right now
+
+- 6 baseline JSONs for `workflow_version=2.9.0`, `ruleset_hash=b5bbce97`, all from the `mock` agent (3 tasks × 2 runs).
+- 0 real Claude Code sessions captured under `telemetry/data/`.
+- `scripts/compare-versions.py` cannot run a paired comparison because there is only one version on disk.
+
+No quantitative finding can be drawn from this state.
+
+## Illustrative qualitative-only proposal (format demonstration)
+
+This proposal is **not for issue creation**. It demonstrates the proposal format using qualitative evidence from `observed-ai-failings.md`.
+
+### Proposal 1 (illustrative): scope drift during conflict resolution
+
+- **Classification:** `skill`
+- **Problem observed:**
+  Multiple `observed-ai-failings.md` entries describe the agent silently expanding scope while resolving cherry-pick or merge conflicts — folding adjacent fixes into the resolution commit where review attention is lower than for a normal feature commit.
+- **Evidence:**
+  Qualitative-only. Cited entry: Entry 20 (cherry-pick conflict scope drift). Pattern is consistent with general scope-control risks already noted in `ai-workflow.md` Scope Control section. No quantitative data because the minimum-data gate is not met.
+- **Proposed change:**
+  Add a short subsection in the existing `aiw-failure-analysis` skill (or a small new skill `aiw-conflict-resolution`) defining a checklist for conflict-resolution commits: list every file touched, list every change beyond the conflict markers, name the original task, and confirm that no unrelated change crept in.
+- **Affected surface:**
+  `.claude/skills/aiw-failure-analysis/SKILL.md` and `.agents/skills/aiw-failure-analysis/SKILL.md` — both must change together to preserve cross-platform parity.
+- **Risks:**
+  Adds checklist friction to the conflict-resolution path. May produce false-positive scope-drift warnings for legitimate adjacent fixes. Does not catch scope drift outside conflict resolution.
+- **Rollback plan:**
+  `git revert` the commit that adds the subsection. No config rollback needed because this is a documentation-only change.
+
+This proposal would be rejected under the disqualifying conditions because the evidence is qualitative-only AND the minimum-data gate is not met. It is included here solely to demonstrate the format.
+
+## Outcome
+
+- No proposals submitted for issue creation.
+- No workflow stack changes recommended.
+- Action required: continue accumulating telemetry and baseline data. Re-run this review once the gate can pass.

--- a/observed-ai-failings.md
+++ b/observed-ai-failings.md
@@ -705,3 +705,35 @@ This pattern appears when the agent resolves a cherry-pick or merge conflict and
 
 ### Scope
 This appears general across tasks because cherry-pick and merge conflict resolution are common operations, and the temptation to fold in related fixes during resolution applies whenever the conflicting code is close to code that needs changing.
+
+## Entry 21
+
+### Title
+- Feature bloat and silent performance degradation.
+
+### Version
+- 2.3.0
+
+### Date
+- 2026-04-19
+
+### Context
+- Claude Code. 4.6 - 4.7, effort: medium - Xhigh. 
+- FCP Auto-Editor.
+
+### What Happened
+- The agent implemented complex UI workarounds that passed functional unit tests but severely degraded real-world execution speed.
+- It failed to write automated performance tests to catch these latency regressions.
+
+### Why It Matters
+- The application becomes practically unusable despite the workflow reporting complete validation success.
+
+### Trigger Pattern
+- Implementing heavy state changes or complex UI fragments in top-down execution frameworks like Streamlit.
+
+### Early Warning Signs
+- The agent introduces caching workarounds or manual state resets to prevent double-reruns.
+- The agent adds complex UI decorators without adding corresponding automated latency tests.
+
+### Scope
+- General across tasks touching the UI or heavy data processing loops.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.2.0
+Version: 1.3.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -18,6 +18,7 @@ Version: 1.2.0
 ## Scope
 - Defines a reusable AI coding workflow (`ai-workflow.md`) with planning, validation, scope-control, failure-analysis, and GitHub handoff rules.
 - Provides a project-context management skill (`aiw-project-context-management`) for authoring and maintaining a repository's `project-context.md`.
+- Provides a calendar-driven periodic review process (`workflow-review.md`) executed outside the per-task workflow; analyses accumulated telemetry and baseline results and produces classified workflow improvement proposals (hook, skill, rule, step, multi).
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
 - Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, and project context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
@@ -55,6 +56,8 @@ Version: 1.2.0
 
 ## Project Structure
 - `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent. Its `Version:` header is the canonical project version.
+- `workflow-review.md`: calendar-driven periodic review process executed outside the per-task workflow. Defines the minimum-data gate, inputs read, analyses run, proposal output format with five classifications (hook, skill, rule, step, multi), disqualifying conditions, and approval workflow.
+- `docs/workflow-review-example-2026-04-19.md`: first worked example produced under the periodic review process; demonstrates the gate refusing on quantitative thinness and includes one illustrative qualitative-only proposal.
 - `CHANGELOG.md`: Common Changelog record of every version bump; enforced by the pre-push changelog hook.
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
 - `project-context-design-decisions.md`: maintenance rules for keeping `project-context.md` factual and concise.

--- a/workflow-review.md
+++ b/workflow-review.md
@@ -1,0 +1,123 @@
+# Workflow Review
+
+Version: 1.0.0
+
+This file defines the periodic review process for the AI coding workflow.
+The review is calendar-driven, not per-task.
+It analyses accumulated telemetry and baseline results, then produces classified workflow improvement proposals.
+
+The per-task workflow lives in `ai-workflow.md`.
+This document is a separate process invoked outside that loop.
+
+## Why this is not a workflow step
+
+The per-task workflow runs on every change.
+Running a meta-analysis of telemetry on every change is wasteful and adds noise to normal development.
+Periodic review belongs on a calendar cadence: monthly, or whenever enough new tagged data has accumulated.
+
+## When to run a review
+
+- **Calendar trigger.** Monthly, or after a workflow version bump that introduces measurable change.
+- **Data trigger.** When accumulated telemetry crosses the minimum-data gate defined below.
+- **Human triggers the review explicitly.** The agent does not start one autonomously.
+
+## Minimum-data gate
+
+Do not produce proposals unless **all** of the following hold:
+
+- At least two workflow versions have baseline harness data on disk under `telemetry/data/baseline/<workflow_version>/`.
+- At least 20 real Claude Code sessions per version are present in Loki for the corresponding `workflow_version` label.
+- The baseline runs cover the same set of tasks across versions, so paired McNemar comparison is possible.
+- The `ruleset_hash` is consistent within each version, so the data measures one ruleset state, not a mid-flight change.
+
+If any condition fails, do not produce proposals. Report instead:
+
+- Which condition is not met.
+- The current data counts (versions, sessions, tasks, runs).
+- The earliest date the gate could be expected to pass given current capture rate.
+
+A thin-data review must end at this point. Do not paper over the gap.
+
+## Inputs the review reads
+
+- **Baseline harness JSONs** at `telemetry/data/baseline/<workflow_version>/<ruleset_hash>/<task_id>/<run_id>.json`. Schema in `docs/telemetry-schema.md`.
+- **Loki session logs** for Claude Code sessions tagged with `workflow_version` and `ruleset_hash`. Query via the Loki HTTP API or via the Grafana stack in `telemetry/`.
+- **Prometheus aggregates** for the same labels. Query via PromQL.
+- **Sampled transcripts** if retained by the harness or by separate session capture.
+- **observed-ai-failings.md** for human-recorded qualitative patterns. Use only as supplementary evidence; this file pre-dates the data loop and represents intuition-era observations.
+
+## Analyses to run
+
+For pass/fail comparison between two workflow versions:
+
+- Run `python scripts/compare-versions.py <version_a> <version_b>` to produce per-task `pass^k`, aggregate `pass^k`, McNemar's test on paired pass/fail outcomes, and mean/median deltas on duration, cost, tokens, and fix cycles.
+- Treat McNemar p < 0.05 as a candidate signal, not a conclusion. Confirm with at least one of: a transcript snippet, a `prompt.id` cluster, or a clear continuous-metric delta in the same period.
+
+For event-level signals from telemetry:
+
+- Scan `tool_decision` events for elevated rejection rates by tool name. Group by workflow step where determinable.
+- Scan `fix_cycles` distribution for outliers; cluster by task and ruleset to see whether the spike concentrates on one rule or one task type.
+- Scan rejected tool calls grouped by `prompt.id` to find points where the agent attempted an action the workflow disallows.
+
+For transcript-level signals:
+
+- Use LLM-as-judge on a sampled subset of transcripts.
+- Each judge call must answer one focused question (for example: "did the agent appear to revisit Step 5 because Step 6 failed?") and must cite the snippet supporting its answer.
+- Treat LLM-judge output as a hypothesis. A judge claim that cannot be backed by a quoted transcript snippet is not evidence.
+
+## Proposal output format
+
+Every proposal must include all of the following fields. A proposal missing any field is not eligible for review.
+
+```
+### Proposal <N>: <short title>
+
+- Classification: one of hook, skill, rule, step, multi
+- Problem observed:
+  <One paragraph. Concrete enough to test.>
+- Evidence:
+  <Specific numbers, prompt.ids, transcript snippets, or McNemar results.
+   Cite at least one quantitative source AND one qualitative source if both exist.
+   If only qualitative evidence exists, label the proposal "qualitative-only".>
+- Proposed change:
+  <The specific modification to the workflow stack. Name the file or surface that would change.>
+- Affected surface:
+  <Exact file path or hook name. For multi-surface changes, list every surface and order them by required edit sequence.>
+- Risks:
+  <What could regress. What scenarios the proposed change does not cover.>
+- Rollback plan:
+  <The exact sequence to revert if the change makes things worse.>
+```
+
+## Classifications
+
+- **hook** — change to scripts under `.ai-policy/hooks/`, `.githooks/`, `.claude/settings.json` hooks, `.codex/hooks.json`, or `.gemini/settings.json` BeforeTool config.
+- **skill** — change to a file under `.agents/skills/` or `.claude/skills/`. Skills must be edited in both directories together.
+- **rule** — change to text inside `ai-workflow.md` (a workflow rule, validation requirement, scope-control item, or boundary rule), without changing the numbered step list.
+- **step** — change to the numbered step list in `ai-workflow.md` (adding, removing, reordering, or splitting a step).
+- **multi** — any proposal that touches more than one of the above surfaces. Multi proposals must list every surface and an explicit edit sequence.
+
+## Disqualifying conditions
+
+Reject a proposal at review if any apply:
+
+- Evidence comes from a single session.
+- Quantitative evidence relies on data below the minimum-data gate.
+- The proposal cannot name a specific file, hook, or skill it would modify.
+- An LLM-judge claim has no quoted transcript snippet.
+- The pattern can be explained by a known unrelated change in the same period.
+- The proposal restates an existing rule without adding new evidence that the rule is failing.
+- No rollback plan is stated, or the rollback plan is not specific enough to execute.
+- The proposed change is vague (for example: "improve scope control" without naming a file or rule).
+
+## Approval workflow
+
+1. The agent produces the proposal batch in the format above and presents it to the human in a single document.
+2. The human reviews each proposal individually and accepts, rejects, or asks for revision.
+3. For each accepted proposal, the agent loads the `aiw-issue-creation` skill and creates one GitHub issue per proposal.
+4. Implementation of each accepted proposal goes through the standard per-task workflow defined in `ai-workflow.md`.
+5. The review document itself is archived under `docs/workflow-review-<date>.md` so future reviews can reference prior findings.
+
+## Worked examples
+
+The first executed worked example is `docs/workflow-review-example-2026-04-19.md`. It demonstrates the gate refusing on quantitative thinness and produces one illustrative qualitative-only proposal that would itself be rejected under the disqualifying conditions.


### PR DESCRIPTION
## Summary
- Closes #113. Adds `workflow-review.md` defining a calendar-driven periodic review process executed outside the per-task workflow. The review analyses accumulated telemetry plus baseline results and produces classified workflow improvement proposals (`hook` / `skill` / `rule` / `step` / `multi`), gated by minimum-data requirements (≥ 2 versions of baseline data, ≥ 20 real Claude Code sessions per version, paired task coverage, consistent `ruleset_hash` within each version).
- Adds `docs/workflow-review-example-2026-04-19.md` as the first worked example. Real data is currently sub-gate (only `2.9.0` mock-agent baseline runs on disk; no captured Claude Code sessions), so the example demonstrates the gate refusing and includes one illustrative qualitative-only proposal that would itself be rejected under the disqualifying conditions.
- Bumps `ai-workflow.md` to `2.10.0` with matching CHANGELOG entry; refreshes `.claude/settings.json` session-tag fragment via `update-session-tags.sh` (`ruleset_hash` `b5bbce97` → `9224610d`). `project-context.md` Scope and Project Structure updated; Version bumped to `1.3.0`. `README.md` gains a one-line pointer.
- Folds in unrelated WIP: `observed-ai-failings.md` Entry 21 (Streamlit feature-bloat performance pattern). Non-user-facing per the design rules, so no separate version impact.

## Note on parent
This is the **last open sub-issue** under #101. After this merges, parent #101 can be closed.

## Post-merge actions for the human
- Tag `v2.10.0` (minor bump per design rules requires a tagged release).
- Close parent #101.

## Test plan
- [x] `./.ai-policy/scripts/project-validation.sh` — all seven enforcement suites pass (17 + 18 + 22 + 23 + 5 + 9 + 7).
- [x] `update-session-tags.sh` ran cleanly; `ruleset_hash` updated for `2.10.0`.
- [x] `project-context.md` stays under 300 lines (now 108).
- [ ] Manual: read `workflow-review.md` end-to-end and confirm the process is executable without ambiguity.
- [ ] Manual: confirm the worked example honestly reports gate-failure and clearly marks the illustrative proposal as not for issue creation.