### PR TITLE
feat: aiw-telemetry-setup skill + downstream-safe session-tags hook

### DIFF
--- a/.agents/skills/aiw-telemetry-setup/SKILL.md
+++ b/.agents/skills/aiw-telemetry-setup/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: aiw-telemetry-setup
+description: "Guided, mostly-automated process for enabling Claude Code session telemetry in any repository and verifying end-to-end that tagged data reaches the local telemetry store before reporting success. Use this skill when the user asks to start recording sessions, enable telemetry in a new repo, set up observability for Claude Code, or investigates why an expected session is missing from Grafana or Loki. The skill exists to prevent the silent non-emission failure mode where a session runs normally but emits nothing because an environment variable did not propagate to the process that actually launched Claude Code."
+---
+
+# Telemetry Setup
+
+Read this file when the user wants to start recording Claude Code session telemetry in a repository.
+The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository — the current one or any other — to emit into that stack.
+
+## Principles
+
+- Automate every detection and probe step.
+- Ask the user exactly once, with a consolidated summary of every file the skill would create or modify, before writing anything.
+- Never enable telemetry as a default side effect. The skill runs only when explicitly invoked.
+- On any failure, leave the repository in the state it was in before the skill ran.
+- Report SUCCESS or FAIL with the specific phase that failed and the next thing for the user to check.
+
+## Phase 1 — Pre-flight detection (automated, read-only)
+
+Run all of these before asking the user anything. Collect findings and present them together.
+
+- Resolve the target repository root. Report it.
+- Detect collector reachability by probing the local OTLP endpoints on the host running the user's shell. Do not probe remote endpoints.
+- Detect whether `direnv` is installed and whether the target repository contains an existing `.envrc`.
+- Detect the launch context of the current Claude Code process and of the likely future launches: terminal vs IDE. Check standard IDE indicator variables, the process parent, and the binary path. State confidence.
+- Detect whether the target repository already has `.claude/settings.json` and whether it has an `env` block.
+- Detect whether telemetry appears to be already configured in the target repository. Do not modify anything if yes; offer re-probe instead.
+- Do not launch Claude Code, do not send any network traffic other than the collector reachability probe, and do not write files during this phase.
+
+## Phase 2 — Propose a single change set
+
+Based on Phase 1, decide the propagation mechanism:
+
+- If direnv is available and the launch context is terminal, propose writing or extending `.envrc`.
+- If direnv is absent or the launch context is IDE, propose writing the enable and endpoint variables into the `env` block of `.claude/settings.json`. Warn that these values are committed to the repository and require a local-only endpoint.
+- Never propose an endpoint that is not `http://localhost:*` without a second explicit confirmation from the user that they understand the endpoint will be committed and visible to anyone who clones the repository.
+
+Pick the tag strategy:
+
+- Default the repository identifier to the repo's directory name.
+- If the target repository has its own `ai-workflow.md` with a `Version:` header, read it and offer it as the `workflow_version` tag. Otherwise propose a plain free-form version string or omit the field.
+- Do not replicate the `update-session-tags.sh` ruleset-hash machinery into downstream repositories. That mechanism belongs to the `ai-coding-workflow` repository. Downstream repositories use a plain-string `OTEL_RESOURCE_ATTRIBUTES`.
+
+Present the change set as a single summary:
+
+- Every file that will be created, with its full proposed content.
+- Every file that will be modified, with a precise diff of the lines being added.
+- The tag string the repository will carry.
+- The probe the skill will run afterwards.
+
+Ask the user to approve this summary once. Proceed only on explicit approval. On approval, proceed through Phases 3 and 4 without further prompts.
+
+## Phase 3 — Apply changes (after single confirmation)
+
+- Back up any file the skill modifies before writing. Restore the backup if any later step in this phase or Phase 4 fails.
+- When writing `.envrc`, read any existing file first and merge rather than overwrite. Never remove user-authored exports that the skill did not add.
+- When writing `.claude/settings.json`, preserve existing keys. Only touch the `env` block.
+- After writing, if direnv is the chosen mechanism, instruct the user to run `direnv allow` and confirm the environment propagates. This is the only user action the skill requests after the confirmation gate.
+
+## Phase 4 — Probe (automated, reported layer by layer)
+
+Run the probe layers in order. Report each layer's result as it completes. Stop and report FAIL at the first failing layer.
+
+- **Layer 1 — Collector reachability.** Send an HTTP probe to the OTLP endpoint and require a success response.
+- **Layer 2 — Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that the enable flag, the OTLP endpoint, and the resource attributes are present with the expected values.
+- **Layer 3 — End-to-end round-trip.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes.
+
+Layer 3 must use a fresh UUID for each probe so a stale matching record cannot produce a false positive. The probe must not emit any real session data.
+
+## Phase 5 — Report
+
+- On full success, report the repository root, the propagation mechanism chosen, the tag string in effect, and the exact Loki query the user can re-run later to confirm tagged sessions are arriving.
+- On any failure, report the phase that failed, the specific check that failed, the observed output, and the next thing for the user to verify manually. Leave no partial state behind.
+- Record that the skill has run. A subsequent invocation in the same repository should detect the prior configuration and offer a re-probe instead of re-writing.
+
+## What not to do
+
+- Do not launch a real Claude Code session as part of the probe. The synthetic OTLP probe is sufficient and deterministic.
+- Do not capture or log prompt content, tool parameters, or any session transcript during probing.
+- Do not write an endpoint other than `http://localhost:*` into `.claude/settings.json` without a second explicit confirmation.
+- Do not overwrite an existing `.envrc` or existing `.claude/settings.json` keys the skill did not add.
+- Do not claim success if any probe layer fails, even if the earlier layers passed.
+- Do not imply that data is being captured if the launch context the user actually uses to start Claude Code is not the one the probe validated.

