### PR TITLE
chore: make policy-layer validation portable across repos (#131)

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -1,54 +1,33 @@
 #!/usr/bin/env bash
+# Portable policy-layer validation.
+# Runs in any repo that has installed this policy layer.
+# Validates only the policy layer itself: shell-script syntax plus enforcement tests
+# that match the agent entry points actually installed in this repo.
+# If ./scripts/repo-validation.sh exists and is executable, runs it afterwards for repo-specific checks.
 set -eu
 
-bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/* ./telemetry/*.sh ./scripts/run-baseline.sh
+bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
 
-# Python syntax check on harness, scripts, tasks, and spikes.
-if command -v python3 >/dev/null 2>&1; then
-  PY_TARGETS=""
-  for d in ./evals/harness ./evals/tasks ./evals/spikes ./scripts; do
-    [ -d "$d" ] || continue
-    while IFS= read -r f; do PY_TARGETS="$PY_TARGETS $f"; done < <(find "$d" -name '*.py' -type f)
-  done
-  if [ -n "$PY_TARGETS" ]; then
-    # shellcheck disable=SC2086
-    python3 -m py_compile $PY_TARGETS
-  fi
-fi
-
-# YAML syntax check on telemetry configs (skipped if python3 or pyyaml missing).
-if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
-  for yaml_file in \
-    ./telemetry/docker-compose.yml \
-    ./telemetry/otel-collector-config.yaml \
-    ./telemetry/prometheus/prometheus.yml \
-    ./telemetry/loki/loki-config.yaml \
-    ./telemetry/grafana/provisioning/datasources/datasources.yml \
-    ./telemetry/grafana/provisioning/dashboards/dashboards.yml; do
-    python3 -c "import yaml,sys; yaml.safe_load(open('$yaml_file'))" || { echo "YAML syntax error in $yaml_file" >&2; exit 1; }
-  done
-fi
-
-# JSON syntax check on Grafana dashboards.
-for dash in ./telemetry/grafana/dashboards/*.json; do
-  python3 -c "import json; json.load(open('$dash'))" 2>/dev/null || {
-    if command -v jq >/dev/null 2>&1; then
-      jq empty "$dash" || { echo "JSON syntax error in $dash" >&2; exit 1; }
-    else
-      echo "Cannot validate $dash (no python3 or jq)" >&2
-    fi
-  }
+for t in ./.ai-policy/scripts/test-*.sh; do
+  [ -x "$t" ] || continue
+  base="$(basename "$t" .sh)"
+  case "$base" in
+    test-claude-code-enforcement|test-session-tags-hook)
+      [ -d ./.claude ] || { echo "Skipping $base (no ./.claude/ — Claude Code not installed)"; continue; }
+      ;;
+    test-codex-enforcement)
+      [ -d ./.codex ] || { echo "Skipping $base (no ./.codex/ — Codex not installed)"; continue; }
+      ;;
+    test-gemini-enforcement)
+      [ -d ./.gemini ] || { echo "Skipping $base (no ./.gemini/ — Gemini CLI not installed)"; continue; }
+      ;;
+    test-vscode-copilot-enforcement)
+      [ -d ./.github/hooks ] || { echo "Skipping $base (no ./.github/hooks/ — VS Code Copilot not installed)"; continue; }
+      ;;
+  esac
+  "$t"
 done
 
-# Optional: docker compose config dry-run when docker is available.
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-  (cd ./telemetry && docker compose config -q) || { echo "docker compose config failed" >&2; exit 1; }
+if [ -x ./scripts/repo-validation.sh ]; then
+  ./scripts/repo-validation.sh
 fi
-
-./.ai-policy/scripts/test-claude-code-enforcement.sh
-./.ai-policy/scripts/test-codex-enforcement.sh
-./.ai-policy/scripts/test-vscode-copilot-enforcement.sh
-./.ai-policy/scripts/test-gemini-enforcement.sh
-./.ai-policy/scripts/test-changelog-hook.sh
-./.ai-policy/scripts/test-session-tags-hook.sh
-./.ai-policy/scripts/test-pre-push-hook.sh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.12.0,workflow_repo=ai-coding-workflow,ruleset_hash=53773ef8"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.13.0,workflow_repo=ai-coding-workflow,ruleset_hash=36b3f156"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.13.0 - 2026-04-19
+
+### Changed
+
+- `.ai-policy/scripts/project-validation.sh` is now portable across repos. It validates only the policy layer itself (`bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`) and then runs each `test-*.sh` under `.ai-policy/scripts/` whose matching agent entry point is installed: `test-claude-code-enforcement.sh` and `test-session-tags-hook.sh` require `./.claude/`, `test-codex-enforcement.sh` requires `./.codex/`, `test-gemini-enforcement.sh` requires `./.gemini/`, `test-vscode-copilot-enforcement.sh` requires `./.github/hooks/`; `test-changelog-hook.sh` and `test-pre-push-hook.sh` always run. If `./scripts/repo-validation.sh` exists and is executable, it runs at the end. Fresh target-repo installs following the README no longer fail validation on missing paths, and per-tool installs (Claude-Code-only, Codex-only, etc.) are now supported out of the box without editing any shipped file ([#131]).
+
+### Added
+
+- `scripts/repo-validation.sh` at the repo root carries this repo's repo-specific checks (telemetry YAML/JSON syntax, baseline-harness Python `py_compile`, `bash -n` on `telemetry/*.sh` and `scripts/run-baseline.sh`, `docker compose config -q`). The file is not part of the shipped policy layer; target repos supply their own `scripts/repo-validation.sh` to declare their tests, linters, or type checks. The shipped `project-validation.sh` invokes it automatically when present ([#131]).
+- README `Post-install setup` now documents `scripts/repo-validation.sh` as the per-repo extension point and describes the agent-gated skipping behaviour of the enforcement tests ([#131]).
+
 ## 2.12.0 - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Run validation:
 ./.ai-policy/scripts/run-validation.sh
 ```
 
+The shipped validator (`./.ai-policy/scripts/project-validation.sh`) checks only the policy layer itself: shell-script syntax in `.ai-policy/` and `.githooks/`, plus the enforcement tests that match the agent entry points installed in your repo (tests for agents you did not install are skipped).
+
+To add repo-specific checks (tests, linters, type checks, etc.) that run as part of the same validation, create an executable `./scripts/repo-validation.sh` at the root of your repo. The shipped validator invokes it automatically when present. The file is not part of the shipped policy layer, so each repo owns its own.
+
 ### Optional: enable session telemetry (Claude Code only)
 
 To start recording Claude Code session data from the target repository into the local stack shipped in this repo, invoke the `aiw-telemetry-setup` skill from a Claude Code session in the target repo, for example:

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.12.0
+Version: 2.13.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.12.0
+Version: 2.13.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.5.0
+Version: 1.6.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -50,7 +50,7 @@ Version: 1.5.0
 - `git`: hooks integrate with the git commit and push lifecycle via `core.hooksPath .githooks`.
 - `jq`: hook scripts and one enforcement test parse JSON with `jq`.
 - `docker` (optional): required only for the local telemetry stack in `telemetry/`. Not needed to use the workflow itself.
-- `python3` + `pyyaml` (optional): used by `project-validation.sh` to syntax-check telemetry YAML/JSON if present; validation skips the check when absent.
+- `python3` + `pyyaml` (optional): used by `scripts/repo-validation.sh` to syntax-check telemetry YAML/JSON if present; the check skips when absent.
 - `python3` (required for the baseline harness): `scripts/run-baseline.sh` creates `evals/.venv` and installs `pytest` and `scipy`. Not needed to use the workflow itself.
 - `docker` (required for the baseline harness's `claude-code` agent): launches the Claude Code CLI in an isolated sandbox. The `mock` agent does not need Docker.
 
@@ -69,7 +69,7 @@ Version: 1.5.0
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
-- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, testing enforcement, and keeping Claude Code session tags in sync via `update-session-tags.sh`.
+- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, testing enforcement, and keeping Claude Code session tags in sync via `update-session-tags.sh`. `project-validation.sh` is the portable policy-layer check: shell-script syntax plus enforcement tests gated on the agent entry points installed in the repo; it invokes `scripts/repo-validation.sh` afterwards when present.
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`. Includes `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry) and `check-session-tags.sh` (pre-commit, rejects drift between `.claude/settings.json`'s `env.OTEL_RESOURCE_ATTRIBUTES` and the current ruleset).
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
@@ -91,13 +91,14 @@ Version: 1.5.0
 - `evals/harness/`: Python baseline harness — runner, JSON writer, workflow-version / ruleset-hash reader, pytest grader, `mock` and `claude-code` agents, plus `Dockerfile` + `compose.yaml` for the sandbox used by the `claude-code` agent.
 - `evals/tasks/<task_id>/`: frozen baseline tasks. Each has `spec.md` (prompt + acceptance criteria), `starter/` (code the agent sees), `grader/` (hidden pytest applied after the agent completes), and `solution/` (reference solution used only by the `mock` agent).
 - `evals/requirements.txt`: Python dependencies for the harness (`pytest`, `scipy`).
+- `scripts/repo-validation.sh`: this repo's repo-specific validation (telemetry YAML/JSON syntax, baseline-harness Python `py_compile`, `bash -n` on `telemetry/*.sh` and `scripts/run-baseline.sh`, `docker compose config -q`). Not part of the shipped policy layer; target repos supply their own.
 - `scripts/run-baseline.sh`: creates `evals/.venv`, runs `N` tasks × `k` repeats, writes results under `telemetry/data/baseline/<version>/<ruleset_hash>/<task>/<run>.json`.
 - `scripts/compare-versions.py`: reads two versions' results and prints per-task pass^k, aggregate pass^k, McNemar's test on paired outcomes, and mean/median deltas on duration, cost, tokens, and fix cycles.
 
 ## Testing Overview
-- Validation runs `bash -n` syntax checks on all shell scripts in `.ai-policy/scripts/`, `.ai-policy/hooks/`, `.githooks/`, and `telemetry/*.sh`.
-- Validation runs YAML syntax checks on telemetry configs when `python3` + `pyyaml` are present, JSON syntax checks on Grafana dashboards, and `docker compose config -q` in `telemetry/` when Docker is installed.
-- Validation also runs seven enforcement integration tests: `test-claude-code-enforcement.sh`, `test-codex-enforcement.sh`, `test-vscode-copilot-enforcement.sh`, `test-gemini-enforcement.sh`, `test-changelog-hook.sh`, `test-session-tags-hook.sh`, and `test-pre-push-hook.sh`.
+- Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` and `test-session-tags-hook.sh` require `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh` and `test-pre-push-hook.sh` always run.
+- Repo-specific validation for this repo lives in `scripts/repo-validation.sh` and is invoked by the policy-layer validator when present: `bash -n` on `telemetry/*.sh` and `scripts/run-baseline.sh`, Python `py_compile` on `evals/` + `scripts/`, YAML syntax checks on telemetry configs when `python3` + `pyyaml` are present, JSON syntax checks on Grafana dashboards, and `docker compose config -q` in `telemetry/` when Docker is installed.
 - No unit test framework exists; there are no automated tests for documentation content or Grafana dashboard correctness.
 - Manual verification is the primary check for documentation changes and telemetry dashboard behaviour.
 

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Repo-specific validation for ai-coding-workflow.
+# Invoked by ./.ai-policy/scripts/project-validation.sh when this file exists and is executable.
+# Target repos should supply their own scripts/repo-validation.sh (tests, linters, etc.).
+set -eu
+
+bash -n ./telemetry/*.sh ./scripts/run-baseline.sh
+
+if command -v python3 >/dev/null 2>&1; then
+  PY_TARGETS=""
+  for d in ./evals/harness ./evals/tasks ./evals/spikes ./scripts; do
+    [ -d "$d" ] || continue
+    while IFS= read -r f; do PY_TARGETS="$PY_TARGETS $f"; done < <(find "$d" -name '*.py' -type f)
+  done
+  if [ -n "$PY_TARGETS" ]; then
+    # shellcheck disable=SC2086
+    python3 -m py_compile $PY_TARGETS
+  fi
+fi
+
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+  for yaml_file in \
+    ./telemetry/docker-compose.yml \
+    ./telemetry/otel-collector-config.yaml \
+    ./telemetry/prometheus/prometheus.yml \
+    ./telemetry/loki/loki-config.yaml \
+    ./telemetry/grafana/provisioning/datasources/datasources.yml \
+    ./telemetry/grafana/provisioning/dashboards/dashboards.yml; do
+    python3 -c "import yaml,sys; yaml.safe_load(open('$yaml_file'))" || { echo "YAML syntax error in $yaml_file" >&2; exit 1; }
+  done
+fi
+
+for dash in ./telemetry/grafana/dashboards/*.json; do
+  python3 -c "import json; json.load(open('$dash'))" 2>/dev/null || {
+    if command -v jq >/dev/null 2>&1; then
+      jq empty "$dash" || { echo "JSON syntax error in $dash" >&2; exit 1; }
+    else
+      echo "Cannot validate $dash (no python3 or jq)" >&2
+    fi
+  }
+done
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  (cd ./telemetry && docker compose config -q) || { echo "docker compose config failed" >&2; exit 1; }
+fi


### PR DESCRIPTION
## Summary

- Rewrite `.ai-policy/scripts/project-validation.sh` as portable: `bash -n` on `.ai-policy/` + `.githooks/`, then run each `test-*.sh` whose matching agent entry point is installed (`.claude/`, `.codex/`, `.gemini/`, `.github/hooks/`), then invoke `./scripts/repo-validation.sh` if present. Fresh target-repo installs that follow the README no longer fail on missing paths, and per-tool installs (Claude-Code-only, Codex-only, etc.) work out of the box without editing any shipped file.
- Move this repo's specific checks (telemetry YAML/JSON, evals/scripts `py_compile`, `bash -n` on `telemetry/*.sh` + `scripts/run-baseline.sh`, `docker compose config -q`) into new `scripts/repo-validation.sh`. Target repos supply their own.
- Bump `ai-workflow.md` 2.12.0 → 2.13.0, `project-context.md` 1.5.0 → 1.6.0, `lite-monolithic/ai-workflow.md` 2.12.0 → 2.13.0. CHANGELOG entry added. Session-tag fragment refreshed.

Closes #131.

## Test plan

- [x] `./.ai-policy/scripts/run-validation.sh` on this branch: passes with same coverage as baseline (105 enforcement sub-tests + repo-validation).
- [x] Scratch-repo simulation — Claude-Code-only install: passes, correctly skips the 3 non-Claude agent tests.
- [x] Scratch-repo simulation — Codex-only install: passes, correctly skips the 3 non-Codex agent tests + session-tags.
- [x] Scratch-repo simulation — VS Code Copilot-only install: passes, correctly skips 4 non-Copilot agent tests + session-tags.
- [ ] Downstream verification: drop updated `.ai-policy/` into the Streamlit repo that surfaced this and confirm its pre-commit hook unblocks.

## Follow-up (not in this PR)

- Consider moving the gating from `project-validation.sh` into each enforcement test (`exit 0` on precondition miss) so the validator can drop back to a plain glob loop. Cosmetic cohesion improvement.
- `test-claude-code-enforcement.sh` calls `git rev-parse HEAD` somewhere, which errors in a truly empty `git init` with no commits. Pre-existing; realistic target repos always have commits.