### PR TITLE
chore(telemetry): hourly eval-readiness launchd agent with transition notifications

### DIFF
--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.10.0
+Version: 1.11.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -85,14 +85,15 @@ Version: 1.10.0
 - `telemetry/grafana/dashboards/`: five pre-built dashboards — `session-overview.json`, `tool-usage.json`, `fix-cycles.json` (placeholder), `version-comparison.json` (PromQL), `version-comparison-loki.json` (LogQL cross-version comparison driven by Loki structured metadata).
 - `telemetry/up.sh`, `telemetry/down.sh`: convenience wrappers around `docker compose`.
 - `telemetry/install-autostart.sh`: idempotent installer that registers `~/Library/LaunchAgents/com.aiw.telemetry.plist` so the stack starts on Mac login and every 5 minutes thereafter.
-- `telemetry/launchd/`: launchd plist template, `ensure-stack-up.sh` wrapper (no-ops when Docker isn't running), and runtime stdout/stderr logs (gitignored).
+- `telemetry/install-eval-readiness-autostart.sh`: idempotent installer that registers `~/Library/LaunchAgents/com.aiw.eval-readiness.plist` so `scripts/eval-preflight.sh` runs hourly. Fires a macOS notification on green→red transitions only; state held in gitignored `telemetry/launchd/eval-readiness.state`.
+- `telemetry/launchd/`: launchd plist templates (`com.aiw.telemetry`, `com.aiw.eval-readiness`), `ensure-stack-up.sh` and `ensure-eval-readiness.sh` wrappers (both no-op when Docker isn't running), and runtime stdout/stderr logs + state file (gitignored).
 - `telemetry/.gitignore`: blocks captured data and launchd runtime logs from being committed.
 - `docs/telemetry-setup.md`: maintainer-facing setup, redaction, and troubleshooting guide for the telemetry stack.
 - `docs/telemetry-schema.md`: baseline-harness per-session JSON contract (v0.2, locked by #112).
 - `evals/harness/`: Python baseline harness — runner, JSON writer, workflow-version / ruleset-hash reader, pytest grader, `mock` and `claude-code` agents, plus `Dockerfile` + `compose.yaml` for the sandbox used by the `claude-code` agent.
 - `evals/tasks/<task_id>/`: frozen baseline tasks. Each has `spec.md` (prompt + acceptance criteria), `starter/` (code the agent sees), `grader/` (hidden pytest applied after the agent completes), and `solution/` (reference solution used only by the `mock` agent).
 - `evals/requirements.txt`: Python dependencies for the harness (`pytest`, `scipy`).
-- `scripts/repo-validation.sh`: this repo's repo-specific validation (telemetry YAML/JSON syntax, baseline-harness Python `py_compile`, `bash -n` on `telemetry/*.sh`, `scripts/run-baseline.sh`, and `scripts/eval-preflight.sh`, `docker compose config -q`). Not part of the shipped policy layer; target repos supply their own.
+- `scripts/repo-validation.sh`: this repo's repo-specific validation (telemetry YAML/JSON syntax, baseline-harness Python `py_compile`, `bash -n` on `telemetry/*.sh`, `telemetry/launchd/*.sh`, `scripts/run-baseline.sh`, and `scripts/eval-preflight.sh`, `docker compose config -q`). Not part of the shipped policy layer; target repos supply their own.
 - `scripts/run-baseline.sh`: creates `evals/.venv`, runs `N` tasks × `k` repeats, writes results under `telemetry/data/baseline/<version>/<ruleset_hash>/<task>/<run>.json`.
 - `scripts/eval-preflight.sh`: between-review readiness check for the periodic evaluation process. Probes Loki and on-disk baseline; writes `telemetry/eval-readiness.{json,md}` (gitignored). Distinct exit codes for gate-pass (0), gate-fail (1), Loki-unreachable (2), misconfiguration (3).
 - `scripts/compare-versions.py`: reads two versions' results and prints per-task pass^k, aggregate pass^k, McNemar's test on paired outcomes, and mean/median deltas on duration, cost, tokens, and fix cycles.
@@ -100,7 +101,7 @@ Version: 1.10.0
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
 - Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh` and `test-pre-push-hook.sh` always run.
-- Repo-specific validation for this repo lives in `scripts/repo-validation.sh` and is invoked by the policy-layer validator when present: `bash -n` on `telemetry/*.sh`, `scripts/run-baseline.sh`, and `scripts/eval-preflight.sh`, Python `py_compile` on `evals/` + `scripts/`, YAML syntax checks on telemetry configs when `python3` + `pyyaml` are present, JSON syntax checks on Grafana dashboards, and `docker compose config -q` in `telemetry/` when Docker is installed.
+- Repo-specific validation for this repo lives in `scripts/repo-validation.sh` and is invoked by the policy-layer validator when present: `bash -n` on `telemetry/*.sh`, `telemetry/launchd/*.sh`, `scripts/run-baseline.sh`, and `scripts/eval-preflight.sh`, Python `py_compile` on `evals/` + `scripts/`, YAML syntax checks on telemetry configs when `python3` + `pyyaml` are present, JSON syntax checks on Grafana dashboards, and `docker compose config -q` in `telemetry/` when Docker is installed.
 - No unit test framework exists; there are no automated tests for documentation content or Grafana dashboard correctness.
 - Manual verification is the primary check for documentation changes and telemetry dashboard behaviour.
 

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -4,7 +4,7 @@
 # Target repos should supply their own scripts/repo-validation.sh (tests, linters, etc.).
 set -eu
 
-bash -n ./telemetry/*.sh ./scripts/run-baseline.sh ./scripts/eval-preflight.sh
+bash -n ./telemetry/*.sh ./telemetry/launchd/*.sh ./scripts/run-baseline.sh ./scripts/eval-preflight.sh
 
 if command -v python3 >/dev/null 2>&1; then
   PY_TARGETS=""

--- a/telemetry/.gitignore
+++ b/telemetry/.gitignore
@@ -12,6 +12,11 @@ docker-compose.override.yml
 # launchd autostart runtime logs (per-machine).
 launchd/stdout.log
 launchd/stderr.log
+launchd/eval-readiness.stdout.log
+launchd/eval-readiness.stderr.log
+
+# Per-machine runtime state for the eval-readiness launchd agent.
+launchd/eval-readiness.state
 
 # Per-machine runtime artifacts written by scripts/eval-preflight.sh.
 eval-readiness.json

--- a/telemetry/install-eval-readiness-autostart.sh
+++ b/telemetry/install-eval-readiness-autostart.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Installs the AIW eval-readiness launchd autostart.
+# Idempotent: safe to re-run after moving the repo or updating the plist template.
+#
+# Effect: ~/Library/LaunchAgents/com.aiw.eval-readiness.plist is created/refreshed
+# and loaded. On every login (and every hour), launchd runs
+# ensure-eval-readiness.sh which calls scripts/eval-preflight.sh and fires a
+# macOS notification on green->red transitions.
+#
+# To uninstall: launchctl unload ~/Library/LaunchAgents/com.aiw.eval-readiness.plist
+#               rm    ~/Library/LaunchAgents/com.aiw.eval-readiness.plist
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/telemetry/launchd/com.aiw.eval-readiness.plist.template"
+WRAPPER="$REPO_ROOT/telemetry/launchd/ensure-eval-readiness.sh"
+TARGET="$HOME/Library/LaunchAgents/com.aiw.eval-readiness.plist"
+LABEL="com.aiw.eval-readiness"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "ERROR: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+if [ ! -f "$WRAPPER" ]; then
+    echo "ERROR: wrapper not found at $WRAPPER" >&2
+    exit 1
+fi
+
+chmod +x "$WRAPPER"
+
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# Unload any previously installed agent. Tolerate absence.
+if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+    echo "Unloading existing $LABEL"
+    launchctl unload "$TARGET" 2>/dev/null || true
+fi
+
+sed "s|__REPO_ROOT__|$REPO_ROOT|g" "$TEMPLATE" > "$TARGET"
+echo "Wrote $TARGET"
+
+launchctl load "$TARGET"
+echo "Loaded $LABEL"
+
+# Kick off the first run immediately rather than waiting for the next hourly tick.
+launchctl start "$LABEL" 2>/dev/null || true
+
+echo
+echo "Verify:"
+echo "  launchctl list | grep $LABEL"
+echo "  cat $REPO_ROOT/telemetry/launchd/eval-readiness.state"
+echo "  tail -f $REPO_ROOT/telemetry/launchd/eval-readiness.stdout.log"

--- a/telemetry/launchd/com.aiw.eval-readiness.plist.template
+++ b/telemetry/launchd/com.aiw.eval-readiness.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.aiw.eval-readiness</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__REPO_ROOT__/telemetry/launchd/ensure-eval-readiness.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__REPO_ROOT__/telemetry/launchd/eval-readiness.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__REPO_ROOT__/telemetry/launchd/eval-readiness.stderr.log</string>
+</dict>
+</plist>

--- a/telemetry/launchd/ensure-eval-readiness.sh
+++ b/telemetry/launchd/ensure-eval-readiness.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Runs scripts/eval-preflight.sh on the AIW eval-readiness launchd schedule
+# (hourly). On a green->red transition, fires a macOS notification naming the
+# failing condition. Persistent-red and Docker-down ticks are silent.
+#
+# State file: telemetry/launchd/eval-readiness.state
+#   Single line containing "pass" or "fail". Inconclusive ticks (Loki
+#   unreachable, Docker down) do not update the file, so the last
+#   definitive answer survives transient outages.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+STATE_FILE="telemetry/launchd/eval-readiness.state"
+PREFLIGHT="scripts/eval-preflight.sh"
+LOG_PREFIX="$(date -u +%FT%TZ) eval-readiness"
+
+# Skip silently when Docker is not running. Same convention as
+# telemetry/launchd/ensure-stack-up.sh.
+if ! docker info >/dev/null 2>&1; then
+    echo "$LOG_PREFIX: docker daemon not reachable, skipping" >&2
+    exit 0
+fi
+
+if [ ! -x "$PREFLIGHT" ]; then
+    echo "$LOG_PREFIX: $PREFLIGHT not found or not executable" >&2
+    exit 0
+fi
+
+set +e
+"$PREFLIGHT" >/dev/null
+rc=$?
+set -e
+
+case "$rc" in
+    0) current="pass" ;;
+    1) current="fail" ;;
+    2)
+        echo "$LOG_PREFIX: preflight inconclusive (Loki unreachable), not updating state" >&2
+        exit 0
+        ;;
+    3)
+        echo "$LOG_PREFIX: preflight misconfigured (exit 3), not updating state" >&2
+        exit 0
+        ;;
+    *)
+        echo "$LOG_PREFIX: preflight returned unexpected exit $rc, not updating state" >&2
+        exit 0
+        ;;
+esac
+
+previous=""
+if [ -f "$STATE_FILE" ]; then
+    previous="$(cat "$STATE_FILE" 2>/dev/null | tr -d '[:space:]')"
+fi
+
+if [ "$previous" != "$current" ]; then
+    printf '%s\n' "$current" > "$STATE_FILE"
+fi
+
+echo "$LOG_PREFIX: preflight=$current (previous=${previous:-<none>})"
+
+# Notify only on green->red transitions. First-run (no previous), red->green,
+# and steady-state ticks are silent.
+if [ "$previous" = "pass" ] && [ "$current" = "fail" ]; then
+    detail=""
+    if [ -f telemetry/eval-readiness.json ] && command -v jq >/dev/null 2>&1; then
+        detail="$(jq -r '
+            [.conditions | to_entries[] | select(.value.status == "fail") | .key]
+            | join(", ")
+        ' telemetry/eval-readiness.json 2>/dev/null || true)"
+    fi
+    msg="Eval readiness went red"
+    if [ -n "$detail" ]; then
+        msg="$msg: $detail"
+    fi
+    osascript -e "display notification \"$msg\" with title \"AIW Eval Readiness\"" 2>/dev/null || \
+        echo "$LOG_PREFIX: osascript notification failed (non-fatal)" >&2
+    echo "$LOG_PREFIX: notified (green->red transition)"
+fi


### PR DESCRIPTION
Part 3 of 3 for #145. Stacked on #147 (PR2) for clean project-context.md sequencing; functionally depends only on #146 (PR1).

## Summary

- `telemetry/launchd/ensure-eval-readiness.sh`: runs `scripts/eval-preflight.sh` on the eval-readiness launchd schedule. Persists last definitive pass/fail in `telemetry/launchd/eval-readiness.state` (gitignored). Notifies via `osascript` only on green->red transitions; first-run, red->green, steady-state, and Docker-down ticks are silent.
- `telemetry/launchd/com.aiw.eval-readiness.plist.template`: hourly (`StartInterval=3600`), `RunAtLoad=true`. Separate stdout/stderr logs.
- `telemetry/install-eval-readiness-autostart.sh`: idempotent installer, mirrors `install-autostart.sh`.
- `scripts/repo-validation.sh`: `bash -n` now also covers `telemetry/launchd/*.sh` (this closes a pre-existing gap where `ensure-stack-up.sh` was not syntax-checked).
- `telemetry/.gitignore`: ignores the state file and eval-readiness log streams.
- `project-context.md`: 1.10.0 -> 1.11.0; structural entries for the new installer, runner, and plist.

Per-machine tooling: no `ai-workflow.md` bump, no CHANGELOG entry.

## Installing on your Mac

```
./telemetry/install-eval-readiness-autostart.sh
```

Then verify:

```
launchctl list | grep com.aiw.eval-readiness
tail -f telemetry/launchd/eval-readiness.stdout.log
```

## Test plan

- [x] Scenario A: first run, no state -> writes state, no notify
- [x] Scenario B: persistent red (state=fail, current=fail) -> no notify, no state change
- [x] Scenario C: simulated green->red transition (state=pass, current=fail) -> notify fires, state updated
- [x] `plutil -lint` on plist template passes
- [x] `bash -n` on new scripts passes; `./.ai-policy/scripts/project-validation.sh` -> 22/22 pass
- [ ] Docker-down code path (early-exit identical to `ensure-stack-up.sh`, not separately exercised)
- [ ] Real macOS notification toast visible: `osascript` exited 0 during scenario C but visual confirmation depends on you having Notifications permission enabled for `osascript`