### PR TITLE
chore: remove em-dashes from skill files (#130)

### DIFF
--- a/.agents/skills/aiw-failure-analysis/SKILL.md
+++ b/.agents/skills/aiw-failure-analysis/SKILL.md
@@ -10,14 +10,14 @@ This file contains the full process for investigating and resolving contradictio
 
 ## Why This Mode Exists
 
-When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix — but if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix. But if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them during investigation:
+This skill works alongside these workflow sections. Consult them during investigation:
 
-- **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
+- **Validation Requirements**: understand what validation should have caught; compare post-change results against the baseline.
+- **Logging and Observability**: load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.agents/skills/aiw-logging-and-observability/SKILL.md
+++ b/.agents/skills/aiw-logging-and-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-logging-and-observability
-description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
+description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly. It covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
 ---
 
 # Logging and Observability

--- a/.agents/skills/aiw-performance-profiling/SKILL.md
+++ b/.agents/skills/aiw-performance-profiling/SKILL.md
@@ -10,11 +10,11 @@ This file contains rules for writing automated performance and UI-state-transiti
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when writing performance tests:
+This skill works alongside these workflow sections. Consult them when writing performance tests:
 
-- **Non-Functional Test Coverage** — defines when automated coverage must be attempted before manual verification.
-- **aiw-testing** — general test construction rules. This skill covers the performance-specific subset.
-- **aiw-logging-and-observability** — covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
+- **Non-Functional Test Coverage**: defines when automated coverage must be attempted before manual verification.
+- **aiw-testing**: general test construction rules. This skill covers the performance-specific subset.
+- **aiw-logging-and-observability**: covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
 
 ## When This Skill Applies
 

--- a/.agents/skills/aiw-planning/SKILL.md
+++ b/.agents/skills/aiw-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-planning
-description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
+description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach: identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 
 # Code-Aware Planning
@@ -10,10 +10,10 @@ This file contains the full requirements for a valid plan and for handling human
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when building the plan:
+This skill works alongside these workflow sections. Consult them when building the plan:
 
-- **Scope Control** — plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
-- **Validation Requirements** — plans must account for how the change will be validated, including baseline comparison.
+- **Scope Control**: plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
+- **Validation Requirements**: plans must account for how the change will be validated, including baseline comparison.
 
 ## What the Plan Must Contain
 

--- a/.agents/skills/aiw-project-context-management/SKILL.md
+++ b/.agents/skills/aiw-project-context-management/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: aiw-project-context-management
-description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context — including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale' — and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
+description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context, including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale', and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 
 # Project Context Management
 
 Read this file before creating or editing `project-context.md`.
-`project-context.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
+`project-context.md` is a repository's factual reference of current implementation truth; agents consult it to orient quickly before planning changes.
 
 ## Required Sections
 
 Use these sections, in order; omit one only when the repository has no reliable information for it.
 
-- `## Product Summary` — what the product is, who uses it, the core user flow.
-- `## Domain Concepts` — the main entities and their relationships.
-- `## Scope` — what the product currently supports, major workflows, known non-goals.
-- `## Important Constraints` — hard product, technical, policy, data, or environment constraints.
-- `## Architecture Summary` — architecture style, runtime layers, primary data flow, external boundaries.
-- `## Key Dependencies` — each dependency and why it exists.
-- `## Project Structure` — each significant path or module and what it owns.
-- `## Testing Overview` — test framework, coverage, major gaps.
-- `## Maintenance Checklist` — when the context file must be updated.
+- `## Product Summary`: what the product is, who uses it, the core user flow.
+- `## Domain Concepts`: the main entities and their relationships.
+- `## Scope`: what the product currently supports, major workflows, known non-goals.
+- `## Important Constraints`: hard product, technical, policy, data, or environment constraints.
+- `## Architecture Summary`: architecture style, runtime layers, primary data flow, external boundaries.
+- `## Key Dependencies`: each dependency and why it exists.
+- `## Project Structure`: each significant path or module and what it owns.
+- `## Testing Overview`: test framework, coverage, major gaps.
+- `## Maintenance Checklist`: when the context file must be updated.
 
 ## Base Rules
 
@@ -37,14 +37,14 @@ Use these sections, in order; omit one only when the repository has no reliable 
 
 ## Scanning the Codebase
 
-Do a systematic pass before writing — fill each section from the scan, not from issues, prior context files, or human descriptions.
+Do a systematic pass before writing. Fill each section from the scan, not from issues, prior context files, or human descriptions.
 
-1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. → Product Summary, Key Dependencies.
-2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. → Scope, Architecture Summary.
-3. **Data.** Find schema, migration, and model files; note recurring nouns in module names. → Domain Concepts.
-4. **Constraints.** Find environment-variable validation, feature flags, CI policy scripts, git hooks, and any product-visible enforced limits. → Important Constraints.
-5. **Structure.** Walk the directory tree; for each top-level path, record what it owns in one bullet. → Project Structure.
-6. **Tests.** Locate the test runner(s), read the canonical test command in CI config (`.github/workflows/`, `.circleci/`, `.gitlab-ci.yml`), note uncovered areas. → Testing Overview.
+1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. Feeds Product Summary and Key Dependencies.
+2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. Feeds Scope and Architecture Summary.
+3. **Data.** Find schema, migration, and model files; note recurring nouns in module names. Feeds Domain Concepts.
+4. **Constraints.** Find environment-variable validation, feature flags, CI policy scripts, git hooks, and any product-visible enforced limits. Feeds Important Constraints.
+5. **Structure.** Walk the directory tree; for each top-level path, record what it owns in one bullet. Feeds Project Structure.
+6. **Tests.** Locate the test runner(s), read the canonical test command in CI config (`.github/workflows/`, `.circleci/`, `.gitlab-ci.yml`), note uncovered areas. Feeds Testing Overview.
 
 For large codebases, skim at the directory level first and only open files that are surfaced by the scan; do not try to read every file.
 
@@ -63,7 +63,7 @@ For large codebases, skim at the directory level first and only open files that 
 
 - Planned features, future refactors, open questions, issue or PR references.
 - Multi-sentence bullets or prose paragraphs.
-- Workflow or process documentation — the context file records implementation facts, not how the team works.
+- Workflow or process documentation. The context file records implementation facts, not how the team works.
 
 ## Before Handing Off
 

--- a/.agents/skills/aiw-telemetry-setup/SKILL.md
+++ b/.agents/skills/aiw-telemetry-setup/SKILL.md
@@ -6,7 +6,7 @@ description: "Guided, mostly-automated process for enabling Claude Code session 
 # Telemetry Setup
 
 Read this file when the user wants to start recording Claude Code session telemetry in a repository.
-The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository — the current one or any other — to emit into that stack.
+The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository (the current one or any other) to emit into that stack.
 
 This skill is the single user-facing action required to enable telemetry in a target repository. After running it, copied-in upstream files must not carry foreign identity, every signal the shipped Grafana dashboards consume must be emitted, and every enabled signal must have its round-trip verified end to end.
 
@@ -19,26 +19,26 @@ This skill is the single user-facing action required to enable telemetry in a ta
 - On any failure, leave the repository in the state it was in before the skill ran.
 - Report SUCCESS or FAIL with the specific phase that failed and the next thing for the user to check.
 
-## Phase 1 — Pre-flight detection (automated, read-only)
+## Phase 1: Pre-flight detection (automated, read-only)
 
 Run all of these before asking the user anything. Collect findings and present them together.
 
-- Resolve the target repository root. Report it, along with the directory's basename — this basename is the expected `workflow_repo` tag value.
+- Resolve the target repository root. Report it, along with the directory's basename. This basename is the expected `workflow_repo` tag value.
 - Detect collector reachability by probing the local OTLP endpoints on the host running the user's shell. Do not probe remote endpoints. Probe both `4317` (gRPC) and `4318` (HTTP).
-- Detect whether the full local telemetry stack is up: Prometheus (`http://localhost:9090/-/ready`), Loki (`http://localhost:3100/ready`), and Grafana. If any is down, record which — the skill must not claim success for a signal whose backend is unreachable.
+- Detect whether the full local telemetry stack is up: Prometheus (`http://localhost:9090/-/ready`), Loki (`http://localhost:3100/ready`), and Grafana. If any is down, record which. The skill must not claim success for a signal whose backend is unreachable.
 - Detect whether `direnv` is installed and whether the target repository contains an existing `.envrc`.
 - Detect the launch context of the current Claude Code process and of the likely future launches: terminal vs IDE. Check standard IDE indicator variables, the process parent, and the binary path. State confidence.
 - Detect whether the target repository already has `.claude/settings.json` and whether it has an `env` block carrying `OTEL_RESOURCE_ATTRIBUTES`. Also read any existing `.envrc` for the same variable and the required exporter variables.
 - Check the existing configuration for every known failure mode before treating it as valid:
   - **Poisoned identity.** If `OTEL_RESOURCE_ATTRIBUTES` contains `workflow_repo=<name>` and `<name>` does not match the target directory basename, the configuration was inherited from a copy of another repo (typically `ai-coding-workflow`). Flag as MISCONFIGURED and plan to replace the tag string.
   - **Missing exporters.** If `CLAUDE_CODE_ENABLE_TELEMETRY=1` is set but either `OTEL_METRICS_EXPORTER=otlp` or `OTEL_LOGS_EXPORTER=otlp` is absent, flag as MISCONFIGURED. Both are required because the shipped Grafana dashboards read Prometheus metrics **and** Loki logs.
-  - **Missing metric temporality override.** If `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` is absent, flag as MISCONFIGURED. Claude Code's OTEL SDK defaults to delta temporality, but the shipped collector pipeline forwards to Prometheus via remote-write, which requires cumulative — without this override, logs reach Loki normally while metrics silently fail to appear in Prometheus.
+  - **Missing metric temporality override.** If `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` is absent, flag as MISCONFIGURED. Claude Code's OTEL SDK defaults to delta temporality, but the shipped collector pipeline forwards to Prometheus via remote-write, which requires cumulative. Without this override, logs reach Loki normally while metrics silently fail to appear in Prometheus.
   - **Protocol/endpoint mismatch.** If `OTEL_EXPORTER_OTLP_ENDPOINT` is set without a matching `OTEL_EXPORTER_OTLP_PROTOCOL`, or the protocol does not match the port (`grpc` with 4317, `http/protobuf` with 4318), flag as MISCONFIGURED.
   - **Stale tracked identity.** If `.claude/settings.json` carries an `env.OTEL_RESOURCE_ATTRIBUTES` value at all, this is a tracked file and propagates to anyone who clones the repo. Flag as MISCONFIGURED and plan to move identity to gitignored `.envrc`.
 - Only if none of those checks flag anything, treat the repository as "already configured" and offer a re-probe instead of proposing changes.
 - Do not launch Claude Code, do not send any network traffic other than the collector-reachability and stack-readiness probes, and do not write files during this phase.
 
-## Phase 2 — Propose a single change set
+## Phase 2: Propose a single change set
 
 Based on Phase 1, decide the propagation mechanism:
 
@@ -49,10 +49,10 @@ Based on Phase 1, decide the propagation mechanism:
 Define the full change set:
 
 - `CLAUDE_CODE_ENABLE_TELEMETRY=1`
-- `OTEL_LOGS_EXPORTER=otlp` **and** `OTEL_METRICS_EXPORTER=otlp` — both always, regardless of which signal the user is focused on.
-- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` — always. The shipped Prometheus pipeline drops Claude Code's default delta-temporality counters silently.
+- `OTEL_LOGS_EXPORTER=otlp` **and** `OTEL_METRICS_EXPORTER=otlp`. Both always, regardless of which signal the user is focused on.
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`. Always. The shipped Prometheus pipeline drops Claude Code's default delta-temporality counters silently.
 - `OTEL_EXPORTER_OTLP_ENDPOINT` paired with an explicit `OTEL_EXPORTER_OTLP_PROTOCOL`. Default to `grpc` with `http://localhost:4317` when Phase 1 detected 4317 open. Fall back to `http/protobuf` with `http://localhost:4318` when only 4318 is open.
-- `OTEL_RESOURCE_ATTRIBUTES` with, at minimum, `workflow_repo=<target-directory-basename>`. If the target repo has its own `ai-workflow.md` with a `Version:` header, also include `workflow_version=<that version>`. Do not include `ruleset_hash` — that machinery belongs to the `ai-coding-workflow` repository itself.
+- `OTEL_RESOURCE_ATTRIBUTES` with, at minimum, `workflow_repo=<target-directory-basename>`. If the target repo has its own `ai-workflow.md` with a `Version:` header, also include `workflow_version=<that version>`. Do not include `ruleset_hash`. That machinery belongs to the `ai-coding-workflow` repository itself.
 
 Never propose a value that contains `workflow_repo=ai-coding-workflow` unless the target repository's directory basename is literally `ai-coding-workflow`.
 
@@ -66,7 +66,7 @@ Present the change set as a single summary:
 
 Ask the user to approve this summary once. Proceed only on explicit approval. On approval, proceed through Phases 3 and 4 without further prompts.
 
-## Phase 3 — Apply changes (after single confirmation)
+## Phase 3: Apply changes (after single confirmation)
 
 - Back up any file the skill modifies before writing. Restore the backup if any later step in this phase or Phase 4 fails.
 - When writing `.envrc`, read any existing file first and merge rather than overwrite. Never remove user-authored exports that the skill did not add. Delimit the skill-managed variables with a sentinel block (`# >>> aiw telemetry (managed, do not edit) >>>` and matching closing sentinel) so re-invocation can replace the block in place.
@@ -74,20 +74,20 @@ Ask the user to approve this summary once. Proceed only on explicit approval. On
 - Never modify `.claude/settings.json` to add telemetry identity or exporter values. If a prior version of this skill wrote such values there, remove them as part of the change set and record the removal in the summary.
 - After writing, if direnv is the chosen mechanism, instruct the user to run `direnv allow` and confirm the environment propagates. This is the only user action the skill requests after the confirmation gate.
 
-## Phase 4 — Probe (automated, reported layer by layer)
+## Phase 4: Probe (automated, reported layer by layer)
 
 Run the probe layers in order. Report each layer's result as it completes. Stop and report FAIL at the first failing layer.
 
-- **Layer 1 — Collector reachability.** Send an HTTP probe to the OTLP endpoint the configuration selected and require a success response.
-- **Layer 2 — Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that every configured variable is present with the expected value: `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_RESOURCE_ATTRIBUTES`. Missing or mismatched values fail the layer.
-- **Layer 3 — Logs round-trip via Loki.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes, including the target directory's `workflow_repo` value.
-- **Layer 4 — Metrics round-trip via Prometheus.** From the same propagation context, emit a synthetic OTLP counter (`aiw_telemetry_probe_total`) labelled with a freshly generated UUID and the target directory's `workflow_repo`. After a short wait (account for the collector's scrape and the Prometheus scrape interval), query Prometheus `/api/v1/query` for the counter filtered by the UUID label and confirm the returned series carries the expected `workflow_repo` label.
+- **Layer 1: Collector reachability.** Send an HTTP probe to the OTLP endpoint the configuration selected and require a success response.
+- **Layer 2: Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that every configured variable is present with the expected value: `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_RESOURCE_ATTRIBUTES`. Missing or mismatched values fail the layer.
+- **Layer 3: Logs round-trip via Loki.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes, including the target directory's `workflow_repo` value.
+- **Layer 4: Metrics round-trip via Prometheus.** From the same propagation context, emit a synthetic OTLP counter (`aiw_telemetry_probe_total`) labelled with a freshly generated UUID and the target directory's `workflow_repo`. After a short wait (account for the collector's scrape and the Prometheus scrape interval), query Prometheus `/api/v1/query` for the counter filtered by the UUID label and confirm the returned series carries the expected `workflow_repo` label.
 
 Each probe layer must use a fresh UUID so a stale matching record cannot produce a false positive. The probes must not emit any real session data.
 
 If Phase 1 found a backend unreachable (Prometheus or Loki), the corresponding layer must FAIL with a message naming the missing backend. The skill may not claim success by skipping a layer whose backend is down.
 
