### PR TITLE
Refine aiw-issue-creation: allow path references, forbid restating file contents (#156)

### DIFF
--- a/.agents/skills/aiw-issue-creation/SKILL.md
+++ b/.agents/skills/aiw-issue-creation/SKILL.md
@@ -19,12 +19,18 @@ Read this file when creating a follow-up or spin-off GitHub issue.
 - State why the change is needed and what triggered the discovery.
 - State acceptance criteria if they are clear.
 
+## What the Issue May Contain
+
+- Reference relevant files by path to locate the concern, so the implementing agent can open current truth in the codebase. Point at the file; never restate, paste, or paraphrase its contents.
+- Optionally, a short list of workflow skills that may help whoever implements it. Frame this as a hint to orient the implementing agent, not a mandate or a prescribed solution.
+
 ## What the Issue Must Not Contain
 
-- Do not include file paths, code snippets, or implementation approaches.
+- Do not restate, paste, or paraphrase the contents of any file. A path that locates the concern is allowed (see above); reproducing what the file says is not.
+- Do not include code snippets or implementation approaches.
 - Do not reference specific functions, variables, or line numbers.
 - Do not prescribe how the implementing agent should solve the problem.
-  (Why: Implementation details peg to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
+  (Why: A bare path only locates the concern, but restated file contents, an implementation approach, or a function/line reference peg the issue to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
 
 ## Keeping Issues Concise
 

--- a/.claude/skills/aiw-issue-creation/SKILL.md
+++ b/.claude/skills/aiw-issue-creation/SKILL.md
@@ -19,12 +19,18 @@ Read this file when creating a follow-up or spin-off GitHub issue.
 - State why the change is needed and what triggered the discovery.
 - State acceptance criteria if they are clear.
 
+## What the Issue May Contain
+
+- Reference relevant files by path to locate the concern, so the implementing agent can open current truth in the codebase. Point at the file; never restate, paste, or paraphrase its contents.
+- Optionally, a short list of workflow skills that may help whoever implements it. Frame this as a hint to orient the implementing agent, not a mandate or a prescribed solution.
+
 ## What the Issue Must Not Contain
 
-- Do not include file paths, code snippets, or implementation approaches.
+- Do not restate, paste, or paraphrase the contents of any file. A path that locates the concern is allowed (see above); reproducing what the file says is not.
+- Do not include code snippets or implementation approaches.
 - Do not reference specific functions, variables, or line numbers.
 - Do not prescribe how the implementing agent should solve the problem.
-  (Why: Implementation details peg to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
+  (Why: A bare path only locates the concern, but restated file contents, an implementation approach, or a function/line reference peg the issue to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
 
 ## Keeping Issues Concise
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 3.4.0 - 2026-06-07
+
+### Changed
+
+- `aiw-issue-creation` skill (both `.agents/skills/` and `.claude/skills/`): issues may now reference relevant files by path to locate a concern, while restating, pasting, or paraphrasing file contents is forbidden. This reconciles the former blanket "no file paths" rule into a single coherent boundary — a bare path locates the concern (allowed); file contents, an implementation approach, or a function/line reference bias the implementing agent (forbidden). Issues may also carry an optional, non-binding list of suggested workflow skills to orient whoever implements them ([#156]).
+
 ## 3.3.0 - 2026-06-02
 
 ### Removed
@@ -304,3 +310,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#104]: https://github.com/philippe-ths/ai-coding-workflow/issues/104
 [#109]: https://github.com/philippe-ths/ai-coding-workflow/issues/109
 [#110]: https://github.com/philippe-ths/ai-coding-workflow/issues/110
+[#156]: https://github.com/philippe-ths/ai-coding-workflow/issues/156

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.3.0
+Version: 3.4.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.


### PR DESCRIPTION
Reconcile the former blanket "no file paths" rule into a single coherent
boundary: a path may locate a concern, but restating, pasting, or paraphrasing
file contents is forbidden, as are implementation approaches and
function/variable/line references. Add an optional, non-binding "suggested
skills" hint an issue may carry to orient the implementing agent.

Applied identically to both skill copies (.claude/ and .agents/). Behaviour
change to a shipped skill, so bump workflow version 3.3.0 -> 3.4.0 with a
matching CHANGELOG entry.

https://claude.ai/code/session_018ohNCwsYzJ23xsznqsYmpJ