### PR TITLE
feat(eval): aiw-evaluation skill (auto-discovered)

### DIFF
--- a/.agents/skills/aiw-evaluation/SKILL.md
+++ b/.agents/skills/aiw-evaluation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: aiw-evaluation
+description: "Periodic review entry point for the data-driven workflow evaluation defined in design/decisions/evaluation.md. Use this skill when the user asks to run the periodic review, evaluate workflow versions, produce improvement proposals, or analyse accumulated Claude Code telemetry. The skill exists to enforce the between-review readiness gate so a review never proceeds past structurally-thin data."
+---
+
+# Evaluation
+
+Read this file when the user asks to run the periodic workflow review defined in `design/decisions/evaluation.md`.
+
+This skill does not reproduce the review process — that lives in `design/decisions/evaluation.md`. This skill enforces the readiness gate that protects the process, then hands off to it when (and only when) the gate would pass.
+
+## Step 1: Determine readiness
+
+- Run `scripts/eval-preflight.sh` and check its exit code.
+- If the script is missing, stop and tell the human the preflight tool is not installed.
+- Exit code `0`: gate would pass. Continue at Step 3.
+- Exit code `1`: gate would fail. Continue at Step 2.
+- Exit code `2`: Loki is unreachable. Tell the human, suggest bringing the telemetry stack up with `./telemetry/up.sh` (or waiting for the launchd agent to restart it), and stop.
+- Exit code `3`: misconfiguration. Tell the human the preflight reported a misconfiguration and stop.
+
+The preflight writes `telemetry/eval-readiness.json` (machine-readable) and `telemetry/eval-readiness.md` (human-readable) on every run. Read whichever is appropriate at each later step.
+
+## Step 2: Write the thin-data report (gate failed)
+
+When exit code `1`, write the review document to `observations/workflow-reviews/<YYYY-MM-DD>.md`. The document must:
+
+- State that the gate is not met.
+- Reproduce the per-condition pass/fail table from `telemetry/eval-readiness.{json,md}`, including the actual counts (sessions per version, baseline versions on disk, etc.).
+- Name the earliest realistic date the gate could pass, given which conditions are failing.
+- Record any structural blockers that are not just sample-size issues (for example, baseline harness never run for any version, or ruleset_hash scoping incompatibilities).
+
+Do not produce proposals. Do not list "findings that would be disqualified under `evaluation.md`'s disqualifying conditions but might be useful" — that is exactly the thin-data paper-over the gate exists to prevent.
+
+Stop after writing the report. Do not continue to Step 3.
+
+## Step 3: Run the periodic review (gate passes)
+
+When exit code `0`, follow the process in `design/decisions/evaluation.md` exactly:
+
+- Read the inputs listed there (baseline JSONs, Loki sessions, Prometheus aggregates, sampled transcripts, `observations/observed-ai-failings.md`).
+- Run the listed analyses (`scripts/compare-versions.py`, event-level scans, transcript-level LLM-judge spot checks).
+- Produce proposals in the required format, with every required field.
+- Apply the disqualifying conditions before presenting any proposal to the human.
+
+Archive the review at `observations/workflow-reviews/<YYYY-MM-DD>.md`.
+
+## What this skill does not do
+
+- It does not run the baseline harness. That is the maintainer's separate action via `scripts/run-baseline.sh`.
+- It does not modify the gate conditions. Those live in `design/decisions/evaluation.md`.
+- It does not trigger itself. The launchd health check (`com.aiw.eval-readiness`) raises macOS notifications on green→red transitions; only the human starts a review.
+- It does not propose changes to the emission policy. The scoping of `ruleset_hash` to `ai-coding-workflow` only is intentional (`update-session-tags.sh`, `aiw-telemetry-setup` skill); the gate respects that scoping rather than fighting it.