-## Phase 5 — Report
+## Phase 5: Report
 
 - On full success, report the repository root, the propagation mechanism chosen, the tag string in effect, and the exact Loki query **and** Prometheus query the user can re-run later to confirm tagged sessions are arriving.
 - On any failure, report the phase that failed, the specific check that failed, the observed output, and the next thing for the user to verify manually. Leave no partial state behind: if Phase 3 wrote files, restore from the pre-change backup before reporting.

--- a/.agents/skills/aiw-testing/SKILL.md
+++ b/.agents/skills/aiw-testing/SKILL.md
@@ -10,12 +10,12 @@ This file contains rules for test construction that serve the implementation fee
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when writing tests:
+This skill works alongside these workflow sections. Consult them when writing tests:
 
-- **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
-- **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
-- **Non-Functional Test Coverage** — covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
-- **aiw-performance-profiling** — detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+- **Validation Requirements**: covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
+- **Test Readiness**: covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+- **Non-Functional Test Coverage**: covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
+- **aiw-performance-profiling**: detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
 
 ## Non-Functional Coverage
 

--- a/.claude/skills/aiw-failure-analysis/SKILL.md
+++ b/.claude/skills/aiw-failure-analysis/SKILL.md
@@ -10,14 +10,14 @@ This file contains the full process for investigating and resolving contradictio
 
 ## Why This Mode Exists
 
