### PR TITLE
feat: aiw-security-testing skill + security testing loader (#129)

### DIFF
--- a/.agents/skills/aiw-security-testing/SKILL.md
+++ b/.agents/skills/aiw-security-testing/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: aiw-security-testing
+description: "Automated security testing rules for changes that touch authentication, authorisation, untrusted input, file-path or shell-command construction, secret handling, external API consumers, or data-access boundaries. Use this skill whenever the change crosses a trust boundary or processes input that could be hostile, even if the surface looks routine. The skill exists to prevent the pattern where happy-path tests pass while negative paths, boundaries, and threat-model assumptions go unchecked."
+---
+
+# Security Testing
+
+Read this file when the change touches a trust boundary or handles input the system cannot trust.
+This file contains rules for writing automated security tests before deferring to manual review or assuming framework guarantees.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections. Consult them when writing security tests:
+
+- **Non-Functional Test Coverage**: defines when automated coverage must be attempted before manual verification.
+- **aiw-testing**: general test construction rules. This skill covers the security-specific subset.
+- **aiw-failure-analysis**: covers what to do when a reported behaviour contradicts what a security test claims.
+
+## When This Skill Applies
+
+Load this skill when the change does any of the following:
+
+- Adds, modifies, or removes an authentication or session check.
+- Adds, modifies, or removes an authorisation rule (role check, ownership check, scope check).
+- Reads, validates, parses, or transforms input from a user, the network, or an untrusted file.
+- Constructs a file path, shell command, SQL query, HTML fragment, or any other string that will later be interpreted by a parser or shell.
+- Reads, writes, transmits, or logs a secret: password, API key, token, signing key, or personally identifying data.
+- Calls an external API, including hidden retries, callbacks, and webhooks.
+- Crosses a data-access boundary between tenants, users, organisations, or environments.
+- Adds or modifies CORS, CSP, cookie flags, redirect handling, or any other browser-trust mechanism.
+
+If any of these apply and no automated security coverage exists for the affected behaviour, add coverage as part of the change.
+
+## Rules
+
+1. Test the negative path before claiming coverage.
+   For every authorisation rule, write a test that supplies the wrong principal and asserts on the deny outcome: status code, raised exception, empty result set.
+   For every input validator, write a test that supplies invalid input and asserts on the rejection.
+   A passing happy-path test is not sufficient security coverage; the bug almost always lives in the path the happy test never walks.
+
+2. Test boundaries, not just typical values.
+   Empty input, oversized input, off-by-one input, unicode and control characters, null bytes, and the edges of any numeric range each get a test when the validator's behaviour at that boundary matters.
+   Validators tend to be correct in the middle of the range and wrong at the edges, so testing only typical values gives a false sense of coverage.
+
+3. Anchor security assertions to the threat model, not to the implementation.
+   State what the attacker is trying to achieve and assert that they cannot achieve it.
+   "Asserts that user A cannot read user B's records" survives a query refactor; "asserts the SQL contains a WHERE user_id clause" breaks the moment the query changes even if the rule still holds.
+
+4. For path or command construction, test against a corpus of attack strings rather than a hand-rolled regex spot check.
+   `..`, absolute paths, symlinks, percent-encoded slashes, null bytes, and shell metacharacters each belong in the corpus.
+   The whole point of a corpus is that the next variant nobody anticipated is already in there; hand-rolled checks miss exactly that variant.
+
+5. For parser, escaper, and serialiser code, test the round-trip.
+   Encode then decode, or escape then unescape, and assert that the input is preserved exactly.
+   A one-way assertion such as "the output contains no `<script>`" misses double-encoded payloads that decode back to the dangerous form downstream.
+
+6. Do not put real secrets in test fixtures.
+   Use clearly marked test values like `test-token-do-not-use-in-prod` so a leaked fixture is recognisable as a test artifact rather than a live credential.
+   Real secrets in tests end up in version control history, CI logs, and grep results, and the leak is permanent.
+
+7. Do not assert on log absence by string-equality of the payload.
+   Assert that the secret-bearing field was redacted at the boundary that owns redaction, and that the redaction function returns the expected sentinel.
+   String-matching the log buffer for the secret is fragile: framework changes, log format changes, and async timing all break the assertion without the redaction itself changing.
+
+8. When an authentication or authorisation check is bypassed for a trusted caller (internal service, admin tool, test harness), write a test that proves the bypass cannot be reached from an untrusted caller.
+   The bypass is the riskiest line in the change; the test exists to keep it from drifting into a general escape hatch on a future refactor.
+
+9. If automated security coverage is not feasible (for example the path requires a live external service, a real signing certificate, or a production-only data store), state the reason in writing in the plan or summary and propose a manual check with explicit success and failure signals.
+   Do not silently fall back to manual verification.
+
+10. Do not weaken, skip, or delete a failing security test before investigating the cause.
+    A failing security assertion is, by default, a security regression until proven otherwise.
+    Loosening the assertion to make CI green hides exactly the class of bug the test was written to catch.
+
+## What Not to Do
+
+- Do not claim security coverage from a happy-path test that happens to use authenticated credentials. Authenticated traffic exercises the success path, not the boundary.
+- Do not test framework-provided protections by reimplementing the attack against the framework. Test the project's own use of the framework: wrong CSRF scope, missing cookie flag, misconfigured CORS, unsigned webhook accepted. Do not test the framework's CSRF middleware itself.
+- Do not paste real production tokens, keys, or personal data into test files, even temporarily during local development.
+- Do not write security tests that depend on test execution order or on shared mutable state. A test that only passes when run after a specific seed leaves the actual security boundary unverified, because nothing pinned the boundary in place.

--- a/.agents/skills/aiw-testing/SKILL.md
+++ b/.agents/skills/aiw-testing/SKILL.md
@@ -16,6 +16,7 @@ This skill works alongside these workflow sections. Consult them when writing te
 - **Test Readiness**: covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
 - **Non-Functional Test Coverage**: covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
 - **aiw-performance-profiling**: detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+- **aiw-security-testing**: detailed rules for writing security tests. Load it in addition to this skill when the change touches a trust boundary or handles untrusted input.
 
 ## Non-Functional Coverage
 
@@ -27,7 +28,7 @@ Before suggesting manual verification for any change, attempt automated coverage
 
 If the change affects UI state, reactive subscriptions, caching, heavy loops, or manual state resets, load the `aiw-performance-profiling` skill and follow its rules.
 
-For security-relevant changes, write tests that exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
+If the change touches authentication, authorisation, untrusted input, file-path or shell-command construction, secret handling, external API consumers, or data-access boundaries, load the `aiw-security-testing` skill and follow its rules. At minimum, exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
 
 If automated coverage is not feasible for a category, state the reason in writing in the plan or summary, and propose a manual check with explicit success and failure signals. Do not silently fall back to manual verification.
 

--- a/.claude/skills/aiw-security-testing/SKILL.md
+++ b/.claude/skills/aiw-security-testing/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: aiw-security-testing
+description: "Automated security testing rules for changes that touch authentication, authorisation, untrusted input, file-path or shell-command construction, secret handling, external API consumers, or data-access boundaries. Use this skill whenever the change crosses a trust boundary or processes input that could be hostile, even if the surface looks routine. The skill exists to prevent the pattern where happy-path tests pass while negative paths, boundaries, and threat-model assumptions go unchecked."
+---
+
+# Security Testing
+
+Read this file when the change touches a trust boundary or handles input the system cannot trust.
+This file contains rules for writing automated security tests before deferring to manual review or assuming framework guarantees.
+
+## Related Workflow Sections
+
+This skill works alongside these workflow sections. Consult them when writing security tests:
+
+- **Non-Functional Test Coverage**: defines when automated coverage must be attempted before manual verification.
+- **aiw-testing**: general test construction rules. This skill covers the security-specific subset.
+- **aiw-failure-analysis**: covers what to do when a reported behaviour contradicts what a security test claims.
+
+## When This Skill Applies
+
+Load this skill when the change does any of the following:
+
+- Adds, modifies, or removes an authentication or session check.
+- Adds, modifies, or removes an authorisation rule (role check, ownership check, scope check).
+- Reads, validates, parses, or transforms input from a user, the network, or an untrusted file.
+- Constructs a file path, shell command, SQL query, HTML fragment, or any other string that will later be interpreted by a parser or shell.
+- Reads, writes, transmits, or logs a secret: password, API key, token, signing key, or personally identifying data.
+- Calls an external API, including hidden retries, callbacks, and webhooks.
+- Crosses a data-access boundary between tenants, users, organisations, or environments.
+- Adds or modifies CORS, CSP, cookie flags, redirect handling, or any other browser-trust mechanism.
+
+If any of these apply and no automated security coverage exists for the affected behaviour, add coverage as part of the change.
+
+## Rules
+
+1. Test the negative path before claiming coverage.
+   For every authorisation rule, write a test that supplies the wrong principal and asserts on the deny outcome: status code, raised exception, empty result set.
+   For every input validator, write a test that supplies invalid input and asserts on the rejection.
+   A passing happy-path test is not sufficient security coverage; the bug almost always lives in the path the happy test never walks.
+
+2. Test boundaries, not just typical values.
+   Empty input, oversized input, off-by-one input, unicode and control characters, null bytes, and the edges of any numeric range each get a test when the validator's behaviour at that boundary matters.
+   Validators tend to be correct in the middle of the range and wrong at the edges, so testing only typical values gives a false sense of coverage.
+
+3. Anchor security assertions to the threat model, not to the implementation.
+   State what the attacker is trying to achieve and assert that they cannot achieve it.
+   "Asserts that user A cannot read user B's records" survives a query refactor; "asserts the SQL contains a WHERE user_id clause" breaks the moment the query changes even if the rule still holds.
+
+4. For path or command construction, test against a corpus of attack strings rather than a hand-rolled regex spot check.
+   `..`, absolute paths, symlinks, percent-encoded slashes, null bytes, and shell metacharacters each belong in the corpus.
+   The whole point of a corpus is that the next variant nobody anticipated is already in there; hand-rolled checks miss exactly that variant.
+
+5. For parser, escaper, and serialiser code, test the round-trip.
+   Encode then decode, or escape then unescape, and assert that the input is preserved exactly.
+   A one-way assertion such as "the output contains no `<script>`" misses double-encoded payloads that decode back to the dangerous form downstream.
+
+6. Do not put real secrets in test fixtures.
+   Use clearly marked test values like `test-token-do-not-use-in-prod` so a leaked fixture is recognisable as a test artifact rather than a live credential.
+   Real secrets in tests end up in version control history, CI logs, and grep results, and the leak is permanent.
+
+7. Do not assert on log absence by string-equality of the payload.
+   Assert that the secret-bearing field was redacted at the boundary that owns redaction, and that the redaction function returns the expected sentinel.
+   String-matching the log buffer for the secret is fragile: framework changes, log format changes, and async timing all break the assertion without the redaction itself changing.
+
+8. When an authentication or authorisation check is bypassed for a trusted caller (internal service, admin tool, test harness), write a test that proves the bypass cannot be reached from an untrusted caller.
+   The bypass is the riskiest line in the change; the test exists to keep it from drifting into a general escape hatch on a future refactor.
+
+9. If automated security coverage is not feasible (for example the path requires a live external service, a real signing certificate, or a production-only data store), state the reason in writing in the plan or summary and propose a manual check with explicit success and failure signals.
+   Do not silently fall back to manual verification.
+
+10. Do not weaken, skip, or delete a failing security test before investigating the cause.
+    A failing security assertion is, by default, a security regression until proven otherwise.
+    Loosening the assertion to make CI green hides exactly the class of bug the test was written to catch.
+
+## What Not to Do
+
+- Do not claim security coverage from a happy-path test that happens to use authenticated credentials. Authenticated traffic exercises the success path, not the boundary.
+- Do not test framework-provided protections by reimplementing the attack against the framework. Test the project's own use of the framework: wrong CSRF scope, missing cookie flag, misconfigured CORS, unsigned webhook accepted. Do not test the framework's CSRF middleware itself.
+- Do not paste real production tokens, keys, or personal data into test files, even temporarily during local development.
+- Do not write security tests that depend on test execution order or on shared mutable state. A test that only passes when run after a specific seed leaves the actual security boundary unverified, because nothing pinned the boundary in place.

--- a/.claude/skills/aiw-testing/SKILL.md
+++ b/.claude/skills/aiw-testing/SKILL.md
@@ -16,6 +16,7 @@ This skill works alongside these workflow sections. Consult them when writing te
 - **Test Readiness**: covers the pre-implementation check for test infrastructure gaps. This skill covers filling those gaps when approved.
 - **Non-Functional Test Coverage**: covers when automated coverage for UI state transitions, latency, and security must be attempted before manual verification.
 - **aiw-performance-profiling**: detailed rules for writing performance and UI-state-transition tests. Load it in addition to this skill when the change triggers those conditions.
+- **aiw-security-testing**: detailed rules for writing security tests. Load it in addition to this skill when the change touches a trust boundary or handles untrusted input.
 
 ## Non-Functional Coverage
 
@@ -27,7 +28,7 @@ Before suggesting manual verification for any change, attempt automated coverage
 
 If the change affects UI state, reactive subscriptions, caching, heavy loops, or manual state resets, load the `aiw-performance-profiling` skill and follow its rules.
 
-For security-relevant changes, write tests that exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
+If the change touches authentication, authorisation, untrusted input, file-path or shell-command construction, secret handling, external API consumers, or data-access boundaries, load the `aiw-security-testing` skill and follow its rules. At minimum, exercise the negative path: rejected input, forbidden access, malformed tokens, and boundary conditions. A passing happy-path test is not sufficient security coverage.
 
 If automated coverage is not feasible for a category, state the reason in writing in the plan or summary, and propose a manual check with explicit success and failure signals. Do not silently fall back to manual verification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 2.16.0 - 2026-04-26
+
+### Added
+
+- `aiw-security-testing` skill in both `.agents/skills/` and `.claude/skills/`: automated security testing rules for changes that touch authentication, authorisation, untrusted input, file-path or shell-command construction, secret handling, external API consumers, or data-access boundaries. Names the trigger surface explicitly and prescribes negative-path coverage, boundary testing, threat-model-aligned assertions, attack-corpus testing for path and command construction, parser/escaper round-trip testing, fixture-secret hygiene, redaction-boundary assertions for log leak coverage, bypass-path testing for trusted-caller exemptions, a feasibility-fallback rule that forbids silent reversion to manual, and a rule against weakening failing security tests without investigation. Motivated by issue #129: security coverage was previously a single negative-path bullet inside `aiw-testing`, which is too narrow for projects with real security surface ([#129]).
+- `Security Testing` loader section in `ai-workflow.md`: names the trigger conditions under which `aiw-security-testing` must be loaded, including the catch-all for novel trust boundaries introduced during implementation ([#129]).
+
+### Changed
+
+- `aiw-testing` skill in both skill directories now cross-references `aiw-security-testing` from its `Related Workflow Sections` block and from its `Non-Functional Coverage` security paragraph; the existing one-line negative-path summary remains in place as a minimum bar so `aiw-testing` is still useful when read on its own ([#129]).
+- `design/decisions/ai-workflow-line-by-line.md` gains a `### Security Testing` block with rationale entries for each new line in the loader, mirroring the structure used for `Performance and UI-State Profiling` ([#129]).
+- `project-context.md` Project Structure section lists `aiw-security-testing`; `Version:` header bumped to `1.8.0` ([#129]).
+
 ## 2.15.0 - 2026-04-22
 
 ### Changed

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 2.15.0
+Version: 2.16.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -210,6 +210,13 @@ Use when the change touches UI state transitions, reactive rerender paths, cachi
 Use when the change introduces a caching workaround or manual state reset to patch a symptom.
 
 Load the `aiw-performance-profiling` skill.
+
+## Security Testing
+
+Use when the change touches authentication, authorisation, untrusted input handling, file-path or shell-command construction, secret handling, external API consumption, or data-access boundaries.
+Use when the change introduces a new boundary between trusted and untrusted data.
+
+Load the `aiw-security-testing` skill.
 
 ## Non-Functional Test Coverage
 

--- a/design/decisions/ai-workflow-line-by-line.md
+++ b/design/decisions/ai-workflow-line-by-line.md
@@ -510,6 +510,22 @@ Rationale: Extracts the detailed performance and UI-state-transition test constr
 
 ---
 
+### Security Testing
+
+> "Use when the change touches authentication, authorisation, untrusted input handling, file-path or shell-command construction, secret handling, external API consumption, or data-access boundaries."
+
+Rationale: Names the trigger surface explicitly so the agent recognises the conditions without inferring them. Each item maps to a class of bug the happy-path test cannot catch: missing authn check, missing authz check, validator gap, injection sink, secret leak, untrusted external response, cross-tenant read. Listing the surface inline keeps the workflow lean while still pulling the skill in when it matters.
+
+> "Use when the change introduces a new boundary between trusted and untrusted data."
+
+Rationale: Catches the case the explicit list misses: a novel boundary the agent invents during implementation, such as a new webhook handler, a new file uploader, or a new admin RPC. Without this line, the agent would only load the skill when editing existing surfaces and would skip it on greenfield additions, which is exactly when threat-model thinking pays off most.
+
+> "Load the `aiw-security-testing` skill."
+
+Rationale: Extracts the detailed security test construction rules to an on-demand skill. Keeps the core workflow lean while making negative-path coverage, boundary testing, threat-model-aligned assertions, and feasibility-fallback discipline available when the triggers fire. Mirrors the structure of `aiw-performance-profiling` so the loader pattern stays uniform across non-functional categories.
+
+---
+
 ### Non-Functional Test Coverage
 
 > "Attempt automated coverage for the following categories before suggesting manual verification:"

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.7.0
+Version: 1.8.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -61,7 +61,7 @@ Version: 1.7.0
 - `observations/observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
 - `observations/workflow-reviews/`: archived periodic review outputs. Each file is named by date (e.g. `2026-04-19.md`).
 - `design/decisions/evaluation.md`: periodic review process — minimum-data gate, inputs, analyses, proposal format, and approval workflow.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-performance-profiling`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-performance-profiling`, `aiw-security-testing`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
Closes #129.

## Summary

- Adds `aiw-security-testing` skill in both `.agents/skills/` and `.claude/skills/`, mirroring the structure of `aiw-performance-profiling`. Names the trigger surface explicitly (auth, authorisation, untrusted input, path/command construction, secrets, external APIs, data-access boundaries) and prescribes 10 numbered rules covering negative-path coverage, boundary testing, threat-model-aligned assertions, attack-corpus testing for paths and commands, parser/escaper round-trip testing, fixture-secret hygiene, redaction-boundary log-leak assertions, bypass-path testing for trusted-caller exemptions, a feasibility-fallback rule consistent with `aiw-performance-profiling`, and a rule against weakening failing security tests.
- Adds a `Security Testing` loader section to `ai-workflow.md` (parallel to `Performance and UI-State Profiling`); bumps `Version:` to 2.16.0.
- Cross-references the new skill from `aiw-testing` in both `Related Workflow Sections` and the `Non-Functional Coverage` security paragraph; keeps the existing one-line negative-path summary as a minimum bar so `aiw-testing` is still useful when read on its own.
- Adds a `### Security Testing` rationale block to `design/decisions/ai-workflow-line-by-line.md`, with one rationale entry per new loader line.
- Updates `project-context.md` skill inventory and bumps its `Version:` to 1.8.0.

## Verification

- `./.ai-policy/scripts/project-validation.sh`: 92/92 PASS, exit 0.
- Both skill directories byte-identical via `diff`.
- Audit of the new skill against `design/decisions/*.md`: 28/28 applicable rules PASS, no FAILs or PARTIALs.
- Comparison run on a path-traversal task with a subagent loading the skill versus a baseline subagent without it: with-skill output cites numbered rules and uses threat-model-anchored assertions per rule 3 (`assert result != SECRET_CONTENT`); baseline pinned `pytest.raises(...)` instead, which would false-pass if the implementation silently returned wrong content.
- Em-dashes removed from all newly added content per the rule in `design/decisions/authoring.md`.

## Test plan

- [x] CI green on the branch.
- [x] Reviewer reads `.claude/skills/aiw-security-testing/SKILL.md` end-to-end and confirms the rules are actionable, distinct, and not duplicated by `aiw-testing` or `aiw-performance-profiling`.
- [x] Reviewer confirms the loader trigger conditions in `ai-workflow.md` cover the surface listed in #129's acceptance criteria.
- [x] Reviewer confirms no behavioural change in `aiw-testing` beyond the cross-reference (negative-path minimum still stated).

## Out of scope

- `lite-monolithic/ai-workflow.md` is intentionally not updated; #114 tracks lite-monolithic drift separately.
- Trigger-description optimization for `aiw-security-testing` (the `skill-creator` description-optimization loop) is not run here. Can follow up if real usage shows under- or over-triggering.