### PR TITLE
feat: aiw-performance-profiling skill + non-functional test coverage rule

### DIFF
--- a/.agents/skills/aiw-performance-profiling/SKILL.md
+++ b/.agents/skills/aiw-performance-profiling/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: aiw-performance-profiling
+description: "Automated performance and UI-state-transition coverage rules. Use this skill when implementing changes to user interfaces, reactive state, heavy data loops, caching logic, or any code path where runtime speed affects usability. The skill exists to prevent the pattern where functional tests pass while real-world execution becomes sluggish or stutters."
+---
+
+# Performance Profiling and Latency Coverage
+
+Read this file when the change touches runtime paths where speed or responsiveness matters.
+This file contains rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when writing performance tests:
+
+- **Non-Functional Test Coverage** — defines when automated coverage must be attempted before manual verification.
+- **aiw-testing** — general test construction rules. This skill covers the performance-specific subset.
+- **aiw-logging-and-observability** — covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
+
+## When This Skill Applies
+
+Load this skill when the change does any of the following:
+
+- Touches a UI state transition, reactive subscription, or view-layer rerender path.
+- Introduces or modifies caching, memoisation, debouncing, or throttling.
+- Introduces or modifies manual state resets or session invalidation.
+- Adds or modifies a data-processing loop over non-trivial input.
+- Adds a UI decorator or wrapper that affects render frequency.
+- Converts a synchronous path to asynchronous or vice versa.
+
+If any of these apply and no automated performance coverage exists for the affected path, add coverage as part of the change.
+
+## Rules
+
+1. Capture a baseline measurement before writing the test.
+   Run the existing code path on a representative input and record the measured time.
+   Anchor the regression test to that number.
+
+2. Write the latency assertion against the baseline plus a stated tolerance.
+   State the tolerance inline in the test.
+   Do not pick a round-number threshold unrelated to the baseline.
+
+3. Run the benchmark multiple times and assert on a stable statistic.
+   Prefer median or 95th percentile over a single sample.
+   Single-sample assertions produce flaky tests.
+
+4. Isolate the measurement from unrelated work.
+   Do not include setup, teardown, or unrelated I/O in the timed section.
+
+5. For UI state transitions, assert on the transition outcome and on the input-to-rendered-state time.
+   Assert the final state equals the expected state.
+   Assert the transition completed within the latency bound.
+
+6. For heavy data loops, assert on total wall-clock time and on per-iteration time when iteration count varies.
+   Do not assert only on total time when input size is not fixed.
+
+7. When a caching workaround or manual state reset is added, write a test that proves the workaround does not reintroduce the problem it is patching.
+   A passing functional test is not sufficient proof.
+
+8. If automated performance coverage is not feasible, state the reason in writing and propose a manual check with explicit success and failure signals.
+   Do not silently fall back to manual verification.
+
+9. Do not weaken a failing performance threshold before investigating the cause.
+   (Why: Lowering the bar to make a test pass hides the regression the test was written to catch.)
+
+10. Keep only benchmarks that run in the regular test suite.
+    Remove one-off benchmark scripts before completion.
+
+## What Not to Do
+
+- Do not claim performance coverage based on a functional test that happens to pass quickly.
+- Do not assert on absolute numbers that depend on the host machine without documenting the host assumption.
+- Do not write a performance test that requires production data or credentials.

--- a/.agents/skills/aiw-testing/SKILL.md
+++ b/.agents/skills/aiw-testing/SKILL.md
@@ -14,6 +14,22 @@ This skill works alongside these workflow sections — consult them when writing
 
 - **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
 - **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+- **Non-Functional Test Coverage** — covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