-When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix — but if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
+When tests pass and validation succeeds, you believe the implementation is correct. If the user then reports that the feature is broken or the app doesn't work, there is a gap between your understanding and reality. Your natural response is to jump to the nearest quick fix. But if your understanding of the system was wrong enough for the tests to miss the problem, a quick fix is likely to be wrong too. This mode forces a structured pause: stop, describe the contradiction, list what could be wrong, and gather evidence before writing more code.
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them during investigation:
+This skill works alongside these workflow sections. Consult them during investigation:
 
-- **Validation Requirements** — understand what validation should have caught; compare post-change results against the baseline.
-- **Logging and Observability** — load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
+- **Validation Requirements**: understand what validation should have caught; compare post-change results against the baseline.
+- **Logging and Observability**: load the `aiw-logging-and-observability` skill when diagnostic approaches are needed during investigation.
 
 ## Process
 

--- a/.claude/skills/aiw-logging-and-observability/SKILL.md
+++ b/.claude/skills/aiw-logging-and-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-logging-and-observability
-description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly — it covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
+description: "Ensures the agent has enough runtime observability to validate its changes. Use this skill when automated tests alone cannot prove the change works correctly. It covers which changes need observability, how to add logging, and how to write diagnostics for runtime investigation."
 ---
 
 # Logging and Observability

