### PR TITLE
chore(telemetry): launchd autostart for stack + remove synthetic baseline JSONs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ The `telemetry/` directory ships a local OpenTelemetry Collector + Prometheus + 
 ./telemetry/down.sh -v     # stop and wipe captured data
 ```
 
+To start the stack automatically on every Mac login (so sessions aren't silently lost when the stack is down), run the autostart installer once per machine:
+
+```bash
+./telemetry/install-autostart.sh
+```
+
+This installs a launchd agent at `~/Library/LaunchAgents/com.aiw.telemetry.plist` that runs `docker compose up -d` at login and every 5 minutes. The wrapper exits cleanly when Docker isn't reachable, so it's safe to leave installed even when you don't want to start Docker right now. To uninstall: `launchctl unload ~/Library/LaunchAgents/com.aiw.telemetry.plist && rm ~/Library/LaunchAgents/com.aiw.telemetry.plist`.
+
 Grafana is at <http://localhost:3000>. See [`docs/telemetry-setup.md`](docs/telemetry-setup.md) for the full setup, redaction rules, and troubleshooting. See [`docs/telemetry-schema.md`](docs/telemetry-schema.md) for the baseline-harness session JSON contract.
 
 ## What This Repository Optimizes For

--- a/project-context.md
+++ b/project-context.md
@@ -82,9 +82,11 @@ Version: 1.8.0
 - `telemetry/otel-collector-config.yaml`: OTLP receivers on `:4317`/`:4318`, redaction processors (identity-attribute strip, body regex scrub, attribute truncation), and exporters to Prometheus and Loki.
 - `telemetry/prometheus/prometheus.yml`, `telemetry/loki/loki-config.yaml`: backend configs with 30-day retention.
 - `telemetry/grafana/provisioning/`: auto-wired datasources and dashboard provider.
-- `telemetry/grafana/dashboards/`: four pre-built dashboards — `session-overview.json`, `tool-usage.json`, `fix-cycles.json` (placeholder until Sub-issue D), `version-comparison.json`.
+- `telemetry/grafana/dashboards/`: five pre-built dashboards — `session-overview.json`, `tool-usage.json`, `fix-cycles.json` (placeholder), `version-comparison.json` (PromQL), `version-comparison-loki.json` (LogQL cross-version comparison driven by Loki structured metadata).
 - `telemetry/up.sh`, `telemetry/down.sh`: convenience wrappers around `docker compose`.
-- `telemetry/.gitignore`: blocks captured data from being committed.
+- `telemetry/install-autostart.sh`: idempotent installer that registers `~/Library/LaunchAgents/com.aiw.telemetry.plist` so the stack starts on Mac login and every 5 minutes thereafter.
+- `telemetry/launchd/`: launchd plist template, `ensure-stack-up.sh` wrapper (no-ops when Docker isn't running), and runtime stdout/stderr logs (gitignored).
+- `telemetry/.gitignore`: blocks captured data and launchd runtime logs from being committed.
 - `docs/telemetry-setup.md`: maintainer-facing setup, redaction, and troubleshooting guide for the telemetry stack.
 - `docs/telemetry-schema.md`: baseline-harness per-session JSON contract (v0.2, locked by #112).
 - `evals/harness/`: Python baseline harness — runner, JSON writer, workflow-version / ruleset-hash reader, pytest grader, `mock` and `claude-code` agents, plus `Dockerfile` + `compose.yaml` for the sandbox used by the `claude-code` agent.

--- a/telemetry/.gitignore
+++ b/telemetry/.gitignore
@@ -8,3 +8,7 @@ grafana/data/
 # Per-machine compose override (e.g. remap ports when 3000/9090/3100 are busy).
 # docker-compose picks this up automatically; keep it out of the repo.
 docker-compose.override.yml
+
+# launchd autostart runtime logs (per-machine).
+launchd/stdout.log
+launchd/stderr.log

--- a/telemetry/install-autostart.sh
+++ b/telemetry/install-autostart.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Installs the AIW telemetry stack launchd autostart.
+# Idempotent: safe to re-run after moving the repo or updating the plist template.
+#
+# Effect: ~/Library/LaunchAgents/com.aiw.telemetry.plist is created/refreshed
+# and loaded. On every login (and every 5 minutes), launchd runs
+# ensure-stack-up.sh which calls `docker compose up -d` in telemetry/.
+#
+# To uninstall: launchctl unload ~/Library/LaunchAgents/com.aiw.telemetry.plist
+#               rm    ~/Library/LaunchAgents/com.aiw.telemetry.plist
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/telemetry/launchd/com.aiw.telemetry.plist.template"
+WRAPPER="$REPO_ROOT/telemetry/launchd/ensure-stack-up.sh"
+TARGET="$HOME/Library/LaunchAgents/com.aiw.telemetry.plist"
+LABEL="com.aiw.telemetry"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "ERROR: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+if [ ! -f "$WRAPPER" ]; then
+    echo "ERROR: wrapper not found at $WRAPPER" >&2
+    exit 1
+fi
+
+chmod +x "$WRAPPER"
+
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# Unload any previously installed agent. Tolerate absence.
+if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+    echo "Unloading existing $LABEL"
+    launchctl unload "$TARGET" 2>/dev/null || true
+fi
+
+sed "s|__REPO_ROOT__|$REPO_ROOT|g" "$TEMPLATE" > "$TARGET"
+echo "Wrote $TARGET"
+
+launchctl load "$TARGET"
+echo "Loaded $LABEL"
+
+# Kick off the first run immediately rather than waiting for the 5-minute tick.
+launchctl start "$LABEL" 2>/dev/null || true
+
+echo
+echo "Verify:"
+echo "  launchctl list | grep $LABEL"
+echo "  docker ps --filter 'name=aiw-'"
+echo "  tail -f $REPO_ROOT/telemetry/launchd/stdout.log"

--- a/telemetry/launchd/com.aiw.telemetry.plist.template
+++ b/telemetry/launchd/com.aiw.telemetry.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.aiw.telemetry</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__REPO_ROOT__/telemetry/launchd/ensure-stack-up.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO_ROOT__/telemetry</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__REPO_ROOT__/telemetry/launchd/stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__REPO_ROOT__/telemetry/launchd/stderr.log</string>
+</dict>
+</plist>

--- a/telemetry/launchd/ensure-stack-up.sh
+++ b/telemetry/launchd/ensure-stack-up.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Idempotent: brings the AIW telemetry stack up if it isn't already.
+# Invoked by launchd at login and every 5 minutes thereafter.
+# Exits 0 quietly when Docker isn't running (the next tick will retry).
+
+set -euo pipefail
+
+if ! docker info >/dev/null 2>&1; then
+    echo "$(date -u +%FT%TZ) docker daemon not reachable, skipping" >&2
+    exit 0
+fi
+
+cd "$(dirname "$0")/.."
+docker compose up -d >/dev/null
+
+echo "$(date -u +%FT%TZ) telemetry stack up"


### PR DESCRIPTION
Closes #143.

## Summary

- Adds `telemetry/install-autostart.sh` — idempotent installer that registers `~/Library/LaunchAgents/com.aiw.telemetry.plist`. After install, the stack runs `docker compose up -d` at every Mac login and every 5 minutes thereafter.
- Adds `telemetry/launchd/ensure-stack-up.sh` — wrapper that no-ops cleanly when Docker isn't running, so it's safe to leave loaded when Docker Desktop is off.
- Adds the plist template with `__REPO_ROOT__` placeholder so the installer can substitute the absolute path on each machine.
- Deletes synthetic baseline JSONs under `telemetry/data/baseline/2.{9,10,11}.0/` (gitignored, so this is a working-tree-only cleanup; not in the diff).
- Updates README and project-context.md to document the autostart.

## Why

The baseline-and-watch comparison workflow assumes telemetry capture is always on. The current dataset has an 11-day gap (May 2–12) because the stack was down silently. This PR fixes that root cause.

## Test plan

- [x] `bash -n` on both shell scripts
- [x] `xmllint` on the plist template and on the path-substituted render — both well-formed
- [x] `./.ai-policy/scripts/project-validation.sh` — 22/22
- [x] **Step 1**: Ran installer → plist written, agent loaded
- [x] **Step 2**: `launchctl list | grep com.aiw.telemetry` → registered, exit 0
- [x] **Step 3**: All four `aiw-*` containers running, wrapper logged `telemetry stack up`
- [x] **Step 4 (recovery)**: Manual `./telemetry/down.sh` → `launchctl start com.aiw.telemetry` → all four containers back in 6 seconds
- [ ] **Step 5 (reboot survival)**: pending — maintainer to verify after merging by rebooting and confirming containers come back without intervention

## Post-merge

Run once on your Mac:

```bash
./telemetry/install-autostart.sh
```