+- **aiw-performance-profiling** — detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+
+## Non-Functional Coverage
+
+Before suggesting manual verification for any change, attempt automated coverage of the following categories when they apply to the change:
+
+- UI state transitions and reactive rerender paths.
+- Execution latency and throughput on the affected code path.
+- Security-relevant behaviour: authorisation checks, input validation, escaping, secret handling, and data-access boundaries.
+
+If the change affects UI state, reactive subscriptions, caching, heavy loops, or manual state resets, load the `aiw-performance-profiling` skill and follow its rules.
+
+For security-relevant changes, write tests that exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
+
+If automated coverage is not feasible for a category, state the reason in writing in the plan or summary, and propose a manual check with explicit success and failure signals. Do not silently fall back to manual verification.
 
 ## Test Construction Rules
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.11.0,workflow_repo=ai-coding-workflow,ruleset_hash=a3a0365f"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.12.0,workflow_repo=ai-coding-workflow,ruleset_hash=53773ef8"
   }
 }

--- a/.claude/skills/aiw-performance-profiling/SKILL.md
+++ b/.claude/skills/aiw-performance-profiling/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: aiw-performance-profiling
+description: "Automated performance and UI-state-transition coverage rules. Use this skill when implementing changes to user interfaces, reactive state, heavy data loops, caching logic, or any code path where runtime speed affects usability. The skill exists to prevent the pattern where functional tests pass while real-world execution becomes sluggish or stutters."
+---
+
+# Performance Profiling and Latency Coverage
+
+Read this file when the change touches runtime paths where speed or responsiveness matters.
+This file contains rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections — consult them when writing performance tests:
+
+- **Non-Functional Test Coverage** — defines when automated coverage must be attempted before manual verification.
+- **aiw-testing** — general test construction rules. This skill covers the performance-specific subset.
+- **aiw-logging-and-observability** — covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
+
+## When This Skill Applies
+
+Load this skill when the change does any of the following:
+
+- Touches a UI state transition, reactive subscription, or view-layer rerender path.
+- Introduces or modifies caching, memoisation, debouncing, or throttling.
+- Introduces or modifies manual state resets or session invalidation.
+- Adds or modifies a data-processing loop over non-trivial input.
+- Adds a UI decorator or wrapper that affects render frequency.
+- Converts a synchronous path to asynchronous or vice versa.
+
+If any of these apply and no automated performance coverage exists for the affected path, add coverage as part of the change.
+
+## Rules
+
+1. Capture a baseline measurement before writing the test.
+   Run the existing code path on a representative input and record the measured time.
+   Anchor the regression test to that number.
+
+2. Write the latency assertion against the baseline plus a stated tolerance.
+   State the tolerance inline in the test.
+   Do not pick a round-number threshold unrelated to the baseline.
+
+3. Run the benchmark multiple times and assert on a stable statistic.
+   Prefer median or 95th percentile over a single sample.
+   Single-sample assertions produce flaky tests.
+
+4. Isolate the measurement from unrelated work.
+   Do not include setup, teardown, or unrelated I/O in the timed section.
+
+5. For UI state transitions, assert on the transition outcome and on the input-to-rendered-state time.
+   Assert the final state equals the expected state.
+   Assert the transition completed within the latency bound.
+
+6. For heavy data loops, assert on total wall-clock time and on per-iteration time when iteration count varies.
+   Do not assert only on total time when input size is not fixed.
+
+7. When a caching workaround or manual state reset is added, write a test that proves the workaround does not reintroduce the problem it is patching.
+   A passing functional test is not sufficient proof.
+
+8. If automated performance coverage is not feasible, state the reason in writing and propose a manual check with explicit success and failure signals.
+   Do not silently fall back to manual verification.
+
+9. Do not weaken a failing performance threshold before investigating the cause.
+   (Why: Lowering the bar to make a test pass hides the regression the test was written to catch.)
+
+10. Keep only benchmarks that run in the regular test suite.
+    Remove one-off benchmark scripts before completion.
+
+## What Not to Do
+
+- Do not claim performance coverage based on a functional test that happens to pass quickly.
+- Do not assert on absolute numbers that depend on the host machine without documenting the host assumption.
+- Do not write a performance test that requires production data or credentials.

