### PR TITLE
Clarify project-context scaffolding and versioning conventions (#106)

### DIFF
--- a/design/decisions/maintenance.md
+++ b/design/decisions/maintenance.md
@@ -38,6 +38,9 @@ Bump it whenever the document is updated to reflect a change in the codebase it 
 Apply the same X.Y.Z scheme: patch (Z) for a small factual correction or wording fix, minor (Y) for adding or restructuring a section or documenting newly added project structure, major (X) for a wholesale rewrite.
 Changes to `project-context.md` do not require a `CHANGELOG.md` entry or a tagged release.
 
+**Derived files.**
+`lite-monolithic/ai-workflow.md` is a standalone condensation of `ai-workflow.md` plus the `aiw-*` skills into a single file. It is not authored independently for content: whenever a change to the full workflow or the skills alters the rules an agent follows, re-condense the lite file in the same change and set its `Version:` header equal to the new canonical version. Because the lite version is held equal to canonical by this rule, a lite `Version:` that lags the canonical version is a drift signal — it means the lite file has not been re-synced and may no longer reflect the current rules. Treat that gap as a defect to resolve by re-condensing, not by editing the version header alone.
+
 **Tagged releases.**
 Create a tagged release for any minor or major version bump.
 Patch bumps do not require a tagged release unless they fix a defect that users need to identify by version.

--- a/design/decisions/maintenance.md
+++ b/design/decisions/maintenance.md
@@ -21,7 +21,7 @@ Files whose changes require a bump:
 Files whose changes do not require a bump:
 
 - Design decisions in `design/` — maintenance docs for this repo, not shipped to target repos.
-- `project-context.md` in this repo — this repo's own context document, not shipped. Only bump if the `aiw-project-context-management` skill changes.
+- `project-context.md` in this repo — this repo's own context document, not shipped. It carries its own independent version (see "`project-context.md` version" below); changes to it never require a canonical bump.
 - `README.md`, `observations/`, test scripts — not shipped as workflow instructions.
 
 Bump the patch version (Z) for any change that corrects wording, fixes a gap, or removes duplication without altering intent.
@@ -30,7 +30,13 @@ Bump the major version (X) for a structural overhaul that changes the number or 
 Update the version on every qualifying edit so session logs can be tied to a specific file state.
 The X.Y.Z scheme follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), adapted here so that "public API" means "observable agent behaviour in a target repo" rather than source code interface.
 
-Every change to the `Version:` header requires a matching entry in `CHANGELOG.md` at the repo root. The pre-push hook (`.ai-policy/hooks/check-changelog.sh`) rejects pushes that bump the version without adding a matching entry. The changelog follows [Common Changelog](https://common-changelog.org/).
+Every change to the canonical `Version:` header in `ai-workflow.md` requires a matching entry in `CHANGELOG.md` at the repo root. The pre-push hook (`.ai-policy/hooks/check-changelog.sh`) rejects pushes that bump the version without adding a matching entry. The changelog follows [Common Changelog](https://common-changelog.org/).
+
+**`project-context.md` version.**
+`project-context.md` carries its own `Version:` header, independent of the canonical `ai-workflow.md` version, identifying the state of this repo's context document.
+Bump it whenever the document is updated to reflect a change in the codebase it describes; it is not shipped to target repos, so its version neither affects nor is affected by the canonical version.
+Apply the same X.Y.Z scheme: patch (Z) for a small factual correction or wording fix, minor (Y) for adding or restructuring a section or documenting newly added project structure, major (X) for a wholesale rewrite.
+Changes to `project-context.md` do not require a `CHANGELOG.md` entry or a tagged release.
 
 **Tagged releases.**
 Create a tagged release for any minor or major version bump.

--- a/lite-monolithic/README.md
+++ b/lite-monolithic/README.md
@@ -16,13 +16,13 @@ Developers who want lightweight AI coding guardrails they can drop into any repo
 2. Point your AI coding agent at the file (e.g. via agent instructions or conversation context).
 3. Run tasks through the workflow. The agent follows the steps; you review at checkpoints.
 
-## What's Different from the Full Version
+## Relationship to the Full Project
 
-The full version includes:
+`ai-workflow.md` here is a self-contained condensation of the [full AI Coding Workflow](https://github.com/philippe-ths/ai-coding-workflow): the same workflow steps, planning discipline, validation gates, scope control, and failure analysis, inlined into one file with no external dependencies. It is a *derived* artifact — re-condensed from the full workflow and its skills — and its `Version:` header is kept equal to the full project's canonical version, so you can tell which release it was distilled from. A lite version that lags the canonical version means it has not yet been re-synced.
+
+Step up to the full version when you want what a single file cannot carry:
 
 - A policy enforcement layer (`.ai-policy/` scripts and git hooks) that blocks commits and pushes when rules are violated.
-- Separate skill files loaded on demand for planning, failure analysis, logging/observability, and issue creation.
+- Skills loaded on demand (planning, ground truth, testing, verification, failure analysis, GitHub handoff, issue creation, project-context management, and more).
 - Multi-agent entry points for VS Code Copilot, Claude Code, Codex, and Gemini CLI.
-- A project-context management skill (`aiw-project-context-management`) for authoring a `project-context.md` that documents implementation truth in target repositories.
-
-This lite version strips all of that down to a single file with the essential rules inlined. If you need deterministic enforcement or multi-agent configuration, use the [full version](https://github.com/philippe-ths/ai-coding-workflow).
+- A maintained `project-context.md` documenting your repository's implementation truth, authored with the `aiw-project-context-management` skill.

--- a/lite-monolithic/README.md
+++ b/lite-monolithic/README.md
@@ -23,6 +23,6 @@ The full version includes:
 - A policy enforcement layer (`.ai-policy/` scripts and git hooks) that blocks commits and pushes when rules are violated.
 - Separate skill files loaded on demand for planning, failure analysis, logging/observability, and issue creation.
 - Multi-agent entry points for VS Code Copilot, Claude Code, Codex, and Gemini CLI.
-- A project-context template for documenting implementation truth in target repositories.
+- A project-context management skill (`aiw-project-context-management`) for authoring a `project-context.md` that documents implementation truth in target repositories.
 
 This lite version strips all of that down to a single file with the essential rules inlined. If you need deterministic enforcement or multi-agent configuration, use the [full version](https://github.com/philippe-ths/ai-coding-workflow).

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.12.0
+Version: 1.13.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -110,3 +110,4 @@ Version: 1.12.0
 - Keep this file aligned with the current codebase, not planned architecture.
 - Keep this file concise and under 300 lines.
 - When a user-facing file changes, bump the version in `ai-workflow.md` following the guidance in `design/decisions/maintenance.md`.
+- When this file changes, bump its own `Version:` header per the `project-context.md` version rule in `design/decisions/maintenance.md`.


### PR DESCRIPTION
- lite-monolithic/README.md: replace the non-existent "project-context
  template" with the aiw-project-context-management skill that actually
  authors project-context.md.
- design/decisions/maintenance.md: document project-context.md's own
  version field — when it bumps (on any update tracking the codebase) and
  the X.Y.Z increment levels — replacing the prior rule that contradicted
  actual practice; scope the CHANGELOG requirement to the canonical header.
- project-context.md: add a maintenance-checklist item to bump its own
  version, and bump it to 1.13.0.

https://claude.ai/code/session_01Mwah2DibhJM2mTazHQDphB