### PR TITLE
feat: strengthen failure-analysis trigger reliability (#98)

### DIFF
--- a/.agents/skills/aiw-failure-analysis/SKILL.md
+++ b/.agents/skills/aiw-failure-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-failure-analysis
-description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
+description: "Structured investigation for when the user reports something is broken or not working, especially after tests passed or a fix was applied. Trigger phrases include 'still broken', 'still doesn't work', 'still fails', 'didn't help', 'didn't work', 'the bug remains', 'not working', 'doing the wrong thing'. Other triggers: tests pass but the user reports the feature is broken; a fix did not resolve the behaviour; a user report contradicts validation output; runtime behaviour contradicts the implementation or plan; manual verification fails. Load on any of these conditions before proposing a fix. The skill forces a structured pause to acknowledge the gap between agent expectations and user reality, then investigate before changing more code."
 ---
 
 # Failure Analysis Mode

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,6 @@
     ]
   },
   "env": {
-    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.13.0,workflow_repo=ai-coding-workflow,ruleset_hash=36b3f156"
+    "OTEL_RESOURCE_ATTRIBUTES": "workflow_version=2.14.0,workflow_repo=ai-coding-workflow,ruleset_hash=5318a168"
   }
 }

--- a/.claude/skills/aiw-failure-analysis/SKILL.md
+++ b/.claude/skills/aiw-failure-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-failure-analysis
-description: "Structured investigation process for when the user reports that something is broken or not working, especially after the agent believed implementation was complete. Use this skill when the user's observed behaviour contradicts what the agent expected — tests passed but the feature doesn't work, a fix didn't help, or the app is visibly broken despite validation succeeding. The skill exists to prevent the agent from jumping to quick fixes and instead force a structured pause: acknowledge the gap between the agent's perspective and the user's reality, then investigate before changing more code."
+description: "Structured investigation for when the user reports something is broken or not working, especially after tests passed or a fix was applied. Trigger phrases include 'still broken', 'still doesn't work', 'still fails', 'didn't help', 'didn't work', 'the bug remains', 'not working', 'doing the wrong thing'. Other triggers: tests pass but the user reports the feature is broken; a fix did not resolve the behaviour; a user report contradicts validation output; runtime behaviour contradicts the implementation or plan; manual verification fails. Load on any of these conditions before proposing a fix. The skill forces a structured pause to acknowledge the gap between agent expectations and user reality, then investigate before changing more code."
 ---
 
 # Failure Analysis Mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.14.0 - 2026-04-20