--- a/.claude/skills/aiw-evaluation/SKILL.md
+++ b/.claude/skills/aiw-evaluation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: aiw-evaluation
+description: "Periodic review entry point for the data-driven workflow evaluation defined in design/decisions/evaluation.md. Use this skill when the user asks to run the periodic review, evaluate workflow versions, produce improvement proposals, or analyse accumulated Claude Code telemetry. The skill exists to enforce the between-review readiness gate so a review never proceeds past structurally-thin data."
+---
+
+# Evaluation
+
+Read this file when the user asks to run the periodic workflow review defined in `design/decisions/evaluation.md`.
+
+This skill does not reproduce the review process — that lives in `design/decisions/evaluation.md`. This skill enforces the readiness gate that protects the process, then hands off to it when (and only when) the gate would pass.
+
+## Step 1: Determine readiness
+
+- Run `scripts/eval-preflight.sh` and check its exit code.
+- If the script is missing, stop and tell the human the preflight tool is not installed.
+- Exit code `0`: gate would pass. Continue at Step 3.
+- Exit code `1`: gate would fail. Continue at Step 2.
+- Exit code `2`: Loki is unreachable. Tell the human, suggest bringing the telemetry stack up with `./telemetry/up.sh` (or waiting for the launchd agent to restart it), and stop.
+- Exit code `3`: misconfiguration. Tell the human the preflight reported a misconfiguration and stop.
+
+The preflight writes `telemetry/eval-readiness.json` (machine-readable) and `telemetry/eval-readiness.md` (human-readable) on every run. Read whichever is appropriate at each later step.
+
+## Step 2: Write the thin-data report (gate failed)
+
+When exit code `1`, write the review document to `observations/workflow-reviews/<YYYY-MM-DD>.md`. The document must:
+
+- State that the gate is not met.
+- Reproduce the per-condition pass/fail table from `telemetry/eval-readiness.{json,md}`, including the actual counts (sessions per version, baseline versions on disk, etc.).
+- Name the earliest realistic date the gate could pass, given which conditions are failing.
+- Record any structural blockers that are not just sample-size issues (for example, baseline harness never run for any version, or ruleset_hash scoping incompatibilities).
+
+Do not produce proposals. Do not list "findings that would be disqualified under `evaluation.md`'s disqualifying conditions but might be useful" — that is exactly the thin-data paper-over the gate exists to prevent.
+
+Stop after writing the report. Do not continue to Step 3.
+
+## Step 3: Run the periodic review (gate passes)
+
+When exit code `0`, follow the process in `design/decisions/evaluation.md` exactly:
+
+- Read the inputs listed there (baseline JSONs, Loki sessions, Prometheus aggregates, sampled transcripts, `observations/observed-ai-failings.md`).
+- Run the listed analyses (`scripts/compare-versions.py`, event-level scans, transcript-level LLM-judge spot checks).
+- Produce proposals in the required format, with every required field.
+- Apply the disqualifying conditions before presenting any proposal to the human.
+
+Archive the review at `observations/workflow-reviews/<YYYY-MM-DD>.md`.
+
+## What this skill does not do
+
+- It does not run the baseline harness. That is the maintainer's separate action via `scripts/run-baseline.sh`.
+- It does not modify the gate conditions. Those live in `design/decisions/evaluation.md`.
+- It does not trigger itself. The launchd health check (`com.aiw.eval-readiness`) raises macOS notifications on green→red transitions; only the human starts a review.
+- It does not propose changes to the emission policy. The scoping of `ruleset_hash` to `ai-coding-workflow` only is intentional (`update-session-tags.sh`, `aiw-telemetry-setup` skill); the gate respects that scoping rather than fighting it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 3.1.0 - 2026-05-28
+
+### Added
+
+- `aiw-evaluation` skill in both `.agents/skills/` and `.claude/skills/`: enforces the between-review readiness gate before the periodic workflow review process can produce proposals. Reads `telemetry/eval-readiness.json` (produced by `scripts/eval-preflight.sh`), refuses to run the review past a red gate, and writes a thin-data report under `observations/workflow-reviews/<date>.md` instead. Hands off to `design/decisions/evaluation.md` only when the preflight returns exit 0 ([#145]).
+
+### Changed
+
+- `project-context.md` Project Structure section lists `aiw-evaluation`; `Version:` header bumped to `1.10.0` ([#145]).
+
 ## 3.0.0 - 2026-05-28
 
 Major redesign of the workflow structure. The 14-step numbered workflow plus reference sections in `ai-workflow.md` is replaced by a leaner four-section structure (First Principles, Task Flow, Boundary Rules, The Human is Responsible For) that delegates enforcement to a refactored skill set. Three new core skills own concerns previously fused into a single workflow document.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.0.0
+Version: 3.1.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.9.0
+Version: 1.10.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -61,7 +61,7 @@ Version: 1.9.0
 - `observations/observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
 - `observations/workflow-reviews/`: archived periodic review outputs. Each file is named by date (e.g. `2026-04-19.md`).
 - `design/decisions/evaluation.md`: periodic review process — minimum-data gate, inputs, analyses, proposal format, and approval workflow.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-performance-profiling`, `aiw-security-testing`, `aiw-project-context-management`, `aiw-telemetry-setup`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-failure-analysis`, `aiw-logging-and-observability`, `aiw-issue-creation`, `aiw-testing`, `aiw-performance-profiling`, `aiw-security-testing`, `aiw-project-context-management`, `aiw-telemetry-setup`, `aiw-evaluation`), each self-contained in a `SKILL.md` file. Used by VS Code Copilot, Gemini CLI, and Codex.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
Part 2 of 3 for #145. Stacked on #146 (PR1).

## Summary

- `aiw-evaluation` skill in both `.agents/skills/` and `.claude/skills/`: loaded when the human invokes the periodic workflow review. Runs `scripts/eval-preflight.sh`, refuses to produce proposals on exit 1, writes a thin-data report under `observations/workflow-reviews/<date>.md`. Hands off to `design/decisions/evaluation.md` only on exit 0.
- Version: `ai-workflow.md` 3.0.0 -> 3.1.0; `project-context.md` 1.9.0 -> 1.10.0; CHANGELOG entry for 3.1.0.

No loader section in `ai-workflow.md`: v3 doesn't use the per-skill loader pattern. The skill is auto-discovered by Claude Code via its frontmatter description.

A 3.1.0 tagged release is warranted per `maintenance.md` after this merges (minor bump).

## Test plan

- [x] `.agents/skills/aiw-evaluation/SKILL.md` and `.claude/skills/aiw-evaluation/SKILL.md` byte-identical
- [x] `aiw-evaluation` appears in the active skill discovery list
- [x] `./.ai-policy/scripts/project-validation.sh` -> 22/22 pass after rebase onto v3
- [ ] End-to-end skill invocation: only fires when human asks for a review next time