### PR TITLE
Agent-driven install and update for the AI workflow (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 The canonical version is the `Version:` header in `ai-workflow.md`. Every bump of that header requires a matching entry here; the pre-push hook enforces this.
 
+Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
+
 ## 3.5.0 - 2026-06-11
 
 ### Added
@@ -30,9 +32,21 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 ### Removed
 
-- The entire telemetry stack (`telemetry/`): OTEL Collector, Prometheus, Loki, Grafana, the five dashboards, the redaction pipeline, and both launchd autostart installers. The OTLP/Prometheus pipeline was silently dropping ~80% of sessions and required a babysitting skill to keep alive.
-- The baseline evaluation harness (`evals/`), `scripts/run-baseline.sh`, `scripts/compare-versions.py`, and `scripts/eval-preflight.sh`. The statistical A/B apparatus (pass^k, McNemar, the n=20 readiness gate) could not produce trustworthy verdicts from a single developer's sparse, cross-repo data.
-- The `aiw-evaluation` and `aiw-telemetry-setup` skills (both `.agents/skills/` and `.claude/skills/`), `design/decisions/evaluation.md`, `docs/telemetry-setup.md`, `docs/telemetry-schema.md`, `docs/spikes/d0-sandbox-otel.md`, `.envrc.example`, and `.ai-policy/scripts/update-session-tags.sh`.
+- `telemetry/` — the entire local OTEL Collector + Prometheus + Loki + Grafana stack, the five dashboards, the redaction pipeline, and both launchd autostart installers. The OTLP/Prometheus pipeline was silently dropping ~80% of sessions and required a babysitting skill to keep alive.
+- `evals/` — the baseline evaluation harness. The statistical A/B apparatus (pass^k, McNemar, the n=20 readiness gate) could not produce trustworthy verdicts from a single developer's sparse, cross-repo data.
+- `scripts/run-baseline.sh` — baseline harness runner.
+- `scripts/compare-versions.py` — pass^k / McNemar comparison.
+- `scripts/eval-preflight.sh` — between-review readiness gate.
+- `.agents/skills/aiw-evaluation/` — review-readiness skill.
+- `.claude/skills/aiw-evaluation/` — review-readiness skill.
+- `.agents/skills/aiw-telemetry-setup/` — telemetry enablement skill.
+- `.claude/skills/aiw-telemetry-setup/` — telemetry enablement skill.
+- `design/decisions/evaluation.md` — evaluation gate rationale.
+- `docs/telemetry-setup.md` — telemetry setup guide.
+- `docs/telemetry-schema.md` — per-session JSON contract.
+- `docs/spikes/d0-sandbox-otel.md` — sandbox OTEL spike.
+- `.envrc.example` — telemetry env template.
+- `.ai-policy/scripts/update-session-tags.sh` — session-tag writer.
 
 ### Added
 
@@ -99,7 +113,8 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 
 ### Removed
 
-- `aiw-logging-and-observability` skill: content redistributed into `aiw-verification` (runtime-output reading as evidence) and `aiw-failure-analysis` (diagnostic logging during investigation). No standalone observability skill remains; the obligations are owned by the verification and failure-analysis skills that consume them.
+- `.agents/skills/aiw-logging-and-observability/` — content redistributed into `aiw-verification` (runtime-output reading as evidence) and `aiw-failure-analysis` (diagnostic logging during investigation). No standalone observability skill remains; the obligations are owned by the verification and failure-analysis skills that consume them.
+- `.claude/skills/aiw-logging-and-observability/` — content redistributed into `aiw-verification` and `aiw-failure-analysis`.
 
 ## 2.16.0 - 2026-04-26
 
@@ -128,9 +143,9 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 
 ### Removed
 
-- `.ai-policy/hooks/check-session-tags.sh` pre-commit hook and its invocation from `.githooks/pre-commit`. The drift it caught was drift in a tracked file; now that identity is no longer tracked, the drift class does not exist ([#136]).
+- `.ai-policy/hooks/check-session-tags.sh` — pre-commit hook (and its invocation from `.githooks/pre-commit`). The drift it caught was drift in a tracked file; now that identity is no longer tracked, the drift class does not exist ([#136]).
 - `.ai-policy/scripts/test-session-tags-hook.sh` — covered the deleted hook ([#136]).
-- Session-tags test gating in `.ai-policy/scripts/project-validation.sh` ([#136]).
+- `.ai-policy/scripts/project-validation.sh` — removed the session-tags test gating from it ([#136]).
 
 ## 2.14.0 - 2026-04-20
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,69 @@
+# Installing and Updating the AI Coding Workflow
+
+This file tells an AI coding agent how to install this workflow into a target
+repository, or update an already-installed copy. Point an agent at this
+repository (a local path or its URL) and say "install the AI workflow" or
+"upgrade the AI workflow"; the agent follows the steps below.
+
+## What you are working with
+
+- This repository is the **source** (the workflow plus its installer).
+- The **target** is the repository the workflow is being installed into, usually
+  the repo the agent is currently working in.
+- `install-manifest.json` is the source of truth for which files are **product**
+  (installed into the target) and which are **factory** (this repo's own
+  machinery, never installed). The installer reads it. Do not copy files by hand.
+  Run `make classify` here to see the boundary.
+
+## If you only have the URL
+
+Clone the repository to a local path first, then use that path as `<source>`:
+
+```bash
+git clone https://github.com/philippe-ths/ai-coding-workflow /tmp/ai-coding-workflow
+```
+
+If the agent's environment cannot clone, ask the human to provide the repository
+as a local path instead.
+
+## Install (fresh)
+
+1. Confirm the target path and that it is a git repository. If not, run
+   `git init` there first (the installer requires it for hooks and vendoring).
+2. Ask the human which agent tool to install for (`claude`, `codex`, `gemini`, or
+   `copilot`) and which profile: `full` (policy layer, skills, entry point) or
+   `lite` (one self-contained file).
+3. Run the installer from the source:
+
+   ```bash
+   <source>/scripts/install.sh --target <target> --tool <tool> --profile <profile>
+   ```
+
+4. Author the target's `project-context.md` using the
+   `aiw-project-context-management` skill. It must describe the **target** repo;
+   the installer does not create it.
+5. Report what was installed.
+
+## Update (already installed)
+
+1. Confirm the target has an installed copy (`ai-workflow.md` at its root).
+2. Run the updater from the source:
+
+   ```bash
+   <source>/scripts/update.sh --target <target>
+   ```
+
+   It auto-detects the installed tool and profile from the target. Pass
+   `--tool` / `--profile` to override or to disambiguate if several tools are
+   installed.
+3. Report the version change and any files that were removed.
+
+## Notes
+
+- **Vendored, not committed.** The installer records the installed files in the
+  target's `.gitignore` so they do not enter the target's history. Do not commit
+  them unless the human asks.
+- **Removals on update** come only from this repo's `CHANGELOG.md` `### Removed`
+  entries. A file is deleted from the target only if it was dropped from the
+  product between the installed and current versions; local additions are kept.
+- The installer copies only product files; factory files are never installed.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: observe observe-test
+.PHONY: observe observe-test classify
+
+# Print the product/factory classification from install-manifest.json (the
+# single source of truth for what installs into a target vs what stays here).
+classify:
+	@./scripts/classify.sh
 
 # Rebuild the Session Store from all transcripts and open the dashboard.
 # See docs/adr/0001 and observation/README.md.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Tipping points are a judgement call. They come from real-world usage in other re
 - `observations/observed-ai-failings.md` — log of concrete failure patterns observed in real AI-agent sessions.
 - `observations/workflow-reviews/` — archived outputs from earlier periodic workflow reviews.
 
+## Product vs Factory
+
+This repository is two things at once: the **product** (the workflow files that install into a target repository) and the **factory** (this repo's own machinery for developing, validating, and observing the workflow). Because the repo runs its own workflow, the product files live at the root alongside the factory files rather than in a separate directory.
+
+`install-manifest.json` is the single source of truth for that boundary. It declares, per profile and per tool, which files are product, which are authored fresh in each target, and which are factory-only and must never be copied. `scripts/check-manifest.sh` (run in validation) guarantees every git-tracked file is classified, so nothing can drift out of the boundary unnoticed.
+
+To see the current classification, read the manifest or run:
+
+```bash
+make classify
+```
+
 ## Installation by Tool
 
 Copy the relevant files into your target repository. Each agent needs its own instruction entry point, the shared workflow file, and the policy enforcement layer. `project-context.md` is not copied — it is authored in the target repository by invoking the `aiw-project-context-management` skill.

--- a/README.md
+++ b/README.md
@@ -78,64 +78,27 @@ To see the current classification, read the manifest or run:
 make classify
 ```
 
-## Installation by Tool
+## Installation
 
-Copy the relevant files into your target repository. Each agent needs its own instruction entry point, the shared workflow file, and the policy enforcement layer. `project-context.md` is not copied — it is authored in the target repository by invoking the `aiw-project-context-management` skill.
+Point an AI coding agent at this repository — a local path or its URL — and say "install the AI workflow" (or "upgrade the AI workflow"). The agent follows [`INSTALL.md`](INSTALL.md), which drives the installer: it asks which tool (`claude`, `codex`, `gemini`, `copilot`) and profile (`full` or `lite`), copies the right files, records them in the target's `.gitignore`, and installs the git hooks. No hand-copying.
 
-### Claude Code
-
-```
-CLAUDE.md
-.claude/
-.ai-policy/
-.githooks/
-ai-workflow.md
-```
-
-### VS Code Copilot
-
-```
-.github/copilot-instructions.md
-.agents/skills/
-.vscode/
-.ai-policy/
-.githooks/
-ai-workflow.md
-```
-
-### Codex
-
-```
-AGENTS.md
-.agents/skills/
-.codex/
-.ai-policy/
-.githooks/
-ai-workflow.md
-```
-
-### Gemini CLI
-
-```
-GEMINI.md
-.agents/skills/
-.gemini/
-.ai-policy/
-.githooks/
-ai-workflow.md
-```
-
-After copying, add the governance files and folders to the target repository's `.gitignore` if they should not be committed there.
-
-### Post-install setup
-
-Install the git hooks:
+To run it directly instead:
 
 ```bash
-./.ai-policy/scripts/install-hooks.sh
+# fresh install
+scripts/install.sh --target <target-repo> --tool claude --profile full
+
+# update an installed copy (auto-detects the installed tool and profile)
+scripts/update.sh --target <target-repo>
 ```
 
-Run validation:
+Which files each tool and profile receives is defined in `install-manifest.json` (run `make classify` to print it); see [Product vs Factory](#product-vs-factory). The installer copies only product files. `project-context.md` is not copied — author it in the target with the `aiw-project-context-management` skill so it describes the target repo.
+
+Governance files are **vendored**: the installer adds them to the target's `.gitignore` so they are not committed into the target's history. The full profile also wires the git hooks (`core.hooksPath`) automatically.
+
+### Wiring in your project's own checks
+
+After installing, run validation in the target:
 
 ```bash
 ./.ai-policy/scripts/run-validation.sh

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,0 +1,39 @@
+{
+  "$comment": "Boundary between product files (copied into a target repo on install) and factory files (this repo's own machinery, never copied). Source-side: this manifest is itself factory-only and is never installed. scripts/check-manifest.sh validates it against git-tracked files; untracked artifacts (e.g. telemetry/, .envrc, .DS_Store) are out of scope by design. Directory entries end with '/'; file entries do not.",
+  "profiles": {
+    "full": {
+      "shared": ["ai-workflow.md", ".ai-policy/", ".githooks/"],
+      "tools": {
+        "claude": ["CLAUDE.md", ".claude/"],
+        "codex": ["AGENTS.md", ".codex/", ".agents/skills/"],
+        "gemini": ["GEMINI.md", ".gemini/", ".agents/skills/"],
+        "copilot": [".github/copilot-instructions.md", ".github/hooks/", ".vscode/", ".agents/skills/"]
+      }
+    },
+    "lite": {
+      "shared": ["lite-monolithic/ai-workflow.md"],
+      "entry_filenames": {
+        "claude": "CLAUDE.md",
+        "codex": "AGENTS.md",
+        "gemini": "GEMINI.md",
+        "copilot": ".github/copilot-instructions.md"
+      }
+    }
+  },
+  "authored_in_target": ["project-context.md"],
+  "factory_only": [
+    "install-manifest.json",
+    ".gitignore",
+    "CHANGELOG.md",
+    "CONTEXT.md",
+    "LICENSE",
+    "Makefile",
+    "README.md",
+    "design/",
+    "docs/",
+    "observation/",
+    "observations/",
+    "scripts/",
+    "lite-monolithic/README.md"
+  ]
+}

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -23,6 +23,7 @@
   "authored_in_target": ["project-context.md"],
   "factory_only": [
     "install-manifest.json",
+    "INSTALL.md",
     ".gitignore",
     "CHANGELOG.md",
     "CONTEXT.md",

--- a/lite-monolithic/README.md
+++ b/lite-monolithic/README.md
@@ -16,6 +16,8 @@ Developers who want lightweight AI coding guardrails they can drop into any repo
 2. Point your AI coding agent at the file (e.g. via agent instructions or conversation context).
 3. Run tasks through the workflow. The agent follows the steps; you review at checkpoints.
 
+Or let the installer do it: from the full project, run `scripts/install.sh --target <repo> --tool <tool> --profile lite`, or point an agent at the full repository and say "install the AI workflow", choosing the `lite` profile. The installer drops `ai-workflow.md` in and generates a minimal entry file for your tool. See the full project's [`INSTALL.md`](../INSTALL.md).
+
 ## Relationship to the Full Project
 
 `ai-workflow.md` here is a self-contained condensation of the [full AI Coding Workflow](https://github.com/philippe-ths/ai-coding-workflow): the same workflow steps, planning discipline, validation gates, scope control, and failure analysis, inlined into one file with no external dependencies. It is a *derived* artifact — re-condensed from the full workflow and its skills — and its `Version:` header is kept equal to the full project's canonical version, so you can tell which release it was distilled from. A lite version that lags the canonical version means it has not yet been re-synced.

--- a/project-context.md
+++ b/project-context.md
@@ -1,11 +1,11 @@
 # Project Context
 
-Version: 1.13.0
+Version: 1.14.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
 - Primary users are human developers who have an AI coding agent (Copilot, Claude Code, Codex) working in their projects.
-- The core user flow is: copy workflow and context files into a target repository, configure the agent to read them, then run tasks through the defined workflow with human checkpoints.
+- The core user flow is: install the workflow into a target repository with the agent-driven installer (or by pointing an agent at this repo), then run tasks through the defined workflow with human checkpoints.
 - The repository also hosts a local, single-developer session-observation tool used to watch the maintainer's own Claude Code usage across repos.
 
 ## Domain Concepts
@@ -15,6 +15,9 @@ Version: 1.13.0
 - **Policy layer**: the set of shell scripts in `.ai-policy/` that enforce protected-branch and validation-state rules.
 - **Skill**: a domain-specific instruction file loaded on demand by the agent when a workflow step requires it.
 - **Checkpoint**: a required human-review pause defined in the workflow before a consequential action.
+- **Install manifest**: the source-of-truth file (`install-manifest.json`) declaring, per profile and tool, which files are product (installed into a target) and which are factory (this repo's own machinery, never installed).
+- **Profile**: an install variant, `full` (policy layer, skills, entry point) or `lite` (single self-contained file).
+- **Vendored install**: installed governance files recorded in the target's `.gitignore` so they are not committed into the target's own history.
 - **Session observation**: the local tooling under `observation/` that reads Claude Code session transcripts and presents descriptive per-session metrics with no statistical verdict.
 - **Session Store**: a global JSONL file (`~/.claude/aiw-observation/sessions.jsonl`) holding one metrics row per session, rebuilt from transcripts on demand.
 - **Manifest**: a global file written by a SessionStart hook recording each session's `workflow_version` and repo, the only reliable source of the version active during a session.
@@ -28,6 +31,8 @@ Version: 1.13.0
 - Provides agent skills for code-aware planning, ground-truth sourcing, failure analysis, GitHub handoff, issue creation, test construction, verification, performance profiling, security testing, and project-context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code).
 - Both skill directories contain the same skills.
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), Codex (`AGENTS.md`), and Gemini CLI (`GEMINI.md`).
+- Provides an agent-driven installer (`scripts/install.sh`) and updater (`scripts/update.sh`) that copy the product file set for a chosen tool and profile into a target repository, vendor them in the target's `.gitignore`, and reconcile removals on update from `CHANGELOG.md`.
+- Declares the product/factory boundary in `install-manifest.json`, validated by `scripts/check-manifest.sh` and printed by `make classify`.
 - Records observed AI agent failure patterns (`observations/observed-ai-failings.md`) to inform workflow rule changes.
 - Provides a lite-monolithic version (`lite-monolithic/ai-workflow.md`) that condenses the workflow into a single self-contained file with no policy layer, skills, or multi-agent entry points.
 - Provides a local session-observation tool (`observation/`) that parses Claude Code transcripts into a JSONL Session Store and a self-contained static HTML dashboard.
@@ -42,11 +47,14 @@ Version: 1.13.0
 - Validation must pass before commit or push when hooks are installed.
 - All facts in `project-context.md` must reflect implementation truth, not planned architecture.
 - The Session Store records metrics only, never prompt or code content, so pooling sessions from many repos locally needs no redaction.
+- `install-manifest.json` must classify every git-tracked file as product, factory, or authored-in-target; `scripts/check-manifest.sh` enforces this in validation.
+- Installed governance files are vendored: the installer records them in the target's `.gitignore` and does not commit them to the target's history.
+- `CHANGELOG.md` `### Removed` bullets must lead with the removed path so the update path can delete dropped files; `scripts/check-changelog-removals.sh` enforces this (factory-only, not shipped).
 
 ## Architecture Summary
-- This is primarily a documentation repository; its only runtime code is the session-observation tool under `observation/`.
+- This is primarily a documentation repository; its runtime code is the session-observation tool under `observation/` and the install/update tooling under `scripts/`.
 - Four layers exist: agent-facing governance files (workflow and context documents), on-demand skill files loaded at specific workflow steps, a local policy enforcement layer (scripts and git hooks), and the local session-observation tool.
-- Primary data flow: human copies files to target repository, the agent reads them before each task, the agent follows the workflow, the human reviews checkpoints.
+- Primary data flow: the agent-driven installer (`scripts/install.sh`) copies the product files into a target repository, the agent reads them before each task, the agent follows the workflow, the human reviews checkpoints.
 - Observation data flow: a SessionStart hook records the Manifest, the `/rate` skill records Ratings, then `observation/collect.py` reads all transcripts under `~/.claude/projects/`, joins the Manifest and Ratings, writes the Session Store, and regenerates a static HTML dashboard.
 - Observation runs on demand with a full rebuild each time; nothing runs in the background except the event-driven Manifest hook.
 - No external service dependencies exist at repository runtime; GitHub is used only for issue and PR tracking.
@@ -60,7 +68,9 @@ Version: 1.13.0
 
 ## Project Structure
 - `ai-workflow.md`: canonical workflow steps, validation rules, scope controls, and GitHub handoff rules for the AI agent; its `Version:` header is the canonical project version.
-- `CHANGELOG.md`: Common Changelog record of every version bump; enforced by the pre-push changelog hook.
+- `install-manifest.json`: source of truth for the product/factory boundary; lists product files per profile and tool, authored-in-target files, and factory-only files.
+- `INSTALL.md`: agent-actionable entry doc for installing or updating the workflow in a target repository.
+- `CHANGELOG.md`: Common Changelog record of every version bump; enforced by the pre-push changelog hook; `### Removed` bullets lead with the removed path so the updater can extract them.
 - `CONTEXT.md`: glossary of the session-observation domain language.
 - `docs/adr/`: architecture decision records; `0001` and `0002` record the move to descriptive observation and global capture.
 - `design/`: maintenance documentation for the repository; `design/decisions/` holds concern-scoped rationale files and `design/research/` holds primary-source notes with stable anchor IDs.
@@ -94,14 +104,20 @@ Version: 1.13.0
 - `observation/capture/rate/SKILL.md`: the global `/rate` skill source.
 - `observation/install-observation.sh`: installs capture and the `/rate` skill into global `~/.claude/`, honoring `CLAUDE_HOME` for testing.
 - `observation/README.md`: setup and usage for the observation tool.
-- `Makefile`: `observe` rebuilds the store and opens the dashboard; `observe-test` runs the parser test.
-- `scripts/repo-validation.sh`: this repo's repo-specific validation; runs `bash -n` and `py_compile` on `observation/`, the parser regression test, and JSONL fixture validity.
+- `Makefile`: `observe` rebuilds the store and opens the dashboard; `observe-test` runs the parser test; `classify` prints the product/factory boundary.
+- `scripts/install.sh`: copies the product set for a tool and profile into a target repo, vendors it in the target's `.gitignore`, and installs hooks (full profile); lite copies the single file plus a generated entry.
+- `scripts/update.sh`: updates an installed copy by re-copying the current product, auto-detecting tool and profile, and reconciling removals from the source `CHANGELOG.md`.
+- `scripts/classify.sh`: prints the product/factory classification read from `install-manifest.json`.
+- `scripts/check-manifest.sh`: validates that the manifest classifies every git-tracked file exactly once.
+- `scripts/check-changelog-removals.sh`: enforces the leading-path convention on `### Removed` bullets (factory-only).
+- `scripts/test-install.sh`, `scripts/test-update.sh`, `scripts/test-changelog-removals.sh`: sandbox tests for the installer, updater, and changelog convention.
+- `scripts/repo-validation.sh`: this repo's repo-specific validation; runs shell and Python checks on `observation/`, the parser regression test, JSONL fixture validity, the manifest integrity check, and the install, update, and changelog-removals sandbox tests.
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
 - Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, and `test-project-validation.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
-- Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, and a JSONL validity check on the fixture.
+- Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.
 - Manual verification is the primary check for documentation changes and for the dashboard's visual behaviour.
 
@@ -111,3 +127,4 @@ Version: 1.13.0
 - Keep this file concise and under 300 lines.
 - When a user-facing file changes, bump the version in `ai-workflow.md` following the guidance in `design/decisions/maintenance.md`.
 - When this file changes, bump its own `Version:` header per the `project-context.md` version rule in `design/decisions/maintenance.md`.
+- When adding a top-level tracked file, classify it in `install-manifest.json`; validation fails until every tracked file is classified.

--- a/scripts/check-changelog-removals.sh
+++ b/scripts/check-changelog-removals.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Enforce the leading-path convention for CHANGELOG `### Removed` bullets.
+#
+# Every bullet inside a `### Removed` section must lead with the removed path as
+# a backticked token, with no spaces inside it:
+#
+#   - `path/to/thing` — explanation
+#
+# The update path (scripts/update.sh) parses these to learn which installed
+# files to delete from a target repo, so the format must stay machine-
+# extractable. This is FACTORY-ONLY validation: it runs from scripts/
+# (never shipped) and only governs this repo's own CHANGELOG, never a target's.
+#
+# Usage: check-changelog-removals.sh [changelog-file]   (defaults to repo CHANGELOG.md)
+set -eu
+
+if [ "${1:-}" != "" ]; then
+  CHANGELOG="$1"
+else
+  ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/.." && pwd))"
+  CHANGELOG="$ROOT_DIR/CHANGELOG.md"
+fi
+
+[ -f "$CHANGELOG" ] || { echo "changelog removals: FAIL — file not found: $CHANGELOG" >&2; exit 1; }
+
+bt='`'
+# A compliant bullet: "- `<path>`..." with no space/backtick inside the token.
+compliant_re="^- ${bt}[^${bt} ]+${bt}"
+
+errors=0
+in_removed=0
+lineno=0
+
+while IFS= read -r line || [ -n "$line" ]; do
+  lineno=$((lineno + 1))
+  case "$line" in
+    "### Removed"*) in_removed=1; continue ;;
+    "### "*)        in_removed=0; continue ;;   # any other ### subsection ends the block
+    "## "*)         in_removed=0; continue ;;   # next version ends the block
+  esac
+  [ "$in_removed" -eq 1 ] || continue
+  # Only top-level bullets are validated; blank lines and prose are ignored.
+  case "$line" in
+    "- "*)
+      if ! [[ "$line" =~ $compliant_re ]]; then
+        echo "changelog removals: FAIL — bullet does not lead with a backticked path (line $lineno): $line" >&2
+        errors=$((errors + 1))
+      fi
+      ;;
+  esac
+done < "$CHANGELOG"
+
+if [ "$errors" -gt 0 ]; then
+  echo "changelog removals: FAIL ($errors problem(s))" >&2
+  exit 1
+fi
+
+echo "changelog removals: OK"

--- a/scripts/check-manifest.sh
+++ b/scripts/check-manifest.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Manifest integrity check for install-manifest.json.
+#
+# Validates the product/factory boundary against the repository's git-tracked
+# files. The boundary is the source of truth for what the installer copies into
+# a target repo (product) and what it must never copy (factory). This check
+# guarantees the boundary stays honest as the repo changes:
+#
+#   1. Existence  — every path listed in the manifest exists on disk.
+#   2. Non-overlap — no path is claimed by more than one category.
+#   3. Coverage   — every git-tracked file is classified by exactly one category
+#                   (zero = unclassified new file; >1 = ambiguous/overlapping).
+#
+# Universe is git-tracked files only; untracked artifacts (telemetry/, .envrc,
+# .DS_Store) are out of scope by design, since the boundary governs what ships.
+#
+# Categories: product (union of every profile's shared + per-tool paths),
+# authored_in_target, and factory_only. lite entry_filenames are target
+# filenames the installer generates, not source paths, so they are not checked.
+set -eu
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+MANIFEST="$ROOT_DIR/install-manifest.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "manifest integrity: SKIPPED (jq not available)" >&2
+  exit 0
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "manifest integrity: FAIL — $MANIFEST not found" >&2
+  exit 1
+fi
+
+# --- read the three category lists from the manifest ---
+product_paths=()
+while IFS= read -r p; do [ -n "$p" ] && product_paths+=("$p"); done < <(
+  jq -r '[.profiles[].shared[]?, .profiles[].tools[]?[]?] | unique[]' "$MANIFEST"
+)
+authored_paths=()
+while IFS= read -r p; do [ -n "$p" ] && authored_paths+=("$p"); done < <(
+  jq -r '.authored_in_target[]?' "$MANIFEST"
+)
+factory_paths=()
+while IFS= read -r p; do [ -n "$p" ] && factory_paths+=("$p"); done < <(
+  jq -r '.factory_only[]?' "$MANIFEST"
+)
+
+errors=0
+
+# matches PATH_ENTRY against tracked file F.
+# Directory entries end with '/' and match by prefix; file entries match exactly.
+path_matches() {
+  local entry="$1" file="$2"
+  case "$entry" in
+    */) [ "${file#"$entry"}" != "$file" ] ;;   # file starts with dir prefix
+    *)  [ "$file" = "$entry" ] ;;
+  esac
+}
+
+# --- 1. existence ---
+for entry in "${product_paths[@]}" "${authored_paths[@]}" "${factory_paths[@]}"; do
+  stripped="${entry%/}"
+  if [ ! -e "$ROOT_DIR/$stripped" ]; then
+    echo "manifest integrity: FAIL — listed path does not exist: $entry" >&2
+    errors=$((errors + 1))
+  fi
+done
+
+# --- 2. non-overlap: no entry appears in more than one category ---
+# Build a combined "path<TAB>category" list and look for any path in 2+ categories.
+combined="$(
+  { for p in "${product_paths[@]:-}";  do [ -n "$p" ] && printf '%s\tproduct\n'  "${p%/}"; done
+    for p in "${authored_paths[@]:-}"; do [ -n "$p" ] && printf '%s\tauthored\n' "${p%/}"; done
+    for p in "${factory_paths[@]:-}";  do [ -n "$p" ] && printf '%s\tfactory\n'  "${p%/}"; done
+  } | sort
+)"
+dupes="$(printf '%s\n' "$combined" | cut -f1 | sort | uniq -d)"
+if [ -n "$dupes" ]; then
+  while IFS= read -r d; do
+    [ -z "$d" ] && continue
+    cats="$(printf '%s\n' "$combined" | awk -F'\t' -v p="$d" '$1==p {print $2}' | paste -sd, -)"
+    echo "manifest integrity: FAIL — path claimed by multiple categories ($cats): $d" >&2
+    errors=$((errors + 1))
+  done <<EOF
+$dupes
+EOF
+fi
+
+# --- 3. coverage: every tracked file classified by exactly one category ---
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  count=0
+  for entry in "${product_paths[@]}" "${authored_paths[@]}" "${factory_paths[@]}"; do
+    if path_matches "$entry" "$f"; then
+      count=$((count + 1))
+    fi
+  done
+  if [ "$count" -eq 0 ]; then
+    echo "manifest integrity: FAIL — tracked file is unclassified: $f" >&2
+    errors=$((errors + 1))
+  elif [ "$count" -gt 1 ]; then
+    echo "manifest integrity: FAIL — tracked file matched by $count categories: $f" >&2
+    errors=$((errors + 1))
+  fi
+done < <(git -C "$ROOT_DIR" ls-files)
+
+if [ "$errors" -gt 0 ]; then
+  echo "manifest integrity: FAIL ($errors problem(s))" >&2
+  exit 1
+fi
+
+echo "manifest integrity: OK"

--- a/scripts/classify.sh
+++ b/scripts/classify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Print the product/factory classification straight from install-manifest.json.
+#
+# install-manifest.json is the single source of truth for the boundary; this is
+# a human-readable view of it. scripts/check-manifest.sh guarantees the manifest
+# classifies every git-tracked file, so this listing can never silently omit one.
+set -eu
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/.." && pwd))"
+MANIFEST="$ROOT_DIR/install-manifest.json"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+[ -f "$MANIFEST" ] || { echo "error: manifest not found: $MANIFEST" >&2; exit 1; }
+
+echo "Source of truth: install-manifest.json (validated by scripts/check-manifest.sh)"
+echo
+
+echo "PRODUCT — copied into a target repo on install"
+echo "  full profile, shared (every tool):"
+jq -r '.profiles.full.shared[] | "    " + .' "$MANIFEST"
+for t in $(jq -r '.profiles.full.tools | keys[]' "$MANIFEST"); do
+  printf '  full profile, %s:\n' "$t"
+  jq -r --arg t "$t" '.profiles.full.tools[$t][] | "    " + .' "$MANIFEST"
+done
+echo "  lite profile:"
+jq -r '.profiles.lite.shared[] | "    " + .' "$MANIFEST"
+echo
+
+echo "AUTHORED IN TARGET — created fresh per target, never copied"
+jq -r '.authored_in_target[] | "  " + .' "$MANIFEST"
+echo
+
+echo "FACTORY — this repo's own machinery, never installed"
+jq -r '.factory_only[] | "  " + .' "$MANIFEST"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Install the AI coding workflow into a target repository.
+#
+#   scripts/install.sh --target <dir> --tool <claude|codex|gemini|copilot> [--profile full|lite] [--source <dir>]
+#
+# Copies the product file set for the chosen tool and profile into the target
+# repo, records the vendored files in the target's .gitignore (the governance
+# files are a local vendored copy, not committed into the target's history),
+# and installs the git hooks. The product/factory boundary comes from
+# install-manifest.json; only git-tracked files are copied, so source-side
+# runtime state (.ai-policy/state/, .claude/*.lock) never ships.
+#
+# project-context.md is NOT created here: it is authored in the target by the
+# aiw-project-context-management skill, since it must describe the target repo.
+#
+# Update of an already-installed copy is a separate path (see --update, added
+# in a later phase); this script performs a fresh install.
+set -eu
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh --target <dir> --tool <name> [--profile full|lite] [--source <dir>]
+
+  --target <dir>    Repository to install into (must be a git work tree). Required.
+  --tool <name>     One of: claude, codex, gemini, copilot. Required.
+  --profile <name>  full (default) or lite.
+  --source <dir>    Workflow source repo. Defaults to the repo containing this script.
+USAGE
+}
+
+SOURCE=""
+TARGET=""
+TOOL=""
+PROFILE="full"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="${2:-}"; shift 2 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --tool) TOOL="${2:-}"; shift 2 ;;
+    --profile) PROFILE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$SOURCE" ]; then
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  SOURCE="$(cd "$script_dir/.." && pwd)"
+fi
+
+[ -n "$TARGET" ] || { echo "error: --target is required" >&2; usage >&2; exit 2; }
+case "$TOOL" in
+  claude|codex|gemini|copilot) ;;
+  *) echo "error: --tool must be one of claude, codex, gemini, copilot" >&2; exit 2 ;;
+esac
+case "$PROFILE" in
+  full|lite) ;;
+  *) echo "error: --profile must be full or lite" >&2; exit 2 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+
+MANIFEST="$SOURCE/install-manifest.json"
+[ -f "$MANIFEST" ] || { echo "error: manifest not found at $MANIFEST" >&2; exit 1; }
+
+git -C "$SOURCE" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || { echo "error: source is not a git work tree: $SOURCE" >&2; exit 1; }
+[ -d "$TARGET" ] || { echo "error: target directory does not exist: $TARGET" >&2; exit 1; }
+git -C "$TARGET" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || { echo "error: target is not a git repo (run 'git init' there first): $TARGET" >&2; exit 1; }
+
+SOURCE="$(cd "$SOURCE" && git rev-parse --show-toplevel)"
+TARGET="$(cd "$TARGET" && git rev-parse --show-toplevel)"
+
+# Copy every git-tracked file under a product path, preserving structure.
+copy_tracked() {
+  local pathspec="${1%/}" f
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    mkdir -p "$TARGET/$(dirname "$f")"
+    cp "$SOURCE/$f" "$TARGET/$f"
+  done < <(git -C "$SOURCE" ls-files -- "$pathspec")
+}
+
+# Rewrite the installer-managed block in the target .gitignore (idempotent).
+write_gitignore_block() {
+  local gi="$TARGET/.gitignore"
+  local begin="# >>> ai-workflow (vendored, managed by installer) >>>"
+  local end="# <<< ai-workflow <<<"
+  touch "$gi"
+  if grep -qF "$begin" "$gi"; then
+    awk -v b="$begin" -v e="$end" '
+      $0==b {skip=1}
+      skip==0 {print}
+      $0==e {skip=0}
+    ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
+  fi
+  if [ -s "$gi" ] && [ -n "$(tail -c1 "$gi" 2>/dev/null)" ]; then
+    printf '\n' >> "$gi"
+  fi
+  {
+    printf '%s\n' "$begin"
+    local p
+    for p in "$@"; do printf '%s\n' "$p"; done
+    printf '%s\n' "$end"
+  } >> "$gi"
+}
+
+ignore_paths=()
+
+if [ "$PROFILE" = "full" ]; then
+  product_paths=()
+  while IFS= read -r p; do [ -n "$p" ] && product_paths+=("$p"); done < <(
+    jq -r --arg t "$TOOL" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$MANIFEST"
+  )
+  for p in "${product_paths[@]}"; do
+    copy_tracked "$p"
+  done
+  ignore_paths=("${product_paths[@]}")
+
+  # Install git hooks in the target (policy layer ships only with the full profile).
+  ( cd "$TARGET" \
+      && git config core.hooksPath .githooks \
+      && chmod +x .githooks/* 2>/dev/null \
+      && chmod +x .ai-policy/scripts/*.sh 2>/dev/null ) || true
+else
+  # lite: a single self-contained file plus a generated entry pointer.
+  mkdir -p "$TARGET"
+  cp "$SOURCE/lite-monolithic/ai-workflow.md" "$TARGET/ai-workflow.md"
+  entry="$(jq -r --arg t "$TOOL" '.profiles.lite.entry_filenames[$t]' "$MANIFEST")"
+  mkdir -p "$TARGET/$(dirname "$entry")"
+  cat > "$TARGET/$entry" <<'ENTRY'
+# AI Coding Workflow (lite)
+
+Read `ai-workflow.md` at the repository root and follow the workflow it defines
+for every task. The human reviews and approves at the checkpoints it describes.
+ENTRY
+  ignore_paths=("ai-workflow.md" "$entry")
+fi
+
+write_gitignore_block "${ignore_paths[@]}"
+
+echo "Installed AI workflow (profile: $PROFILE, tool: $TOOL) into $TARGET"
+echo "Vendored files recorded in $TARGET/.gitignore"
+if [ "$PROFILE" = "full" ]; then
+  echo "Git hooks installed (core.hooksPath = .githooks)"
+fi
+echo "Next: author project-context.md in the target via the aiw-project-context-management skill."

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -33,6 +33,11 @@ if [ -x ./scripts/check-manifest.sh ]; then
   ./scripts/check-manifest.sh
 fi
 
+# --- install: sandbox test of the installer against throwaway target repos ---
+if [ -x ./scripts/test-install.sh ]; then
+  ./scripts/test-install.sh
+fi
+
 # --- parser regression test: guards the one place the transcript format lives ---
 if command -v python3 >/dev/null 2>&1 && [ -f ./observation/test_parse.py ]; then
   python3 ./observation/test_parse.py

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -38,6 +38,14 @@ if [ -x ./scripts/test-install.sh ]; then
   ./scripts/test-install.sh
 fi
 
+# --- changelog removals: enforce the leading-path convention (factory-only) ---
+if [ -x ./scripts/check-changelog-removals.sh ]; then
+  ./scripts/check-changelog-removals.sh
+fi
+if [ -x ./scripts/test-changelog-removals.sh ]; then
+  ./scripts/test-changelog-removals.sh
+fi
+
 # --- parser regression test: guards the one place the transcript format lives ---
 if command -v python3 >/dev/null 2>&1 && [ -f ./observation/test_parse.py ]; then
   python3 ./observation/test_parse.py

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -28,6 +28,11 @@ if command -v python3 >/dev/null 2>&1; then
   fi
 fi
 
+# --- manifest integrity: the product/factory boundary must stay honest ---
+if [ -x ./scripts/check-manifest.sh ]; then
+  ./scripts/check-manifest.sh
+fi
+
 # --- parser regression test: guards the one place the transcript format lives ---
 if command -v python3 >/dev/null 2>&1 && [ -f ./observation/test_parse.py ]; then
   python3 ./observation/test_parse.py

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -46,6 +46,11 @@ if [ -x ./scripts/test-changelog-removals.sh ]; then
   ./scripts/test-changelog-removals.sh
 fi
 
+# --- update: sandbox test of the update path against a real historical version pair ---
+if [ -x ./scripts/test-update.sh ]; then
+  ./scripts/test-update.sh
+fi
+
 # --- parser regression test: guards the one place the transcript format lives ---
 if command -v python3 >/dev/null 2>&1 && [ -f ./observation/test_parse.py ]; then
   python3 ./observation/test_parse.py

--- a/scripts/test-changelog-removals.sh
+++ b/scripts/test-changelog-removals.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-changelog-removals.sh.
+set -u
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK="$ROOT_DIR/scripts/check-changelog-removals.sh"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+TMP="$(mktemp -d 2>/dev/null || mktemp -d -t aiw-clog)"
+trap 'rm -rf "$TMP"' EXIT
+
+# 1. Compliant: every Removed bullet leads with a backticked path; Added bullets are ignored.
+cat > "$TMP/good.md" <<'MD'
+# Changelog
+
+## 1.0.0
+
+### Removed
+
+- `foo/bar.sh` — gone
+- `baz/` — whole dir gone
+
+### Added
+
+- a feature described in prose, not a path
+MD
+if "$CHECK" "$TMP/good.md" >/dev/null 2>&1; then ok "compliant changelog passes"; else bad "compliant changelog should pass"; fi
+
+# 2. Non-compliant: a Removed bullet that does not lead with a path.
+cat > "$TMP/bad.md" <<'MD'
+# Changelog
+
+## 1.0.0
+
+### Removed
+
+- The thing in `foo/bar.sh` was removed
+MD
+if "$CHECK" "$TMP/bad.md" >/dev/null 2>&1; then bad "non-compliant changelog should fail"; else ok "non-compliant changelog fails"; fi
+
+# 3. Non-compliant only outside Removed must still pass (scope is Removed-only).
+cat > "$TMP/scope.md" <<'MD'
+# Changelog
+
+## 1.0.0
+
+### Changed
+
+- reworded a prose bullet, not a path
+
+### Removed
+
+- `x/y.sh` — gone
+MD
+if "$CHECK" "$TMP/scope.md" >/dev/null 2>&1; then ok "non-path bullets outside Removed are ignored"; else bad "should ignore bullets outside Removed"; fi
+
+# 4. Regression: this repo's real CHANGELOG.md complies.
+if "$CHECK" "$ROOT_DIR/CHANGELOG.md" >/dev/null 2>&1; then ok "real CHANGELOG.md complies"; else bad "real CHANGELOG.md does not comply"; fi
+
+echo
+echo "Results: $pass passed, $fail failed."
+[ "$fail" -eq 0 ]

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Sandbox test for scripts/install.sh.
+#
+# Installs into throwaway git repos under a temp dir and asserts the product
+# set lands, factory files do not, the target .gitignore records the vendored
+# files, hooks are wired for the full profile, and the install is idempotent.
+set -u
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL="$ROOT_DIR/scripts/install.sh"
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad()  { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+present() { if [ -e "$1/$2" ]; then ok "present: $2"; else bad "missing: $2"; fi; }
+absent()  { if [ -e "$1/$2" ]; then bad "should be absent: $2"; else ok "absent: $2"; fi; }
+has_line() { if grep -qF "$2" "$1/.gitignore" 2>/dev/null; then ok ".gitignore has $2"; else bad ".gitignore missing $2"; fi; }
+
+SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t aiw-install)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+new_target() {
+  local d="$SANDBOX/$1"
+  mkdir -p "$d"
+  ( cd "$d" && git init -q && git config user.email t@t && git config user.name t ) >/dev/null 2>&1
+  echo "$d"
+}
+
+echo "full / claude:"
+T="$(new_target full-claude)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "install exited non-zero"
+present "$T" CLAUDE.md
+present "$T" .claude/settings.json
+present "$T" .claude/skills
+present "$T" ai-workflow.md
+present "$T" .ai-policy/scripts/install-hooks.sh
+present "$T" .githooks
+absent  "$T" AGENTS.md
+absent  "$T" .codex
+absent  "$T" .gemini
+absent  "$T" .vscode
+absent  "$T" .agents
+absent  "$T" observation
+absent  "$T" CHANGELOG.md
+absent  "$T" README.md
+absent  "$T" install-manifest.json
+absent  "$T" project-context.md
+absent  "$T" .ai-policy/state/validation.status
+has_line "$T" "CLAUDE.md"
+has_line "$T" ".claude/"
+has_line "$T" ".ai-policy/"
+has_line "$T" ".githooks/"
+has_line "$T" "ai-workflow.md"
+hp="$(cd "$T" && git config core.hooksPath || true)"
+if [ "$hp" = ".githooks" ]; then ok "core.hooksPath set"; else bad "core.hooksPath not set (got '$hp')"; fi
+
+echo "idempotency (re-run):"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+n="$(grep -cF "# >>> ai-workflow (vendored, managed by installer) >>>" "$T/.gitignore")"
+if [ "$n" -eq 1 ]; then ok "single managed block after re-run"; else bad "managed block count = $n"; fi
+
+echo "full / codex (tool specificity):"
+T="$(new_target full-codex)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool codex --profile full >/dev/null 2>&1
+present "$T" AGENTS.md
+present "$T" .codex/config.toml
+present "$T" .agents/skills
+absent  "$T" CLAUDE.md
+absent  "$T" .claude
+
+echo "full / gemini (tool specificity):"
+T="$(new_target full-gemini)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1
+present "$T" GEMINI.md
+present "$T" .gemini/settings.json
+present "$T" .agents/skills
+absent  "$T" CLAUDE.md
+absent  "$T" .codex
+
+echo "full / copilot (tool specificity):"
+T="$(new_target full-copilot)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool copilot --profile full >/dev/null 2>&1
+present "$T" .github/copilot-instructions.md
+present "$T" .github/hooks/block-protected-branch.json
+present "$T" .vscode/settings.json
+present "$T" .agents/skills
+absent  "$T" CLAUDE.md
+absent  "$T" GEMINI.md
+
+echo "lite / claude:"
+T="$(new_target lite-claude)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1
+present "$T" ai-workflow.md
+present "$T" CLAUDE.md
+absent  "$T" .ai-policy
+absent  "$T" .githooks
+absent  "$T" .claude
+if grep -qF "self-contained" "$T/ai-workflow.md"; then ok "lite workflow content copied"; else bad "lite workflow content wrong"; fi
+has_line "$T" "ai-workflow.md"
+has_line "$T" "CLAUDE.md"
+hp="$(cd "$T" && git config core.hooksPath || true)"
+if [ -z "$hp" ]; then ok "no hooks for lite"; else bad "lite should not set hooks (got '$hp')"; fi
+
+echo
+echo "Results: $pass passed, $fail failed."
+[ "$fail" -eq 0 ]

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Sandbox test for scripts/update.sh.
+#
+# Uses real ground truth: the removed paths come from this repo's real
+# CHANGELOG `### Removed` entries, and the version range spans the real 2.15.0
+# and 3.3.0 removals. Asserts genuinely-removed product files are deleted, a
+# named-but-still-product file is kept, and a local addition survives.
+set -u
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL="$ROOT_DIR/scripts/install.sh"
+UPDATE="$ROOT_DIR/scripts/update.sh"
+SRC_VERSION="$(awk '/^Version:[[:space:]]*/ {print $2; exit}' "$ROOT_DIR/ai-workflow.md")"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+present() { if [ -e "$1/$2" ]; then ok "kept: $2"; else bad "should be kept: $2"; fi; }
+absent()  { if [ -e "$1/$2" ]; then bad "should be removed: $2"; else ok "removed: $2"; fi; }
+
+SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t aiw-update)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+new_target() {
+  local d="$SANDBOX/$1"; mkdir -p "$d"
+  ( cd "$d" && git init -q && git config user.email t@t && git config user.name t ) >/dev/null 2>&1
+  echo "$d"
+}
+set_version() {
+  local f="$1" v="$2" tmp; tmp="$(mktemp)"
+  awk -v v="$v" '!d && /^Version:[[:space:]]/ {print "Version: " v; d=1; next} {print}' "$f" > "$tmp" && mv "$tmp" "$f"
+}
+
+echo "real-history update (installed 2.14.0 -> $SRC_VERSION):"
+T="$(new_target hist)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+set_version "$T/ai-workflow.md" 2.14.0
+# stale product files that 3.3.0 removed (real removed paths):
+mkdir -p "$T/.claude/skills/aiw-evaluation";     echo stale > "$T/.claude/skills/aiw-evaluation/SKILL.md"
+mkdir -p "$T/.claude/skills/aiw-telemetry-setup"; echo stale > "$T/.claude/skills/aiw-telemetry-setup/SKILL.md"
+echo stale > "$T/.ai-policy/scripts/update-session-tags.sh"
+# a genuine local addition under a vendored path:
+mkdir -p "$T/.claude/skills/my-local-skill";      echo mine > "$T/.claude/skills/my-local-skill/SKILL.md"
+
+"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "update exited non-zero"
+
+absent  "$T" .claude/skills/aiw-evaluation
+absent  "$T" .claude/skills/aiw-telemetry-setup
+absent  "$T" .ai-policy/scripts/update-session-tags.sh
+present "$T" .claude/skills/my-local-skill/SKILL.md
+present "$T" .ai-policy/scripts/project-validation.sh
+v="$(awk '/^Version:[[:space:]]*/ {print $2; exit}' "$T/ai-workflow.md")"
+if [ "$v" = "$SRC_VERSION" ]; then ok "version bumped to $SRC_VERSION"; else bad "version is '$v', expected $SRC_VERSION"; fi
+
+echo "already up-to-date (no-op):"
+T="$(new_target current)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+mkdir -p "$T/.claude/skills/my-local-skill"; echo mine > "$T/.claude/skills/my-local-skill/SKILL.md"
+"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+ec=$?
+if [ "$ec" -eq 0 ]; then ok "up-to-date update exits 0"; else bad "up-to-date update exit=$ec"; fi
+present "$T" .claude/skills/my-local-skill/SKILL.md
+present "$T" CLAUDE.md
+
+echo "refuse downgrade (target ahead):"
+T="$(new_target ahead)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+set_version "$T/ai-workflow.md" 99.0.0
+"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+if [ "$?" -ne 0 ]; then ok "refuses to downgrade"; else bad "should refuse downgrade"; fi
+present "$T" ai-workflow.md
+
+echo "lite update:"
+T="$(new_target lite)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1
+set_version "$T/ai-workflow.md" 2.14.0
+"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1 || bad "lite update exited non-zero"
+present "$T" ai-workflow.md
+present "$T" CLAUDE.md
+
+echo
+echo "Results: $pass passed, $fail failed."
+[ "$fail" -eq 0 ]

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -70,11 +70,26 @@ set_version "$T/ai-workflow.md" 99.0.0
 if [ "$?" -ne 0 ]; then ok "refuses to downgrade"; else bad "should refuse downgrade"; fi
 present "$T" ai-workflow.md
 
