### PR TITLE
Fix installer appending duplicate .gitignore entries (#166)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,13 +89,24 @@ write_gitignore_block() {
   local begin="# >>> ai-workflow (vendored, managed by installer) >>>"
   local end="# <<< ai-workflow <<<"
   touch "$gi"
-  if grep -qF "$begin" "$gi"; then
-    awk -v b="$begin" -v e="$end" '
-      $0==b {skip=1}
-      skip==0 {print}
-      $0==e {skip=0}
-    ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
-  fi
+  # Drop our previous managed block, and also any pre-existing unmarked lines
+  # that exactly match a vendored path (ignoring trailing slashes). The latter
+  # folds entries from an earlier manual install into the managed block instead
+  # of leaving the same path listed twice.
+  local joined; joined="$(printf '%s|' "$@")"
+  awk -v b="$begin" -v e="$end" -v paths="$joined" '
+    BEGIN {
+      n = split(paths, parr, "|")
+      for (i = 1; i <= n; i++) { k = parr[i]; sub(/\/+$/, "", k); if (k != "") drop[k] = 1 }
+    }
+    $0==b {skip=1}
+    skip==0 {
+      key = $0
+      sub(/^[ \t]+/, "", key); sub(/[ \t]+$/, "", key); sub(/\/+$/, "", key)
+      if (!(key in drop)) print
+    }
+    $0==e {skip=0}
+  ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
   if [ -s "$gi" ] && [ -n "$(tail -c1 "$gi" 2>/dev/null)" ]; then
     printf '\n' >> "$gi"
   fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -17,6 +17,7 @@ bad()  { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
 present() { if [ -e "$1/$2" ]; then ok "present: $2"; else bad "missing: $2"; fi; }
 absent()  { if [ -e "$1/$2" ]; then bad "should be absent: $2"; else ok "absent: $2"; fi; }
 has_line() { if grep -qF "$2" "$1/.gitignore" 2>/dev/null; then ok ".gitignore has $2"; else bad ".gitignore missing $2"; fi; }
+exactly_once() { local c; c="$(grep -cxF "$2" "$1/.gitignore" 2>/dev/null || true)"; if [ "${c:-0}" -eq 1 ]; then ok ".gitignore has exactly one '$2'"; else bad ".gitignore has $c '$2' (expected 1)"; fi; }
 
 SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t aiw-install)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -60,6 +61,25 @@ echo "idempotency (re-run):"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
 n="$(grep -cF "# >>> ai-workflow (vendored, managed by installer) >>>" "$T/.gitignore")"
 if [ "$n" -eq 1 ]; then ok "single managed block after re-run"; else bad "managed block count = $n"; fi
+
+echo "pre-existing unmarked .gitignore entries (no duplicates):"
+T="$(new_target preexisting-gitignore)"
+cat > "$T/.gitignore" <<'GI'
+# user's own ignores
+node_modules/
+ai-workflow.md
+.claude/
+.ai-policy
+.githooks/
+CLAUDE.md
+GI
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+exactly_once "$T" "ai-workflow.md"
+exactly_once "$T" ".claude/"
+exactly_once "$T" ".ai-policy/"
+exactly_once "$T" ".githooks/"
+exactly_once "$T" "CLAUDE.md"
+has_line   "$T" "node_modules/"
 
 echo "full / codex (tool specificity):"
 T="$(new_target full-codex)"


### PR DESCRIPTION
Closes #166.

## Problem
`write_gitignore_block` in `scripts/install.sh` stripped and rewrote only its own marked block. Plain unmarked entries for the same vendored paths (from an earlier manual install) were never recognised, so the managed block listed them a second time.

## Fix
The `awk` pass now also drops any pre-existing unmarked line that exactly matches a vendored path (trailing slashes ignored), folding earlier manual entries into the managed block. Unrelated user patterns are preserved.

## Tests
`scripts/test-install.sh` gains a case seeding plain unmarked vendored entries and asserting each vendored path appears exactly once after install, while an unrelated entry (`node_modules/`) survives. Full suite: 55/55.

## Notes
- `scripts/install.sh` is factory tooling (not shipped into targets), so no version bump per the maintenance rule.
- Independent of the other two open PRs; no version/changelog overlap.