+
+### Changed
+
+- `ai-workflow.md` Step 9 header reframed from "fix and revalidate" to "check [Failure Analysis Mode] before proposing a fix" so the trigger check runs ahead of the fix; the bullet count drops from four to three ([#98]).
+- `ai-workflow.md` Failure Analysis Mode section rewritten to name the dominant trigger inline (user says behaviour is still broken, a fix didn't help, or what they see contradicts what validation reported), retain the manual-verification and runtime-contradiction triggers, and add an explicit "if uncertain, enter" line; total length held to five short sentences ([#98]).
+- `aiw-failure-analysis` skill in both `.agents/skills/` and `.claude/skills/` updated: the frontmatter description now names concrete user phrases ("still broken", "still doesn't work", "didn't help", "the bug remains", "not working", "doing the wrong thing") to raise Claude Code auto-surface salience, and the em-dash construction is removed. The skill body is unchanged; triggers live once, in the description, and the body describes the process after entry ([#98]).
+- `lite-monolithic/ai-workflow.md` mirrors the Step 9 reframe and the leaner Failure Analysis Mode wording inline; `Version:` header bumped to `2.14.0` ([#98]).
+
 ## 2.13.0 - 2026-04-19
 
 ### Changed

--- a/ai-workflow-design-decisions.md
+++ b/ai-workflow-design-decisions.md
@@ -8,7 +8,8 @@ The design decisions for `ai-workflow.md` have been split into topic-scoped file
 - [audience-and-file-structure.md](ai-workflow-design-decisions/audience-and-file-structure.md) — Who `ai-workflow.md` is written for and the purpose of each section type.
 - [writing-rules.md](ai-workflow-design-decisions/writing-rules.md) — How to write lines: sentence structure, style, tone, and formatting.
 - [rule-placement.md](ai-workflow-design-decisions/rule-placement.md) — Where rules belong: canonical location, section boundaries, and structural discipline.
-- [context-budget-and-maintenance.md](ai-workflow-design-decisions/context-budget-and-maintenance.md) — How much to include, versioning, file splitting, session logs, and the reusable maintenance prompt.
+- [context-budget.md](ai-workflow-design-decisions/context-budget.md) — How much to include in `ai-workflow.md` before compliance degrades.
+- [maintenance.md](ai-workflow-design-decisions/maintenance.md) — Versioning, file splitting, session logs, and the reusable maintenance prompt.
 - [review-taxonomy.md](ai-workflow-design-decisions/review-taxonomy.md) — Classification system for identifying structural problems during review.
 - [line-by-line-rationale.md](ai-workflow-design-decisions/line-by-line-rationale.md) — Rationale and source for every line in `ai-workflow.md`.
 - [policy-and-hooks.md](ai-workflow-design-decisions/policy-and-hooks.md) — Design decisions for the `.ai-policy/` enforcement layer and `.githooks/`.

--- a/ai-workflow-design-decisions/context-budget.md
+++ b/ai-workflow-design-decisions/context-budget.md
@@ -1,0 +1,11 @@
+# Context Budget — AI Workflow Design Decisions
+
+**Context budget.**
+Every line in the file consumes context window tokens that compete with the actual task.
+Research suggests frontier models reliably follow roughly 150-200 instructions, with degradation uniform across all rules as the count increases.
+The agent tool's own system prompt already consumes some of this budget before the workflow file loads.
+This means every low-value line added dilutes the compliance probability of every high-value line.
+Before adding a rule, ask: could the agent figure this out by reading the codebase?
+If yes, do not add it.
+If a boundary is bright-line and machine-checkable, prefer deterministic repo-local enforcement over repeated workflow wording.
+Prefer fewer, higher-quality rules over comprehensive coverage.

--- a/ai-workflow-design-decisions/maintenance.md
+++ b/ai-workflow-design-decisions/maintenance.md
@@ -1,18 +1,6 @@
-# Context Budget and Maintenance Operations — AI Workflow Design Decisions
+# Maintenance Operations — AI Workflow Design Decisions
 
 Covers how much to include in `ai-workflow.md`, versioning, file splitting, session logs, and the reusable maintenance prompt.
-
-## Context Budget
-
-**Context budget.**
-Every line in the file consumes context window tokens that compete with the actual task.
-Research suggests frontier models reliably follow roughly 150-200 instructions, with degradation uniform across all rules as the count increases.
-The agent tool's own system prompt already consumes some of this budget before the workflow file loads.
-This means every low-value line added dilutes the compliance probability of every high-value line.
-Before adding a rule, ask: could the agent figure this out by reading the codebase?
-If yes, do not add it.
-If a boundary is bright-line and machine-checkable, prefer deterministic repo-local enforcement over repeated workflow wording.
-Prefer fewer, higher-quality rules over comprehensive coverage.
 
 ## Version Number
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.13.0
+Version: 2.14.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -69,12 +69,11 @@ After the human merges the pull request, run post-merge cleanup and return to St
 
 8. **Checkpoint 8: human reviews validation results and manual verification.**
 
-9. **Step 9: If the human reports issues, fix and revalidate.**
+9. **Step 9: If the human reports issues, check [Failure Analysis Mode](#failure-analysis-mode) before proposing a fix.**
 
-   - Fix reported issues.
-   - Rerun relevant validation checks after each fix.
+   - If any failure-analysis trigger matches, enter failure analysis mode first.
+   - Otherwise fix the reported issue and rerun relevant validation checks after each fix.
    - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
-   - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
 10. **Step 10: Summarise.**
 
@@ -236,7 +235,9 @@ Manual verification covers what only a human can verify.
 
 ## Failure Analysis Mode
 
-Enter failure analysis mode when manual verification fails, runtime behaviour contradicts the implementation, or test results conflict with observed behaviour.
+Enter failure analysis mode when the user says the behaviour is still broken, a fix didn't help, or what they see contradicts what validation reported.
+Enter failure analysis mode when manual verification fails or runtime behaviour contradicts the implementation.
+If uncertain whether to enter, enter.
 Do not make further code changes until failure analysis is complete.
 
 Load the `aiw-failure-analysis` skill.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.13.0
+Version: 2.14.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -60,12 +60,11 @@ The human reviews and approves at defined checkpoints.
 
 8. **Checkpoint 8: human reviews validation results and manual verification.**
 
-9. **Step 9: If the human reports issues, fix and revalidate.**
+9. **Step 9: If the human reports issues, check [Failure Analysis Mode](#failure-analysis-mode) before proposing a fix.**
 
-   - Fix reported issues.
-   - Rerun relevant validation checks after each fix.
+   - If any failure-analysis trigger matches, enter failure analysis mode first.
+   - Otherwise fix the reported issue and rerun relevant validation checks after each fix.
    - Return to Step 5 if further implementation is needed, or Step 6 if only validation is needed.
-   - If a fix fails or manual verification fails, enter [Failure Analysis Mode](#failure-analysis-mode).
 
 10. **Step 10: Summarise.**
 
@@ -216,9 +215,9 @@ Manual verification covers what only a human can verify.
 
 ## Failure Analysis Mode
 
-Enter failure analysis mode when manual verification fails.
-Enter failure analysis mode when runtime behaviour contradicts the implementation.
-Enter failure analysis mode when test results conflict with observed behaviour.
+Enter failure analysis mode when the user says the behaviour is still broken, a fix didn't help, or what they see contradicts what validation reported.
+Enter failure analysis mode when manual verification fails or runtime behaviour contradicts the implementation.
+If uncertain whether to enter, enter.
 Stop implementation and do not make further code changes until failure analysis is complete.
 
 When in failure analysis mode:

--- a/project-context.md
+++ b/project-context.md
@@ -106,4 +106,4 @@ Version: 1.6.0
 - Update this file when the project structure, key files, or policy rules change.
 - Keep this file aligned with the current codebase, not planned architecture.
 - Keep this file concise and under 300 lines.
-- When a user-facing file changes, bump the version in `ai-workflow.md` following the guidance in `ai-workflow-design-decisions/context-budget-and-maintenance.md`.
+- When a user-facing file changes, bump the version in `ai-workflow.md` following the guidance in `ai-workflow-design-decisions/maintenance.md`.


### PR DESCRIPTION
## Summary
- Reframe Step 9 and tighten the Failure Analysis Mode wording so the trigger check runs before any fix attempt, with concrete user-phrase triggers ("still broken", "fix didn't help", observation contradicts validation) surfaced inline.
- Update the aiw-failure-analysis skill frontmatter description with the same phrase set to raise Claude Code auto-surface salience; skill body unchanged.
- Fold in an unrelated design-doc split: ai-workflow-design-decisions/context-budget-and-maintenance.md becomes context-budget.md + maintenance.md; index and project-context.md pointer updated.

Version bumped to 2.14.0 (minor) with matching CHANGELOG entry. Policy validation: 105/105 tests pass.

Closes #98.

## Test plan
- [x] Review Step 9 rewording in ai-workflow.md for tone and imperative voice.
- [x] Confirm Failure Analysis Mode section length does not visually dominate adjacent sections.
- [x] Confirm aiw-failure-analysis skill description lists the intended trigger phrases without duplicating them in the body.
- [x] Confirm .claude/skills/ and .agents/skills/ copies are byte-identical.
- [x] Confirm lite-monolithic/ai-workflow.md mirrors the new wording and carries Version 2.14.0.
- [x] Confirm the design-doc split has no remaining references to the old filename.