### PR TITLE
Add "Asking for Guidance" rule to workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+## 3.5.0 - 2026-06-11
+
+### Added
+
+- `ai-workflow.md` and `lite-monolithic/ai-workflow.md`: new "Asking for Guidance" section. Whenever the agent asks the human a question or requests guidance on a decision, it must present it as a short framing paragraph, a list of options each with an explanation, a clear recommendation, and the rationale for that recommendation.
+
 ## 3.4.1 - 2026-06-09
 
 ### Fixed

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.4.1
+Version: 3.5.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -71,6 +71,10 @@ Do not do any of the following under any circumstances:
 - NEVER claim the issue is nearly complete while the root cause is still unknown.
 - NEVER hardcode sensitive values.
 - NEVER bypass deterministic policy checks or treat them as optional.
+
+## Asking for Guidance
+
+When asking the human a question or requesting guidance on a decision, present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation.
 
 ## Reactive Rules
 

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.4.1
+Version: 3.5.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -354,6 +354,10 @@ Do not do any of the following under any circumstances:
 - NEVER silently expand scope or introduce unrelated changes.
 - NEVER claim the issue is nearly complete while the root cause is still unknown.
 - NEVER hardcode sensitive values.
+
+## Asking for Guidance
+
+When asking the human a question or requesting guidance on a decision, present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation.
 
 ## Reactive Rules
 


### PR DESCRIPTION
Adds a new `## Asking for Guidance` section to `ai-workflow.md` and the lite-monolithic version.

## What changed
- **`ai-workflow.md`**: new section between Boundary Rules and Reactive Rules. Whenever the agent asks the human a question or requests guidance on a decision, it must present it as a short framing paragraph, a list of options each with an explanation, a clear recommendation, and the rationale for that recommendation.
- **`lite-monolithic/ai-workflow.md`**: same section, version held equal at `3.5.0` per the derived-file rule.
- **Version**: `3.4.1` → `3.5.0` (minor: new rule).
- **`CHANGELOG.md`**: matching `3.5.0` entry.

## Validation
- `./.ai-policy/scripts/project-validation.sh`: 5/5 and 22/22 passed; repo parser test OK.
- Both canonical and lite headers set to `3.5.0` (no drift).

## Notes
- Not tied to a GitHub issue; changelog entry carries no `[#NNN]` reference.
- A tagged release is warranted for this minor bump per `design/decisions/maintenance.md`.