--- a/.claude/skills/aiw-performance-profiling/SKILL.md
+++ b/.claude/skills/aiw-performance-profiling/SKILL.md
@@ -10,11 +10,11 @@ This file contains rules for writing automated performance and UI-state-transiti
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when writing performance tests:
+This skill works alongside these workflow sections. Consult them when writing performance tests:
 
-- **Non-Functional Test Coverage** — defines when automated coverage must be attempted before manual verification.
-- **aiw-testing** — general test construction rules. This skill covers the performance-specific subset.
-- **aiw-logging-and-observability** — covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
+- **Non-Functional Test Coverage**: defines when automated coverage must be attempted before manual verification.
+- **aiw-testing**: general test construction rules. This skill covers the performance-specific subset.
+- **aiw-logging-and-observability**: covers ad-hoc runtime diagnostics. This skill covers pre-commit automated tests.
 
 ## When This Skill Applies
 

--- a/.claude/skills/aiw-planning/SKILL.md
+++ b/.claude/skills/aiw-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiw-planning
-description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach — identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
+description: "Structured planning process for producing a code-aware implementation plan before writing code. Use this skill when the agent needs to plan an implementation approach: identifying what files to touch, what assumptions to verify, what risks exist, and how to validate the change. The skill exists to prevent the agent from jumping straight into coding without thinking through scope, assumptions, and consequences."
 ---
 
 # Code-Aware Planning