-echo "lite update:"
+echo "auto-detect tool and profile (full/claude):"
+T="$(new_target detect)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+set_version "$T/ai-workflow.md" 2.14.0
+"$UPDATE" --source "$ROOT_DIR" --target "$T" >/dev/null 2>&1 || bad "auto-detect update exited non-zero"
+v="$(awk '/^Version:[[:space:]]*/ {print $2; exit}' "$T/ai-workflow.md")"
+if [ "$v" = "$SRC_VERSION" ]; then ok "auto-detected full/claude and updated"; else bad "auto-detect failed (v=$v)"; fi
+
+echo "ambiguous tool requires --tool:"
+T="$(new_target ambig)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+touch "$T/AGENTS.md"
+"$UPDATE" --source "$ROOT_DIR" --target "$T" >/dev/null 2>&1
+if [ "$?" -ne 0 ]; then ok "ambiguous tool errors without --tool"; else bad "should error on ambiguous tool"; fi
+
+echo "lite update (auto-detected):"
 T="$(new_target lite)"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1
 set_version "$T/ai-workflow.md" 2.14.0
-"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1 || bad "lite update exited non-zero"
+"$UPDATE" --source "$ROOT_DIR" --target "$T" >/dev/null 2>&1 || bad "lite update exited non-zero"
 present "$T" ai-workflow.md
 present "$T" CLAUDE.md
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Update an already-installed AI workflow copy in a target repository.
+#
+#   scripts/update.sh --target <dir> --tool <name> [--profile full|lite] [--source <dir>]
+#
+# Reconciles an installed (vendored) copy to the source's current version:
+#   1. Reads the installed version (target ai-workflow.md `Version:`) and the
+#      source version; refuses to downgrade and no-ops if already current.
+#   2. Re-copies the current product set (adds new, overwrites changed) by
+#      delegating to install.sh.
+#   3. Removes files the source dropped between the two versions, learned from
+#      the source CHANGELOG `### Removed` entries (leading-path convention).
+#      A file is deleted only if it is BOTH named as removed AND absent from the
+#      current product set; files under vendored paths that are not in the
+#      current product and not named as removed are kept (local additions).
+#
+# The source CHANGELOG is read from the source repo (factory). The target's own
+# changelog is never touched.
+set -eu
+
+SOURCE=""
+TARGET=""
+TOOL=""
+PROFILE="full"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="${2:-}"; shift 2 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --tool) TOOL="${2:-}"; shift 2 ;;
+    --profile) PROFILE="${2:-}"; shift 2 ;;
+    -h|--help) echo "Usage: update.sh --target <dir> --tool <name> [--profile full|lite] [--source <dir>]"; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+[ -n "$SOURCE" ] || SOURCE="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+[ -n "$TARGET" ] || { echo "error: --target is required" >&2; exit 2; }
+case "$TOOL" in claude|codex|gemini|copilot) ;; *) echo "error: --tool must be claude|codex|gemini|copilot" >&2; exit 2 ;; esac
+case "$PROFILE" in full|lite) ;; *) echo "error: --profile must be full or lite" >&2; exit 2 ;; esac
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+
+MANIFEST="$SOURCE/install-manifest.json"
+[ -f "$MANIFEST" ] || { echo "error: manifest not found at $MANIFEST" >&2; exit 1; }
+git -C "$SOURCE" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: source is not a git work tree: $SOURCE" >&2; exit 1; }
+git -C "$TARGET" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: target is not a git repo: $TARGET" >&2; exit 1; }
+SOURCE="$(cd "$SOURCE" && git rev-parse --show-toplevel)"
+TARGET="$(cd "$TARGET" && git rev-parse --show-toplevel)"
+
+read_version() { awk '/^Version:[[:space:]]*/ { print $2; exit }' "$1" 2>/dev/null; }
+
+[ -f "$TARGET/ai-workflow.md" ] || { echo "error: no installed workflow found in target (ai-workflow.md missing); use install.sh" >&2; exit 1; }
+installed_version="$(read_version "$TARGET/ai-workflow.md")"
+source_version="$(read_version "$SOURCE/ai-workflow.md")"
+[ -n "$installed_version" ] || { echo "error: target ai-workflow.md has no Version header" >&2; exit 1; }
+[ -n "$source_version" ] || { echo "error: source ai-workflow.md has no Version header" >&2; exit 1; }
+
+# --- version comparison (semver-ish, via sort -V) ---
+ver_le() { [ "$1" = "$2" ] || [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]; }
+ver_lt() { [ "$1" != "$2" ] && ver_le "$1" "$2"; }
+
+if [ "$installed_version" = "$source_version" ]; then
+  echo "Target already at $source_version. Re-syncing product files."
+elif ver_lt "$source_version" "$installed_version"; then
+  echo "Refusing to update: target is ahead (installed $installed_version > source $source_version)." >&2
+  exit 1
+else
+  echo "Updating target from $installed_version to $source_version."
+fi
+
+# --- additive: re-copy the current product set (overwrites changed, adds new) ---
+"$SCRIPT_DIR/install.sh" --source "$SOURCE" --target "$TARGET" --tool "$TOOL" --profile "$PROFILE" >/dev/null \
+  || { echo "error: re-copy step failed" >&2; exit 1; }
+
+# --- removal reconciliation (full profile; lite is a single file with nothing to reconcile) ---
+removed_count=0
+if [ "$PROFILE" = "full" ]; then
+  current_product="$(mktemp)"
+  trap 'rm -f "$current_product"' EXIT
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    git -C "$SOURCE" ls-files -- "${p%/}" >> "$current_product"
+  done < <(jq -r --arg t "$TOOL" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$MANIFEST")
+
+  in_range() { # version, installed, source : installed < version <= source
+    ver_lt "$2" "$1" && ver_le "$1" "$3"
+  }
+
+  # Collect removed paths named in CHANGELOG for versions in (installed, source].
+  removed_paths="$(
+    awk '
+      /^## /      { match($0, /[0-9][0-9.]*/); ver=substr($0,RSTART,RLENGTH); inrem=0; next }
+      /^### Removed/ { inrem=1; next }
+      /^### /     { inrem=0; next }
+      inrem==1 && /^- `/ {
+        s=$0; sub(/^- `/,"",s); sub(/`.*/,"",s); print ver "\t" s
+      }
+    ' "$SOURCE/CHANGELOG.md"
+  )"
+
+  while IFS=$'\t' read -r ver rp; do
+    [ -z "${ver:-}" ] && continue
+    in_range "$ver" "$installed_version" "$source_version" || continue
+    rp_stripped="${rp%/}"
+    case "$rp" in
+      */)  # directory removal: delete target files under it that are not current product
+        if [ -d "$TARGET/$rp_stripped" ]; then
+          while IFS= read -r f; do
+            rel="${f#"$TARGET"/}"
+            if ! grep -Fxq "$rel" "$current_product"; then
+              rm -f "$f"; removed_count=$((removed_count + 1)); echo "  removed: $rel"
+            fi
+          done < <(find "$TARGET/$rp_stripped" -type f 2>/dev/null)
+          find "$TARGET/$rp_stripped" -type d -empty -delete 2>/dev/null || true
+        fi
+        ;;
+      *)   # file removal
+        if [ -e "$TARGET/$rp_stripped" ] && ! grep -Fxq "$rp_stripped" "$current_product"; then
+          rm -f "$TARGET/$rp_stripped"; removed_count=$((removed_count + 1)); echo "  removed: $rp_stripped"
+        fi
+        ;;
+    esac
+  done <<EOF
+$removed_paths
+EOF
+fi
+
+echo "Update complete: target now at $source_version (profile: $PROFILE, tool: $TOOL); $removed_count file(s) removed."
+echo "Local additions under vendored paths were left in place."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -21,7 +21,7 @@ set -eu
 SOURCE=""
 TARGET=""
 TOOL=""
-PROFILE="full"
+PROFILE=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -38,8 +38,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 [ -n "$SOURCE" ] || SOURCE="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 [ -n "$TARGET" ] || { echo "error: --target is required" >&2; exit 2; }
-case "$TOOL" in claude|codex|gemini|copilot) ;; *) echo "error: --tool must be claude|codex|gemini|copilot" >&2; exit 2 ;; esac
-case "$PROFILE" in full|lite) ;; *) echo "error: --profile must be full or lite" >&2; exit 2 ;; esac
 
 command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
 
@@ -53,6 +51,27 @@ TARGET="$(cd "$TARGET" && git rev-parse --show-toplevel)"
 read_version() { awk '/^Version:[[:space:]]*/ { print $2; exit }' "$1" 2>/dev/null; }
 
 [ -f "$TARGET/ai-workflow.md" ] || { echo "error: no installed workflow found in target (ai-workflow.md missing); use install.sh" >&2; exit 1; }
+
+# Auto-detect tool and profile from the installed target when not given.
+if [ -z "$PROFILE" ]; then
+  if [ -d "$TARGET/.ai-policy" ]; then PROFILE="full"; else PROFILE="lite"; fi
+fi
+if [ -z "$TOOL" ]; then
+  detected=""
+  [ -f "$TARGET/CLAUDE.md" ] && detected="$detected claude"
+  [ -f "$TARGET/AGENTS.md" ] && detected="$detected codex"
+  [ -f "$TARGET/GEMINI.md" ] && detected="$detected gemini"
+  [ -f "$TARGET/.github/copilot-instructions.md" ] && detected="$detected copilot"
+  detected="$(echo $detected | xargs)"
+  case "$detected" in
+    "")     echo "error: could not detect installed tool; pass --tool" >&2; exit 2 ;;
+    *" "*)  echo "error: multiple tools installed ($detected); pass --tool to choose" >&2; exit 2 ;;
+    *)      TOOL="$detected" ;;
+  esac
+fi
+case "$TOOL" in claude|codex|gemini|copilot) ;; *) echo "error: --tool must be claude|codex|gemini|copilot" >&2; exit 2 ;; esac
+case "$PROFILE" in full|lite) ;; *) echo "error: --profile must be full or lite" >&2; exit 2 ;; esac
+
 installed_version="$(read_version "$TARGET/ai-workflow.md")"
 source_version="$(read_version "$SOURCE/ai-workflow.md")"
 [ -n "$installed_version" ] || { echo "error: target ai-workflow.md has no Version header" >&2; exit 1; }


### PR DESCRIPTION
## Summary

Makes the AI workflow installable and updatable by pointing an agent at this repository (a local path or its URL): the agent reads `INSTALL.md` and runs a deterministic installer, with no hand-copying and no manual `.gitignore` edits. Closes #160.

The work is built on two facts the repo previously did not express: a machine-readable **product/factory boundary**, and a **vendored** install model (governance files gitignored in the target, never committed there).

## What's included

- **`install-manifest.json`** — the product/factory boundary, the single source of truth for what installs vs what stays here. `scripts/check-manifest.sh` proves every git-tracked file is classified; `make classify` / a README "Product vs Factory" section surface it.
- **`scripts/install.sh`** — installs a tool (`claude`/`codex`/`gemini`/`copilot`) and profile (`full`/`lite`) into a target git repo: copies git-tracked product files, writes an idempotent vendored block to the target `.gitignore`, wires hooks (full). Lite copies the single file plus a generated entry.
- **`scripts/update.sh`** — reconciles an installed copy to the current version: version-drift check (refuses downgrade), re-copy of current product, and removal reconciliation that deletes a file only if it is **both** named in the source `CHANGELOG.md` `### Removed` range **and** absent from the current product set. Auto-detects tool/profile.
- **CHANGELOG leading-path convention** — `### Removed` bullets lead with the removed path so the updater can extract them; enforced **factory-only** by `scripts/check-changelog-removals.sh`.
- **`INSTALL.md`** — the agent-actionable entry point (clone-if-URL, ask tool+profile on install, run the scripts, author `project-context.md`).
- README + `lite-monolithic/README.md` rewritten to the agent-driven flow; `project-context.md` updated.
- Factory cleanup: removed the dead `telemetry/` husk and `.envrc` left over from the deleted telemetry stack.

## Design notes

- **Factory-only changelog enforcement.** The leading-path convention is enforced in `scripts/repo-validation.sh` (never shipped), not the shipped `check-changelog.sh` hook, so a target repo's own changelog process is never constrained by this repo's format.
- **No canonical version bump.** Every changed file is factory; the installed workflow's behaviour is byte-for-byte unchanged, so per `design/decisions/maintenance.md` the `ai-workflow.md` version does not bump and no CHANGELOG entry is required. `project-context.md` carries its own bump (1.14.0).

## Testing

- Full validation green, with new sandbox tests wired in: manifest integrity, installer (all four tools, lite, tool-specificity, idempotency, factory-absence), updater (real historical version pair spanning the 2.15.0 and 3.3.0 removals, proving genuine removals delete, named-but-still-product is kept, local additions survive), and the changelog-removals checker.
- Two end-to-end tests with fresh agents (no prior context): a clean install into a sample repo, and an upgrade of a reconstructed real-world `1.0.0` install to current. Both discovered the procedure from `INSTALL.md` unaided and produced correct results.

## Known follow-ups (found during end-to-end upgrade testing)

These affect upgrading *old or manually-installed* copies and are limits of the specified CHANGELOG-driven design, not defects in it:

1. **Orphaned legacy skills.** Upgrading from a pre-`aiw-`-prefix install leaves the old un-prefixed skill dirs behind, because the rename was never recorded as a path removal.
2. **`.gitignore` duplication.** A pre-existing manual install's bare vendored entries are not recognised by the installer's managed block, so paths can be listed twice.
