### PR TITLE
Warn loudly when no repo-validation.sh is wired into the gate (#155)

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -4,6 +4,8 @@
 # Validates only the policy layer itself: shell-script syntax plus enforcement tests
 # that match the agent entry points actually installed in this repo.
 # If ./scripts/repo-validation.sh exists and is executable, runs it afterwards for repo-specific checks.
+# If it is absent, warns loudly that only the policy layer ran so a "passed" result is
+# not mistaken for the host project's own tests/lint/type-checks having run.
 set -eu
 
 bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
@@ -29,5 +31,13 @@ for t in ./.ai-policy/scripts/test-*.sh; do
 done
 
 if [ -x ./scripts/repo-validation.sh ]; then
+  echo "Running repo-specific checks from ./scripts/repo-validation.sh ..."
   ./scripts/repo-validation.sh
+else
+  echo "WARNING: no ./scripts/repo-validation.sh found."
+  echo "         Validation ran ONLY this workflow's policy-layer self-checks."
+  echo "         Your project's own tests, linters, and type checks were NOT run,"
+  echo "         so a \"passed\" result here does not mean your code is validated."
+  echo "         Wire your checks in by creating an executable ./scripts/repo-validation.sh"
+  echo "         (see README 'Post-install setup')."
 fi

--- a/.ai-policy/scripts/test-project-validation.sh
+++ b/.ai-policy/scripts/test-project-validation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for project-validation.sh's repo-validation wiring branch.
+# Builds a minimal sandbox containing only project-validation.sh (plus trivially
+# valid files so its upfront `bash -n` glob has something to check) and exercises
+# both branches: repo checks absent (must warn loudly, still pass) and present
+# (must run them, no warning).
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SRC="$ROOT_DIR/.ai-policy/scripts/project-validation.sh"
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) PASS=$((PASS + 1)); echo "  PASS: $label" ;;
+    *) FAIL=$((FAIL + 1)); echo "  FAIL: $label (missing: $needle)" ;;
+  esac
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) FAIL=$((FAIL + 1)); echo "  FAIL: $label (unexpected: $needle)" ;;
+    *) PASS=$((PASS + 1)); echo "  PASS: $label" ;;
+  esac
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected exit $expected, got $actual)"
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+mkdir -p "$SANDBOX/.ai-policy/scripts" "$SANDBOX/.ai-policy/hooks" "$SANDBOX/.githooks" "$SANDBOX/scripts"
+cp "$SRC" "$SANDBOX/.ai-policy/scripts/project-validation.sh"
+chmod +x "$SANDBOX/.ai-policy/scripts/project-validation.sh"
+
+# Minimal valid files so the upfront `bash -n .../*.sh .../* ` globs resolve.
+printf '#!/usr/bin/env bash\n:\n' > "$SANDBOX/.ai-policy/hooks/noop.sh"
+printf '#!/usr/bin/env bash\n:\n' > "$SANDBOX/.githooks/noop"
+
+WARN_MARKER="no ./scripts/repo-validation.sh found"
+
+cd "$SANDBOX"
+
+echo "project-validation repo-check branch tests:"
+
+# Case A — no ./scripts/repo-validation.sh: must warn loudly and still pass.
+rc=0
+out_absent="$(./.ai-policy/scripts/project-validation.sh 2>&1)" || rc=$?
+assert_exit "absent repo-validation still passes" 0 "$rc"
+assert_contains "absent repo-validation warns" "$out_absent" "$WARN_MARKER"
+
+# Case B — executable ./scripts/repo-validation.sh present: must run it, no warning.
+cat > scripts/repo-validation.sh <<'STUB'
+#!/usr/bin/env bash
+echo "REPO_CHECKS_RAN_SENTINEL"
+STUB
+chmod +x scripts/repo-validation.sh
+
+rc=0
+out_present="$(./.ai-policy/scripts/project-validation.sh 2>&1)" || rc=$?
+assert_exit "present repo-validation passes" 0 "$rc"
+assert_contains "present repo-validation is invoked" "$out_present" "REPO_CHECKS_RAN_SENTINEL"
+assert_not_contains "present repo-validation does not warn" "$out_present" "$WARN_MARKER"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 3.4.1 - 2026-06-09
+
+### Fixed
+
+- `.ai-policy/scripts/project-validation.sh` now warns loudly when no `./scripts/repo-validation.sh` is wired, instead of silently skipping it. A fresh install previously reported "Validation passed" while running only the policy-layer self-checks — none of the host project's tests, linters, or type checks — implying coverage that was not there. The validator now prints an unmistakable `WARNING` whenever repo-specific checks are absent (and announces them when present), so a fresh install can no longer present a silently-empty green gate. Behaviour is unchanged for repos that have wired their own checks ([#155]).
+
+### Added
+
+- `.ai-policy/scripts/test-project-validation.sh`: sandbox regression test asserting the validator warns and still passes when `./scripts/repo-validation.sh` is absent, and runs it without warning when present.
+
 ## 3.4.0 - 2026-06-07
 
 ### Changed