--- a/.ai-policy/scripts/test-session-tags-hook.sh
+++ b/.ai-policy/scripts/test-session-tags-hook.sh
@@ -138,6 +138,41 @@ rc=0
 "$HOOK" >/dev/null 2>&1 || rc=$?
 assert_exit "version bump without update is blocked" 1 "$rc"
 
+# Case H: downstream repo with non-upstream tag string → hook exits 0 and
+# does not overwrite the existing tag value.
+cat > .claude/settings.json <<'EOF'
+{
+  "permissions": { "allow": [], "deny": [] },
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "service.name=claude-code,repo=downstream-test,workflow_version=9.9.9"
+  }
+}
+EOF
+rc=0
+"$HOOK" >/dev/null 2>&1 || rc=$?
+assert_exit "downstream tag string is skipped by hook" 0 "$rc"
+
+preserved="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES' .claude/settings.json)"
+if [ "$preserved" = "service.name=claude-code,repo=downstream-test,workflow_version=9.9.9" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: downstream tag string preserved by write mode"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: downstream tag string was overwritten ($preserved)"
+fi
+rc=0
+"$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit "write mode in downstream repo returns 0" 0 "$rc"
+
+after_write="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES' .claude/settings.json)"
+if [ "$after_write" = "service.name=claude-code,repo=downstream-test,workflow_version=9.9.9" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: write mode left downstream tag string untouched"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: write mode modified downstream tag string ($after_write)"
+fi
+
 # Case G: missing settings.json → exit 2.
 rm .claude/settings.json
 rc=0

--- a/.ai-policy/scripts/update-session-tags.sh
+++ b/.ai-policy/scripts/update-session-tags.sh
@@ -64,6 +64,16 @@ if [ ! -f "$SETTINGS_FILE" ]; then
   exit 2
 fi
 
+# Self-scope to the ai-coding-workflow upstream repo. Downstream repos that
+# copy .ai-policy/ wholesale set their own OTEL_RESOURCE_ATTRIBUTES via the
+# aiw-telemetry-setup skill; their tag string does not carry
+# workflow_repo=ai-coding-workflow and must not be overwritten or drift-checked
+# against the upstream ruleset hash.
+existing="$(jq -r '.env.OTEL_RESOURCE_ATTRIBUTES // ""' "$SETTINGS_FILE")"
+if [ -n "$existing" ] && ! printf '%s' "$existing" | grep -q 'workflow_repo=ai-coding-workflow'; then
+  exit 0
+fi
+
 tmp_input="$(mktemp)"
 trap 'rm -f "$tmp_input"' EXIT
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.10.0,workflow_repo=ai-coding-workflow,ruleset_hash=9224610d"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.11.0,workflow_repo=ai-coding-workflow,ruleset_hash=a3a0365f"
   }
 }