@@ -10,10 +10,10 @@ This file contains the full requirements for a valid plan and for handling human
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when building the plan:
+This skill works alongside these workflow sections. Consult them when building the plan:
 
-- **Scope Control** — plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
-- **Validation Requirements** — plans must account for how the change will be validated, including baseline comparison.
+- **Scope Control**: plans must respect scope boundaries; flag multi-area changes or unrelated objectives.
+- **Validation Requirements**: plans must account for how the change will be validated, including baseline comparison.
 
 ## What the Plan Must Contain
 

--- a/.claude/skills/aiw-project-context-management/SKILL.md
+++ b/.claude/skills/aiw-project-context-management/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: aiw-project-context-management
-description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context — including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale' — and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
+description: "Structured process for initializing and updating `project-context.md`, a repository's factual reference of current implementation truth. Use this skill when the human asks to create, scaffold, refresh, or correct the project context, including phrasings like 'update the context', 'the architecture summary is out of date', 'document the project structure', or 'the project-context.md is stale', and when the agent detects the existing context file has drifted from the codebase after changes to routes, schema, sync rules, dependencies, project structure, or test coverage. The skill exists to prevent context files from drifting into planned architecture, roadmap language, or multi-sentence lines that degrade agent parsing in future sessions."
 ---
 
 # Project Context Management
 
 Read this file before creating or editing `project-context.md`.
-`project-context.md` is a repository's factual reference of current implementation truth — agents consult it to orient quickly before planning changes.
+`project-context.md` is a repository's factual reference of current implementation truth; agents consult it to orient quickly before planning changes.
 
 ## Required Sections
 
 Use these sections, in order; omit one only when the repository has no reliable information for it.
 
-- `## Product Summary` — what the product is, who uses it, the core user flow.
-- `## Domain Concepts` — the main entities and their relationships.
-- `## Scope` — what the product currently supports, major workflows, known non-goals.
-- `## Important Constraints` — hard product, technical, policy, data, or environment constraints.
-- `## Architecture Summary` — architecture style, runtime layers, primary data flow, external boundaries.
-- `## Key Dependencies` — each dependency and why it exists.
-- `## Project Structure` — each significant path or module and what it owns.
-- `## Testing Overview` — test framework, coverage, major gaps.
-- `## Maintenance Checklist` — when the context file must be updated.
+- `## Product Summary`: what the product is, who uses it, the core user flow.
+- `## Domain Concepts`: the main entities and their relationships.
+- `## Scope`: what the product currently supports, major workflows, known non-goals.
+- `## Important Constraints`: hard product, technical, policy, data, or environment constraints.
+- `## Architecture Summary`: architecture style, runtime layers, primary data flow, external boundaries.
+- `## Key Dependencies`: each dependency and why it exists.
+- `## Project Structure`: each significant path or module and what it owns.
+- `## Testing Overview`: test framework, coverage, major gaps.
+- `## Maintenance Checklist`: when the context file must be updated.
 
 ## Base Rules
 
@@ -37,14 +37,14 @@ Use these sections, in order; omit one only when the repository has no reliable 
 
 ## Scanning the Codebase
 
-Do a systematic pass before writing — fill each section from the scan, not from issues, prior context files, or human descriptions.
+Do a systematic pass before writing. Fill each section from the scan, not from issues, prior context files, or human descriptions.
 