@@ -311,3 +321,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#109]: https://github.com/philippe-ths/ai-coding-workflow/issues/109
 [#110]: https://github.com/philippe-ths/ai-coding-workflow/issues/110
 [#156]: https://github.com/philippe-ths/ai-coding-workflow/issues/156
+[#155]: https://github.com/philippe-ths/ai-coding-workflow/issues/155

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ Run validation:
 
 The shipped validator (`./.ai-policy/scripts/project-validation.sh`) checks only the policy layer itself: shell-script syntax in `.ai-policy/` and `.githooks/`, plus the enforcement tests that match the agent entry points installed in your repo (tests for agents you did not install are skipped).
 
-To add repo-specific checks (tests, linters, type checks, etc.) that run as part of the same validation, create an executable `./scripts/repo-validation.sh` at the root of your repo. The shipped validator invokes it automatically when present. The file is not part of the shipped policy layer, so each repo owns its own.
+**Wire in your project's own checks — required for the gate to mean anything.** Out of the box the validator runs *none* of your project's tests, linters, or type checks, so a "passed" result only attests to the policy layer. Until you wire your own checks in, every run prints a `WARNING` saying exactly this, so a fresh install can never present a silently-empty green gate.
+
+To close that gap, create an executable `./scripts/repo-validation.sh` at the root of your repo and have it run your tests, linters, and type checks. The shipped validator invokes it automatically when present (and the warning disappears once it is). The file is not part of the shipped policy layer, so each repo owns its own; see this repo's `scripts/repo-validation.sh` for a worked example.
 
 ## Session Observation (this repo)
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.4.0
+Version: 3.4.1
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -73,7 +73,7 @@ Version: 1.12.0
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
-- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present.
+- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry).
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
@@ -99,7 +99,8 @@ Version: 1.12.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh` and `test-pre-push-hook.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, and `test-project-validation.sh` always run.
+- When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, and a JSONL validity check on the fixture.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.
 - Manual verification is the primary check for documentation changes and for the dashboard's visual behaviour.


### PR DESCRIPTION
A freshly-installed repo ran only the policy-layer self-checks yet
reported "Validation passed", implying coverage of the host project's
tests, linters, and type checks that was never there. The repo-specific
hook (scripts/repo-validation.sh) was skipped silently when absent.

project-validation.sh now prints an unmistakable WARNING whenever
scripts/repo-validation.sh is absent, and announces it when present, so
a fresh install can no longer present a silently-empty green gate.
Behaviour is unchanged for repos that have wired their own checks.

- Add test-project-validation.sh: sandbox regression test covering both
  the absent (warns, still passes) and present (runs it, no warning)
  branches.
- README "Post-install setup": frame wiring host checks as required and
  document the warning.
- Bump ai-workflow.md to 3.4.1 with matching CHANGELOG entry.
- Update project-context.md validator description and testing overview.

https://claude.ai/code/session_01RzGAC7sGqfqqJ5PiXtTcPm