### PR TITLE
Remove dangling reference to deleted evaluation design doc in CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,4 +54,4 @@ _Avoid_: ruleset version, release.
 
 ## Flagged ambiguities
 
-- **"Evaluation"** is retired. It previously named the whole statistical apparatus (pass^k, McNemar, the n=20 gate in `design/decisions/evaluation.md`, the `aiw-evaluation` skill), all of which are being deleted. The replacement is **Observation** (descriptive, human-judged). Do not reuse "evaluation" for the new system; it implies a verdict the new system deliberately does not produce.
+- **"Evaluation"** is retired. It previously named the whole statistical apparatus (pass^k, McNemar, the n=20 gate, the `aiw-evaluation` skill), all of which have been deleted. The replacement is **Observation** (descriptive, human-judged). Do not reuse "evaluation" for the new system; it implies a verdict the new system deliberately does not produce.


### PR DESCRIPTION
## What

The CONTEXT.md glossary's "Evaluation is retired" entry linked `design/decisions/evaluation.md`, which no longer exists — it was deleted when the statistical telemetry/eval stack was replaced by the descriptive observation tool (#154). This drops the dead path and corrects the tense ("are being deleted" → "have been deleted") to reflect that the apparatus has already been removed.

Surfaced while closing #101 (the abandoned objective-evaluation framework) and checking for leftover residue. The hard residue (the `telemetry/`, `evals/`, `docs/telemetry*` dirs, the eval/telemetry skills, and the baseline scripts) is already clean; this dangling glossary reference was the one stray pointer to a deleted file.

The `design/research/evaluation-methodology.md` research notes were deliberately kept — they back ADR 0001's rationale for abandoning the statistical approach.

## Change

One line in `CONTEXT.md`. No shipped files affected, so no version bump.

https://claude.ai/code/session_01RzGAC7sGqfqqJ5PiXtTcPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzGAC7sGqfqqJ5PiXtTcPm)_