-1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. → Product Summary, Key Dependencies.
-2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. → Scope, Architecture Summary.
-3. **Data.** Find schema, migration, and model files; note recurring nouns in module names. → Domain Concepts.
-4. **Constraints.** Find environment-variable validation, feature flags, CI policy scripts, git hooks, and any product-visible enforced limits. → Important Constraints.
-5. **Structure.** Walk the directory tree; for each top-level path, record what it owns in one bullet. → Project Structure.
-6. **Tests.** Locate the test runner(s), read the canonical test command in CI config (`.github/workflows/`, `.circleci/`, `.gitlab-ci.yml`), note uncovered areas. → Testing Overview.
+1. **Root.** Read `README.md` and every build or package manifest (`package.json`, `pyproject.toml`, `go.mod`, or equivalent); record why each direct dependency exists. Feeds Product Summary and Key Dependencies.
+2. **Entry points.** Locate the runtime entry points (`main.*`, `index.*`, `cli.*`, framework route files); from each, trace the top-level wiring and list user-visible routes, commands, or public API. Ignore internal helpers. Feeds Scope and Architecture Summary.
+3. **Data.** Find schema, migration, and model files; note recurring nouns in module names. Feeds Domain Concepts.
+4. **Constraints.** Find environment-variable validation, feature flags, CI policy scripts, git hooks, and any product-visible enforced limits. Feeds Important Constraints.
+5. **Structure.** Walk the directory tree; for each top-level path, record what it owns in one bullet. Feeds Project Structure.
+6. **Tests.** Locate the test runner(s), read the canonical test command in CI config (`.github/workflows/`, `.circleci/`, `.gitlab-ci.yml`), note uncovered areas. Feeds Testing Overview.
 
 For large codebases, skim at the directory level first and only open files that are surfaced by the scan; do not try to read every file.
 
@@ -63,7 +63,7 @@ For large codebases, skim at the directory level first and only open files that 
 
 - Planned features, future refactors, open questions, issue or PR references.
 - Multi-sentence bullets or prose paragraphs.
-- Workflow or process documentation — the context file records implementation facts, not how the team works.
+- Workflow or process documentation. The context file records implementation facts, not how the team works.
 
 ## Before Handing Off
 

--- a/.claude/skills/aiw-telemetry-setup/SKILL.md
+++ b/.claude/skills/aiw-telemetry-setup/SKILL.md
@@ -6,7 +6,7 @@ description: "Guided, mostly-automated process for enabling Claude Code session 
 # Telemetry Setup
 
 Read this file when the user wants to start recording Claude Code session telemetry in a repository.
-The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository — the current one or any other — to emit into that stack.
+The telemetry stack itself lives in the `ai-coding-workflow` repository under `telemetry/`; this skill configures a repository (the current one or any other) to emit into that stack.
 
 This skill is the single user-facing action required to enable telemetry in a target repository. After running it, copied-in upstream files must not carry foreign identity, every signal the shipped Grafana dashboards consume must be emitted, and every enabled signal must have its round-trip verified end to end.
 
@@ -19,26 +19,26 @@ This skill is the single user-facing action required to enable telemetry in a ta
 - On any failure, leave the repository in the state it was in before the skill ran.
 - Report SUCCESS or FAIL with the specific phase that failed and the next thing for the user to check.
 
-## Phase 1 — Pre-flight detection (automated, read-only)
+## Phase 1: Pre-flight detection (automated, read-only)
 
 Run all of these before asking the user anything. Collect findings and present them together.
 
-- Resolve the target repository root. Report it, along with the directory's basename — this basename is the expected `workflow_repo` tag value.
+- Resolve the target repository root. Report it, along with the directory's basename. This basename is the expected `workflow_repo` tag value.
 - Detect collector reachability by probing the local OTLP endpoints on the host running the user's shell. Do not probe remote endpoints. Probe both `4317` (gRPC) and `4318` (HTTP).
-- Detect whether the full local telemetry stack is up: Prometheus (`http://localhost:9090/-/ready`), Loki (`http://localhost:3100/ready`), and Grafana. If any is down, record which — the skill must not claim success for a signal whose backend is unreachable.
+- Detect whether the full local telemetry stack is up: Prometheus (`http://localhost:9090/-/ready`), Loki (`http://localhost:3100/ready`), and Grafana. If any is down, record which. The skill must not claim success for a signal whose backend is unreachable.
 - Detect whether `direnv` is installed and whether the target repository contains an existing `.envrc`.
 - Detect the launch context of the current Claude Code process and of the likely future launches: terminal vs IDE. Check standard IDE indicator variables, the process parent, and the binary path. State confidence.
 - Detect whether the target repository already has `.claude/settings.json` and whether it has an `env` block carrying `OTEL_RESOURCE_ATTRIBUTES`. Also read any existing `.envrc` for the same variable and the required exporter variables.
 - Check the existing configuration for every known failure mode before treating it as valid:
   - **Poisoned identity.** If `OTEL_RESOURCE_ATTRIBUTES` contains `workflow_repo=<name>` and `<name>` does not match the target directory basename, the configuration was inherited from a copy of another repo (typically `ai-coding-workflow`). Flag as MISCONFIGURED and plan to replace the tag string.
   - **Missing exporters.** If `CLAUDE_CODE_ENABLE_TELEMETRY=1` is set but either `OTEL_METRICS_EXPORTER=otlp` or `OTEL_LOGS_EXPORTER=otlp` is absent, flag as MISCONFIGURED. Both are required because the shipped Grafana dashboards read Prometheus metrics **and** Loki logs.