--- a/.claude/skills/aiw-testing/SKILL.md
+++ b/.claude/skills/aiw-testing/SKILL.md
@@ -14,6 +14,22 @@ This skill works alongside these workflow sections — consult them when writing
 
 - **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
 - **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+- **Non-Functional Test Coverage** — covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
+- **aiw-performance-profiling** — detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+
+## Non-Functional Coverage
+
+Before suggesting manual verification for any change, attempt automated coverage of the following categories when they apply to the change:
+
+- UI state transitions and reactive rerender paths.
+- Execution latency and throughput on the affected code path.
+- Security-relevant behaviour: authorisation checks, input validation, escaping, secret handling, and data-access boundaries.
+
+If the change affects UI state, reactive subscriptions, caching, heavy loops, or manual state resets, load the `aiw-performance-profiling` skill and follow its rules.
+
+For security-relevant changes, write tests that exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
+
+If automated coverage is not feasible for a category, state the reason in writing in the plan or summary, and propose a manual check with explicit success and failure signals. Do not silently fall back to manual verification.
 
 ## Test Construction Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.12.0 - 2026-04-19
+
+### Added
+
+- `aiw-performance-profiling` skill in both `.agents/skills/` and `.claude/skills/` — automated performance and UI-state-transition coverage rules. Lists the trigger conditions (UI state transitions, reactive rerenders, caching, memoisation, debouncing, manual state resets, heavy data loops, sync/async path swaps) and prescribes baseline capture, tolerance-anchored latency assertions, multi-run stable-statistic benchmarks, isolated timed sections, UI transition outcome plus latency assertions, caching-workaround regression tests, a feasibility-fallback rule that forbids silent reversion to manual, and a rule against weakening failing thresholds without investigation ([#127]).
+- `Non-Functional Test Coverage` reference section in `ai-workflow.md` — requires the agent to attempt automated coverage for UI state transitions, execution latency, and security-relevant behaviour before suggesting manual verification, and to state in writing when automation is not feasible. Motivated by Entry 21 in `observed-ai-failings.md`, where the agent passed functional tests while shipping severe UI stuttering and latency regressions in FCP Auto-Editor ([#127]).
+- `Performance and UI-State Profiling` loader section in `ai-workflow.md` — names the conditions under which `aiw-performance-profiling` must be loaded ([#127]).
+
+### Changed
+
+- `Manual Verification Requirements` in `ai-workflow.md` tightened — manual checks must cite the non-functional coverage section before being proposed, and the "automated tests can verify" exclusion is rephrased to target behaviour rather than checks ([#127]).
+- Step 7 in `ai-workflow.md` now points at `Non-Functional Test Coverage` and restricts manual checks to what automation cannot cover ([#127]).
+- `aiw-testing` skill in both skill directories gained a `Non-Functional Coverage` subsection covering the three categories, a pointer to `aiw-performance-profiling`, a security negative-path rule, and the feasibility-fallback rule ([#127]).
+- `lite-monolithic/ai-workflow.md` mirrors the Non-Functional Test Coverage rules inline and carries `Version: 2.12.0`; the file had drifted from canonical since `2.8.0` and this change realigns it only for the non-functional coverage rule set, not for changes introduced between `2.9.0` and `2.11.0` ([#127]).
+- `project-context.md` Project Structure section lists `aiw-performance-profiling`; `Version:` header bumped to `1.5.0` ([#127]).
+
 ## 2.11.0 - 2026-04-19
 
 ### Added

--- a/ai-workflow-design-decisions/line-by-line-rationale.md
+++ b/ai-workflow-design-decisions/line-by-line-rationale.md
@@ -142,9 +142,13 @@ Rationale: Validation after every code change catches regressions immediately. D
 
 ### Workflow Step 7: Support manual verification
 
-> "Suggest manual checks for the human."
+> "Attempt automated coverage for non-functional categories before suggesting manual checks."
 
-Rationale: Automated tests cannot cover every user-facing path. The agent should identify what manual checks are needed and make them easy for the human.
+Rationale: Prevents the workflow's most common blindspot, where the agent passes functional tests while UI responsiveness, latency, or security behaviour degrades silently (Entry 21 in `observed-ai-failings.md`). Forces the automation attempt up front rather than letting manual verification become the default coverage path.
+
+> "Suggest manual checks only for what automation cannot cover."
+
+Rationale: Keeps manual verification expensive and scarce. Once the agent has attempted automated coverage, anything left over belongs to the human; anything the agent could have automated should not be offloaded.
 
 ---
 
@@ -490,19 +494,59 @@ Rationale: Defers detailed test-writing guidance to a skill that loads on demand
 
 ---
 
+### Performance and UI-State Profiling
+
+> "Use when the change touches UI state transitions, reactive rerender paths, caching, memoisation, debouncing, manual state resets, or heavy data-processing loops."
+
+Rationale: Defines the primary activation condition from the trigger patterns in Entry 21 of `observed-ai-failings.md`. These are the code shapes where functional tests mask real-world performance regressions.
+
+> "Use when the change introduces a caching workaround or manual state reset to patch a symptom."
+
+Rationale: A workaround added to fix an observed problem is itself a signal that the underlying path is fragile. Without a regression test anchored to the workaround, the next refactor silently reintroduces the problem.
+
+> "Load the `aiw-performance-profiling` skill."
+
+Rationale: Extracts the detailed performance and UI-state-transition test construction rules to an on-demand skill. Keeps the core workflow lean while making baseline capture, tolerance assertions, and feasibility-fallback discipline available when the triggers fire.
+
+---
+
+### Non-Functional Test Coverage
+
+> "Attempt automated coverage for the following categories before suggesting manual verification:"
+
+Rationale: Inverts the previous default where manual verification absorbed any coverage the agent did not bother to automate. The categories list (UI state transitions, latency, security-relevant behaviour) names the specific blindspots that passed functional tests cannot close.
+
+> "A passing functional test is not proof of performance, responsiveness, or security."
+
+Rationale: Names the false-confidence mode directly. Entry 21 showed the agent treating functional-test success as total coverage while the app was becoming unusable. Without this line, the agent can satisfy the workflow's validation checks without ever exercising the non-functional dimensions.
+
+> "If automated coverage is not feasible for a category, state the reason in writing in the plan or summary before falling back to a manual check."
+
+Rationale: Makes the fallback to manual explicit rather than silent. Requires the agent to name the constraint (toolchain limits, environment access, time cost) so the human can contest the claim or accept the gap. Prevents manual verification from becoming a convenience default.
+
+> "Do not treat manual verification as the default coverage path for non-functional behaviour."
+
+Rationale: The rule that closes the loop. Even with the "attempt automation first" directive, the agent can comply literally while still treating manual as the expected home for non-functional checks. This line removes that escape.
+
+---
+
 ### Manual Verification Requirements
 
 > "Manual verification covers what only a human can verify."
 
 Rationale: Scopes the section to human-only checks, preventing the agent from suggesting automated verifications here.
 
+> "Before suggesting a manual check, attempt automated coverage per [Non-Functional Test Coverage](#non-functional-test-coverage)."
+
+Rationale: Acts as a point-of-use pointer rather than a duplicate rule. The canonical rule lives in Non-Functional Test Coverage; placing a pointer here catches the agent at the moment it would otherwise skip ahead to manual-check suggestions.
+
 > "Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses."
 
 Rationale: Concrete examples prevent the agent from suggesting vague "test the feature" checks. Each category represents something the agent cannot observe.
 
-> "Do not suggest checks that can be verified through automated tests or tool output."
+> "Do not suggest a manual check for behaviour that automated tests or tool output can verify."
 
-Rationale: Manual verification is expensive. Wasting the human's time on checks the agent could automate undermines the workflow's efficiency.
+Rationale: Manual verification is expensive. Wasting the human's time on behaviour the agent could automate undermines the workflow's efficiency. Worded to target behaviour rather than "checks" so the agent cannot reframe an automatable behaviour as a non-automatable "check."
 
 > "State the success signal for each check."
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.11.0
+Version: 2.12.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -62,7 +62,9 @@ After the human merges the pull request, run post-merge cleanup and return to St
 
 7. **Step 7: Support manual verification.**
 
-   - Suggest manual checks for the human.
+   - Attempt automated coverage for non-functional categories before suggesting manual checks.
+   - See [Non-Functional Test Coverage](#non-functional-test-coverage).
+   - Suggest manual checks only for what automation cannot cover.
    - See [Manual Verification Requirements](#manual-verification-requirements).
 
 8. **Checkpoint 8: human reviews validation results and manual verification.**
@@ -203,12 +205,32 @@ Use when the task is specifically about creating tests.
 
 Load the `aiw-testing` skill.
 
+## Performance and UI-State Profiling
+
+Use when the change touches UI state transitions, reactive rerender paths, caching, memoisation, debouncing, manual state resets, or heavy data-processing loops.
+Use when the change introduces a caching workaround or manual state reset to patch a symptom.
+
+Load the `aiw-performance-profiling` skill.
+
+## Non-Functional Test Coverage
+
+Attempt automated coverage for the following categories before suggesting manual verification:
+
+- UI state transitions and reactive rerender paths.
+- Execution latency and throughput on the affected code path.
+- Security-relevant behaviour: authorisation checks, input validation, escaping, secret handling, and data-access boundaries.
+
+A passing functional test is not proof of performance, responsiveness, or security.
+If automated coverage is not feasible for a category, state the reason in writing in the plan or summary before falling back to a manual check.
+Do not treat manual verification as the default coverage path for non-functional behaviour.
+
 ## Manual Verification Requirements
 
 Manual verification covers what only a human can verify.
 
+- Before suggesting a manual check, attempt automated coverage per [Non-Functional Test Coverage](#non-functional-test-coverage).
 - Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses.
-- Do not suggest checks that can be verified through automated tests or tool output.
+- Do not suggest a manual check for behaviour that automated tests or tool output can verify.
 - State the success signal for each check.
 - State the failure signal for each check.
 

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.8.0
+Version: 2.12.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -53,7 +53,9 @@ The human reviews and approves at defined checkpoints.
 
 7. **Step 7: Support manual verification.**
 
-   - Suggest manual checks for the human.
+   - Attempt automated coverage for non-functional categories before suggesting manual checks.
+   - See [Non-Functional Test Coverage](#non-functional-test-coverage).
+   - Suggest manual checks only for what automation cannot cover.
    - See [Manual Verification Requirements](#manual-verification-requirements).
 
 8. **Checkpoint 8: human reviews validation results and manual verification.**
@@ -179,12 +181,36 @@ When reporting validation:
 - Report what was not tested and why.
 - Do not claim code is tested when it is not or ignore failing tests and continue as if the task is complete.
 
+## Non-Functional Test Coverage
+
+Attempt automated coverage for the following categories before suggesting manual verification:
+
+- UI state transitions and reactive rerender paths.
+- Execution latency and throughput on the affected code path.
+- Security-relevant behaviour: authorisation checks, input validation, escaping, secret handling, and data-access boundaries.
+
+A passing functional test is not proof of performance, responsiveness, or security.
+If automated coverage is not feasible for a category, state the reason in writing in the plan or summary before falling back to a manual check.
+Do not treat manual verification as the default coverage path for non-functional behaviour.
+
+When a change touches UI state transitions, reactive rerenders, caching, memoisation, debouncing, manual state resets, or heavy data loops:
+
+- Capture a baseline measurement before writing the test.
+- Write latency assertions against the baseline plus a stated tolerance.
+- Run benchmarks multiple times and assert on a stable statistic, not a single sample.
+- Isolate the timed section from setup, teardown, and unrelated I/O.
+- For UI state transitions, assert on both the transition outcome and the input-to-rendered-state time.
+- When a caching workaround or manual state reset is added, write a test that proves it does not reintroduce the problem it is patching.
+- Do not weaken a failing performance threshold before investigating the cause.
+- Do not claim performance coverage based on a functional test that happens to pass quickly.
+
 ## Manual Verification Requirements
 
 Manual verification covers what only a human can verify.
 
+- Before suggesting a manual check, attempt automated coverage per [Non-Functional Test Coverage](#non-functional-test-coverage).
 - Suggest checks that require human observation: visual behaviour, user experience flows, real-device interaction, external system responses.
-- Do not suggest checks that can be verified through automated tests or tool output.
+- Do not suggest a manual check for behaviour that automated tests or tool output can verify.
 - State the success signal for each check.
 - State the failure signal for each check.
 

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.4.0
+Version: 1.5.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -21,7 +21,7 @@ Version: 1.4.0
 - Provides a calendar-driven periodic review process (`workflow-review.md`) executed outside the per-task workflow; analyses accumulated telemetry and baseline results and produces classified workflow improvement proposals (hook, skill, rule, step, multi).
 - Provides a local policy enforcement layer (`.ai-policy/`) with scripts that enforce protected-branch and validation-state rules.
 - Provides git hooks (`.githooks/pre-commit`, `.githooks/pre-push`) that block commits and pushes when policy checks fail.
-- Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, and project context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
+- Provides agent skills for code-aware planning, failure analysis, issue creation, test construction, performance profiling, and project context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code). Both directories contain the same skills.
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), and Codex (`AGENTS.md`).
 - Records observed AI agent failure patterns (`observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
@@ -62,7 +62,7 @@ Version: 1.4.0
 - `ai-workflow-design-decisions/`: maintenance rules and rationale for editing `ai-workflow.md`, split into topic-scoped files.
 - `project-context-design-decisions.md`: maintenance rules for keeping `project-context.md` factual and concise.
 - `observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-performance-profiling`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
## Summary

- Adds `aiw-performance-profiling` skill in both `.agents/skills/` and `.claude/skills/` with triggers (UI state transitions, caching, manual resets, heavy loops, sync/async swaps) and rules for baseline capture, tolerance-anchored latency assertions, multi-run stable-statistic benchmarks, UI transition outcome + latency assertions, caching-workaround regression tests, and feasibility-fallback.
- Adds `Non-Functional Test Coverage` reference section and `Performance and UI-State Profiling` loader in `ai-workflow.md`; tightens `Manual Verification Requirements` so automation must be attempted before manual checks are suggested.
- Updates `aiw-testing` skill (both dirs) with the non-functional coverage categories, a security negative-path rule, and a cross-reference to `aiw-performance-profiling`.
- Mirrors rules into `lite-monolithic/ai-workflow.md`; bumps canonical version to `2.12.0` with matching CHANGELOG entry; updates `project-context.md` skill inventory to `1.5.0`; adds line-by-line rationale for all new workflow lines; refreshes OTEL session tags.

Addresses Entry 21 in `observed-ai-failings.md` — agent passed functional tests while shipping UI stuttering and latency regressions in FCP Auto-Editor.

Closes #127.

## Test plan

- [x] `./.ai-policy/scripts/project-validation.sh` passes (17 / 18 / 22 / 23 / 5 / 13 / 7 across all seven enforcement suites — same counts as pre-change baseline).
- [x] `./.ai-policy/scripts/update-session-tags.sh --check` returns 0 after workflow edits.
- [ ] Manual review of the new reference section, new skill, and updated `aiw-testing` skill for wording, trigger completeness, and alignment with `writing-rules.md` and `rule-placement.md`.
- [ ] Sanity check: would these rules have caught the FCP Auto-Editor regression earlier?