--- a/.claude/skills/aiw-telemetry-setup/SKILL.md
+++ b/.claude/skills/aiw-telemetry-setup/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: aiw-telemetry-setup
+description: "Guided, mostly-automated process for enabling Claude Code session telemetry in any repository and verifying end-to-end that tagged data reaches the local telemetry store before reporting success. Use this skill when the user asks to start recording sessions, enable telemetry in a new repo, set up observability for Claude Code, or investigates why an expected session is missing from Grafana or Loki. The skill exists to prevent the silent non-emission failure mode where a session runs normally but emits nothing because an environment variable did not propagate to the process that actually launched Claude Code."
+---
+
+# Telemetry Setup
+
+Read this file when the user wants to start recording Claude Code session telemetry in a repository.
+The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository — the current one or any other — to emit into that stack.
+
+## Principles
+
+- Automate every detection and probe step.
+- Ask the user exactly once, with a consolidated summary of every file the skill would create or modify, before writing anything.
+- Never enable telemetry as a default side effect. The skill runs only when explicitly invoked.
+- On any failure, leave the repository in the state it was in before the skill ran.
+- Report SUCCESS or FAIL with the specific phase that failed and the next thing for the user to check.
+
+## Phase 1 — Pre-flight detection (automated, read-only)
+
+Run all of these before asking the user anything. Collect findings and present them together.
+
+- Resolve the target repository root. Report it.
+- Detect collector reachability by probing the local OTLP endpoints on the host running the user's shell. Do not probe remote endpoints.
+- Detect whether `direnv` is installed and whether the target repository contains an existing `.envrc`.
+- Detect the launch context of the current Claude Code process and of the likely future launches: terminal vs IDE. Check standard IDE indicator variables, the process parent, and the binary path. State confidence.
+- Detect whether the target repository already has `.claude/settings.json` and whether it has an `env` block.
+- Detect whether telemetry appears to be already configured in the target repository. Do not modify anything if yes; offer re-probe instead.
+- Do not launch Claude Code, do not send any network traffic other than the collector reachability probe, and do not write files during this phase.
+
+## Phase 2 — Propose a single change set
+
+Based on Phase 1, decide the propagation mechanism:
+
+- If direnv is available and the launch context is terminal, propose writing or extending `.envrc`.
+- If direnv is absent or the launch context is IDE, propose writing the enable and endpoint variables into the `env` block of `.claude/settings.json`. Warn that these values are committed to the repository and require a local-only endpoint.
+- Never propose an endpoint that is not `http://localhost:*` without a second explicit confirmation from the user that they understand the endpoint will be committed and visible to anyone who clones the repository.
+
+Pick the tag strategy:
+
+- Default the repository identifier to the repo's directory name.
+- If the target repository has its own `ai-workflow.md` with a `Version:` header, read it and offer it as the `workflow_version` tag. Otherwise propose a plain free-form version string or omit the field.
+- Do not replicate the `update-session-tags.sh` ruleset-hash machinery into downstream repositories. That mechanism belongs to the `ai-coding-workflow` repository. Downstream repositories use a plain-string `OTEL_RESOURCE_ATTRIBUTES`.
+
+Present the change set as a single summary:
+
+- Every file that will be created, with its full proposed content.
+- Every file that will be modified, with a precise diff of the lines being added.
+- The tag string the repository will carry.
+- The probe the skill will run afterwards.
+
+Ask the user to approve this summary once. Proceed only on explicit approval. On approval, proceed through Phases 3 and 4 without further prompts.
+
+## Phase 3 — Apply changes (after single confirmation)
+
+- Back up any file the skill modifies before writing. Restore the backup if any later step in this phase or Phase 4 fails.
+- When writing `.envrc`, read any existing file first and merge rather than overwrite. Never remove user-authored exports that the skill did not add.
+- When writing `.claude/settings.json`, preserve existing keys. Only touch the `env` block.
+- After writing, if direnv is the chosen mechanism, instruct the user to run `direnv allow` and confirm the environment propagates. This is the only user action the skill requests after the confirmation gate.
+
+## Phase 4 — Probe (automated, reported layer by layer)
+
+Run the probe layers in order. Report each layer's result as it completes. Stop and report FAIL at the first failing layer.
+
+- **Layer 1 — Collector reachability.** Send an HTTP probe to the OTLP endpoint and require a success response.
+- **Layer 2 — Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that the enable flag, the OTLP endpoint, and the resource attributes are present with the expected values.
+- **Layer 3 — End-to-end round-trip.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes.
+
+Layer 3 must use a fresh UUID for each probe so a stale matching record cannot produce a false positive. The probe must not emit any real session data.
+
+## Phase 5 — Report
+
+- On full success, report the repository root, the propagation mechanism chosen, the tag string in effect, and the exact Loki query the user can re-run later to confirm tagged sessions are arriving.
+- On any failure, report the phase that failed, the specific check that failed, the observed output, and the next thing for the user to verify manually. Leave no partial state behind.
+- Record that the skill has run. A subsequent invocation in the same repository should detect the prior configuration and offer a re-probe instead of re-writing.
+
+## What not to do
+
+- Do not launch a real Claude Code session as part of the probe. The synthetic OTLP probe is sufficient and deterministic.
+- Do not capture or log prompt content, tool parameters, or any session transcript during probing.
+- Do not write an endpoint other than `http://localhost:*` into `.claude/settings.json` without a second explicit confirmation.
+- Do not overwrite an existing `.envrc` or existing `.claude/settings.json` keys the skill did not add.
+- Do not claim success if any probe layer fails, even if the earlier layers passed.
+- Do not imply that data is being captured if the launch context the user actually uses to start Claude Code is not the one the probe validated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.11.0 - 2026-04-19
+
+### Added
+
+- `aiw-telemetry-setup` skill in both `.agents/skills/` and `.claude/skills/` — guided, mostly-automated process for enabling Claude Code session telemetry in any repository and verifying end-to-end that tagged data reaches the local telemetry store before reporting success. The skill automates pre-flight detection (collector reachability, direnv presence, launch context, existing configuration) and the round-trip probe (collector reachability, shell-env propagation, synthetic OTLP log carrying a fresh UUID matched back in Loki), presents a single consolidated change set for user approval, and never enables telemetry as a default side effect. Motivated by a silent non-emission failure observed during acceptance testing of #101 on 2026-04-19, where an IDE-launched Claude Code session in this repo emitted nothing because `.envrc` did not propagate through the VS Code launch path ([#124]).
+
+### Changed
+
+- `project-context.md` Project Structure section lists `aiw-telemetry-setup` in the enumerated skill set; `Version:` header bumped to `1.4.0` ([#124]).
+
 ## 2.10.0 - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 ### Changed
 
 - `project-context.md` Project Structure section lists `aiw-telemetry-setup` in the enumerated skill set; `Version:` header bumped to `1.4.0` ([#124]).
+- `.ai-policy/scripts/update-session-tags.sh` self-scopes to the `ai-coding-workflow` upstream repository. When the current `env.OTEL_RESOURCE_ATTRIBUTES` does not declare `workflow_repo=ai-coding-workflow`, both `--check` and write modes exit 0 without reading, writing, or drift-checking. Downstream repositories that copy `.ai-policy/` wholesale per the install instructions no longer have their skill-written repo-distinguishing tag strings overwritten or commits blocked by the session-tags hook. Covered by three new cases in `.ai-policy/scripts/test-session-tags-hook.sh` ([#124]).
 
 ## 2.10.0 - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Run validation:
 ./.ai-policy/scripts/run-validation.sh
 ```
 
+### Optional: enable session telemetry (Claude Code only)
+
+To start recording Claude Code session data from the target repository into the local stack shipped in this repo, invoke the `aiw-telemetry-setup` skill from a Claude Code session in the target repo, for example:
+
+> "use the aiw-telemetry-setup skill to start recording telemetry here"
+
+The skill auto-detects the environment (collector reachability, `direnv` presence, terminal vs IDE launch context, existing configuration), proposes one consolidated set of file changes, and — after a single confirmation — writes the configuration and verifies round-trip by sending a synthetic OTLP record carrying a fresh UUID and re-querying it from Loki. It reports PASS or FAIL with the specific phase that failed and leaves no partial state on failure. It never enables telemetry as a default side effect. The local stack itself lives in this repo's `telemetry/` — see [Session Telemetry](#session-telemetry-claude-code) below.
+
 ## Session Telemetry (Claude Code)
 
 Every Claude Code session started in this repository emits OTEL events tagged with the current workflow version and an 8-character ruleset hash. The tag fragment lives in `.claude/settings.json`'s `env.OTEL_RESOURCE_ATTRIBUTES` block and is kept in sync with the rule files by `.ai-policy/scripts/update-session-tags.sh`. A pre-commit check blocks commits when the fragment drifts.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.10.0
+Version: 2.11.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.3.0
+Version: 1.4.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -62,7 +62,7 @@ Version: 1.3.0
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
 - `project-context-design-decisions.md`: maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-context-management`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
## Summary

- Adds `aiw-telemetry-setup` skill (in both `.agents/skills/` and `.claude/skills/`) that guides enabling Claude Code session telemetry in any repository. Performs layered pre-flight detection, presents a single consolidated change proposal, and runs a synthetic-UUID OTLP round-trip probe to confirm tagged data reaches the local stack before reporting success. Motivated by the silent non-emission failure mode observed during #101 acceptance testing, where an IDE-launched Claude Code session emitted nothing because `.envrc` did not propagate through the VS Code launch path.
- Self-scopes `.ai-policy/scripts/update-session-tags.sh` to the `ai-coding-workflow` upstream repository. Both `--check` and write modes exit 0 when the existing `env.OTEL_RESOURCE_ATTRIBUTES` is non-empty and does not declare `workflow_repo=ai-coding-workflow`. Downstream repositories that copy `.ai-policy/` wholesale per the install instructions no longer have their skill-written repo-distinguishing tag strings overwritten or pre-commit blocked by the session-tags hook.

Closes #124.

## Test plan

- [x] `./.ai-policy/scripts/test-session-tags-hook.sh` — 13/13 pass (10 existing upstream cases plus 3 new downstream-skip cases: hook exits 0 on downstream tag string, write mode preserves existing tag, write mode returns 0).
- [x] `./.ai-policy/scripts/project-validation.sh` — full suite green after the changes, including all seven enforcement integration tests.
- [x] Skill dogfooded end-to-end in a second repository: direnv-based propagation configured, synthetic UUID round-tripped through Loki with `service_name=claude-code,repo=<downstream>,workflow_version=2.11.0`. All three probe layers reported SUCCESS.
- [x] Downstream commit unblock verified: a commit previously rejected by the session-tags hook completes after copying the updated `update-session-tags.sh`; `.claude/settings.json`'s skill-written tag string is preserved intact.
- [x] Reviewer confirms the `CHANGELOG.md` 2.11.0 entry accurately reflects both the skill addition and the session-tags scoping change.
- [x] Reviewer decides whether the 2.11.0 minor bump should land as a tagged release per `ai-workflow-design-decisions/context-budget-and-maintenance.md`.