-  - **Missing metric temporality override.** If `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` is absent, flag as MISCONFIGURED. Claude Code's OTEL SDK defaults to delta temporality, but the shipped collector pipeline forwards to Prometheus via remote-write, which requires cumulative — without this override, logs reach Loki normally while metrics silently fail to appear in Prometheus.
+  - **Missing metric temporality override.** If `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` is absent, flag as MISCONFIGURED. Claude Code's OTEL SDK defaults to delta temporality, but the shipped collector pipeline forwards to Prometheus via remote-write, which requires cumulative. Without this override, logs reach Loki normally while metrics silently fail to appear in Prometheus.
   - **Protocol/endpoint mismatch.** If `OTEL_EXPORTER_OTLP_ENDPOINT` is set without a matching `OTEL_EXPORTER_OTLP_PROTOCOL`, or the protocol does not match the port (`grpc` with 4317, `http/protobuf` with 4318), flag as MISCONFIGURED.
   - **Stale tracked identity.** If `.claude/settings.json` carries an `env.OTEL_RESOURCE_ATTRIBUTES` value at all, this is a tracked file and propagates to anyone who clones the repo. Flag as MISCONFIGURED and plan to move identity to gitignored `.envrc`.
 - Only if none of those checks flag anything, treat the repository as "already configured" and offer a re-probe instead of proposing changes.
 - Do not launch Claude Code, do not send any network traffic other than the collector-reachability and stack-readiness probes, and do not write files during this phase.
 
-## Phase 2 — Propose a single change set
+## Phase 2: Propose a single change set
 
 Based on Phase 1, decide the propagation mechanism:
 
@@ -49,10 +49,10 @@ Based on Phase 1, decide the propagation mechanism:
 Define the full change set:
 
 - `CLAUDE_CODE_ENABLE_TELEMETRY=1`
-- `OTEL_LOGS_EXPORTER=otlp` **and** `OTEL_METRICS_EXPORTER=otlp` — both always, regardless of which signal the user is focused on.
-- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` — always. The shipped Prometheus pipeline drops Claude Code's default delta-temporality counters silently.
+- `OTEL_LOGS_EXPORTER=otlp` **and** `OTEL_METRICS_EXPORTER=otlp`. Both always, regardless of which signal the user is focused on.
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`. Always. The shipped Prometheus pipeline drops Claude Code's default delta-temporality counters silently.
 - `OTEL_EXPORTER_OTLP_ENDPOINT` paired with an explicit `OTEL_EXPORTER_OTLP_PROTOCOL`. Default to `grpc` with `http://localhost:4317` when Phase 1 detected 4317 open. Fall back to `http/protobuf` with `http://localhost:4318` when only 4318 is open.
-- `OTEL_RESOURCE_ATTRIBUTES` with, at minimum, `workflow_repo=<target-directory-basename>`. If the target repo has its own `ai-workflow.md` with a `Version:` header, also include `workflow_version=<that version>`. Do not include `ruleset_hash` — that machinery belongs to the `ai-coding-workflow` repository itself.
+- `OTEL_RESOURCE_ATTRIBUTES` with, at minimum, `workflow_repo=<target-directory-basename>`. If the target repo has its own `ai-workflow.md` with a `Version:` header, also include `workflow_version=<that version>`. Do not include `ruleset_hash`. That machinery belongs to the `ai-coding-workflow` repository itself.
 
 Never propose a value that contains `workflow_repo=ai-coding-workflow` unless the target repository's directory basename is literally `ai-coding-workflow`.
 
@@ -66,7 +66,7 @@ Present the change set as a single summary:
 
 Ask the user to approve this summary once. Proceed only on explicit approval. On approval, proceed through Phases 3 and 4 without further prompts.
 
-## Phase 3 — Apply changes (after single confirmation)
+## Phase 3: Apply changes (after single confirmation)
 
 - Back up any file the skill modifies before writing. Restore the backup if any later step in this phase or Phase 4 fails.
 - When writing `.envrc`, read any existing file first and merge rather than overwrite. Never remove user-authored exports that the skill did not add. Delimit the skill-managed variables with a sentinel block (`# >>> aiw telemetry (managed, do not edit) >>>` and matching closing sentinel) so re-invocation can replace the block in place.
@@ -74,20 +74,20 @@ Ask the user to approve this summary once. Proceed only on explicit approval. On
 - Never modify `.claude/settings.json` to add telemetry identity or exporter values. If a prior version of this skill wrote such values there, remove them as part of the change set and record the removal in the summary.
 - After writing, if direnv is the chosen mechanism, instruct the user to run `direnv allow` and confirm the environment propagates. This is the only user action the skill requests after the confirmation gate.
 
-## Phase 4 — Probe (automated, reported layer by layer)
+## Phase 4: Probe (automated, reported layer by layer)
 
 Run the probe layers in order. Report each layer's result as it completes. Stop and report FAIL at the first failing layer.
 
