### PR TITLE
feat(eval): notify on red->green transition too

### DIFF
--- a/telemetry/launchd/ensure-eval-readiness.sh
+++ b/telemetry/launchd/ensure-eval-readiness.sh
@@ -62,8 +62,8 @@ fi
 
 echo "$LOG_PREFIX: preflight=$current (previous=${previous:-<none>})"
 
-# Notify only on green->red transitions. First-run (no previous), red->green,
-# and steady-state ticks are silent.
+# Notify on both transitions. First-run (no previous) and steady-state ticks
+# are silent.
 if [ "$previous" = "pass" ] && [ "$current" = "fail" ]; then
     detail=""
     if [ -f telemetry/eval-readiness.json ] && command -v jq >/dev/null 2>&1; then
@@ -79,4 +79,9 @@ if [ "$previous" = "pass" ] && [ "$current" = "fail" ]; then
     osascript -e "display notification \"$msg\" with title \"AIW Eval Readiness\"" 2>/dev/null || \
         echo "$LOG_PREFIX: osascript notification failed (non-fatal)" >&2
     echo "$LOG_PREFIX: notified (green->red transition)"
+elif [ "$previous" = "fail" ] && [ "$current" = "pass" ]; then
+    msg="Eval readiness gate is GREEN. Periodic review is unblocked."
+    osascript -e "display notification \"$msg\" with title \"AIW Eval Readiness\"" 2>/dev/null || \
+        echo "$LOG_PREFIX: osascript notification failed (non-fatal)" >&2
+    echo "$LOG_PREFIX: notified (red->green transition)"
 fi


### PR DESCRIPTION
## Summary

Wrapper previously fired a macOS notification only on green->red. Add the inverse so the user hears about the gate clearing, not just it breaking.

Typical trigger: Condition 2 (≥20 sessions per version in Loki, scoped to this repo) finally accumulates enough sessions per version. That is the only remaining red on this branch and is calendar/usage-bound rather than code-fixable.

## Test plan

- [x] `bash -n` passes on the wrapper
- [x] `osascript display notification` fires (verified by direct invocation in this session)
- [x] Steady-state-fail tick remains silent (verified: `preflight=fail (previous=fail)` with no `notified` line)
- [ ] Red->green path will be exercised the first time real sessions cross the threshold in the wild; verified-by-code-inspection only here since we cannot synthesise enough Loki data to flip the gate without polluting future measurements