-- **Layer 1 — Collector reachability.** Send an HTTP probe to the OTLP endpoint the configuration selected and require a success response.
-- **Layer 2 — Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that every configured variable is present with the expected value: `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_RESOURCE_ATTRIBUTES`. Missing or mismatched values fail the layer.
-- **Layer 3 — Logs round-trip via Loki.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes, including the target directory's `workflow_repo` value.
-- **Layer 4 — Metrics round-trip via Prometheus.** From the same propagation context, emit a synthetic OTLP counter (`aiw_telemetry_probe_total`) labelled with a freshly generated UUID and the target directory's `workflow_repo`. After a short wait (account for the collector's scrape and the Prometheus scrape interval), query Prometheus `/api/v1/query` for the counter filtered by the UUID label and confirm the returned series carries the expected `workflow_repo` label.
+- **Layer 1: Collector reachability.** Send an HTTP probe to the OTLP endpoint the configuration selected and require a success response.
+- **Layer 2: Shell environment propagation.** Start a child shell under the same context the user will launch Claude Code from, and verify that every configured variable is present with the expected value: `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_RESOURCE_ATTRIBUTES`. Missing or mismatched values fail the layer.
+- **Layer 3: Logs round-trip via Loki.** From the same propagation context, send a synthetic OTLP log record that carries a freshly generated UUID in its body. After a short wait, query Loki for that UUID and confirm the returned record carries the expected resource attributes, including the target directory's `workflow_repo` value.
+- **Layer 4: Metrics round-trip via Prometheus.** From the same propagation context, emit a synthetic OTLP counter (`aiw_telemetry_probe_total`) labelled with a freshly generated UUID and the target directory's `workflow_repo`. After a short wait (account for the collector's scrape and the Prometheus scrape interval), query Prometheus `/api/v1/query` for the counter filtered by the UUID label and confirm the returned series carries the expected `workflow_repo` label.
 
 Each probe layer must use a fresh UUID so a stale matching record cannot produce a false positive. The probes must not emit any real session data.
 
 If Phase 1 found a backend unreachable (Prometheus or Loki), the corresponding layer must FAIL with a message naming the missing backend. The skill may not claim success by skipping a layer whose backend is down.
 
-## Phase 5 — Report
+## Phase 5: Report
 
 - On full success, report the repository root, the propagation mechanism chosen, the tag string in effect, and the exact Loki query **and** Prometheus query the user can re-run later to confirm tagged sessions are arriving.
 - On any failure, report the phase that failed, the specific check that failed, the observed output, and the next thing for the user to verify manually. Leave no partial state behind: if Phase 3 wrote files, restore from the pre-change backup before reporting.

--- a/.claude/skills/aiw-testing/SKILL.md
+++ b/.claude/skills/aiw-testing/SKILL.md
@@ -10,12 +10,12 @@ This file contains rules for test construction that serve the implementation fee
 
 ## Related Workflow Sections
 
-This skill works alongside these workflow sections — consult them when writing tests:
+This skill works alongside these workflow sections. Consult them when writing tests:
 
-- **Validation Requirements** — covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
-- **Test Readiness** — covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
-- **Non-Functional Test Coverage** — covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
-- **aiw-performance-profiling** — detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+- **Validation Requirements**: covers when to run tests, baseline comparison, and result reporting. This skill covers how to write them.
+- **Test Readiness**: covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
+- **Non-Functional Test Coverage**: covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
+- **aiw-performance-profiling**: detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
 
 ## Non-Functional Coverage
 


### PR DESCRIPTION
## Summary

- Replace all em-dashes (`—`) in `.claude/skills/` and `.agents/skills/` with colons, periods, or rephrased sentences to comply with the "No em-dashes." rule in `design/decisions/authoring.md:24`.
- 47 instances per skill directory cleaned up across 7 files; the eighth skill (`aiw-issue-creation`) was already clean.
- No rule wording changed and no rules were weakened. Both skill directories remain byte-identical (`diff -r` confirms).

Closes #130.

## Replacement strategy

- `**Label** — explanation` (bullet lists) → `**Label**: explanation`.
- Phase / layer headings (`## Phase 1 — Pre-flight detection`) → colon (`## Phase 1: Pre-flight detection`).
- Mid-sentence parentheticals → split into two sentences with a period, or rephrased.
- Frontmatter `description:` em-dashes → colon or period; no trigger keywords removed.

## Note on issue text

The issue references `ai-workflow-design-decisions/writing-rules.md`, which does not exist at that path; the rule lives at `design/decisions/authoring.md:24` after the design/observation reorg in #134. The rule itself is unchanged and authoritative; the path in the issue is stale.

## Test plan

- [x] `grep -rn "—" .claude/skills/ .agents/skills/` returns zero matches.
- [x] `grep -rn "–" .claude/skills/ .agents/skills/` returns zero matches (no en-dash substitution slipped in).
- [x] `diff -r .claude/skills/ .agents/skills/` returns no differences.
- [x] `./.ai-policy/scripts/project-validation.sh` passes (50/50 + 7/7 + 22/22).
- [ ] Spot-read of `aiw-telemetry-setup` and `aiw-project-context-management` for prose readability.