### PR TITLE
Reconcile superseded un-prefixed skills on update (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.5.1 - 2026-06-12
+
+### Fixed
+
+- The update path now removes the superseded un-prefixed skill directories left behind when upgrading an install that predates the `aiw-` skill-name prefix. The prefix rename ([#100], [#105]) and the project-spec to project-context rename ([#99], [#107]) were recorded only under `### Changed`, never as removable paths, so the updater treated the old directories as local additions and kept them next to the current `aiw-*` skills. They are now recorded as `### Removed` paths below, so the existing directory-removal reconciliation in `scripts/update.sh` deletes them while still preserving genuine local additions (skill directories with no current-product counterpart) ([#165]).
+
+### Removed
+
+- `.claude/skills/planning/` — superseded by `aiw-planning` in the `aiw-` prefix rename; left behind on upgrades from pre-prefix installs.
+- `.claude/skills/testing/` — superseded by `aiw-testing`.
+- `.claude/skills/failure-analysis/` — superseded by `aiw-failure-analysis`.
+- `.claude/skills/issue-creation/` — superseded by `aiw-issue-creation`.
+- `.claude/skills/project-spec-management/` — superseded by `aiw-project-context-management` (renamed in the project-spec to project-context move).
+- `.claude/skills/logging-and-observability/` — content redistributed into `aiw-verification` and `aiw-failure-analysis`; no standalone skill remains.
+- `.agents/skills/planning/` — superseded by `aiw-planning`.
+- `.agents/skills/testing/` — superseded by `aiw-testing`.
+- `.agents/skills/failure-analysis/` — superseded by `aiw-failure-analysis`.
+- `.agents/skills/issue-creation/` — superseded by `aiw-issue-creation`.
+- `.agents/skills/project-spec-management/` — superseded by `aiw-project-context-management`.
+- `.agents/skills/logging-and-observability/` — content redistributed into `aiw-verification` and `aiw-failure-analysis`.
+
 ## 3.5.0 - 2026-06-11
 
 ### Added
@@ -343,3 +364,5 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#110]: https://github.com/philippe-ths/ai-coding-workflow/issues/110
 [#156]: https://github.com/philippe-ths/ai-coding-workflow/issues/156
 [#155]: https://github.com/philippe-ths/ai-coding-workflow/issues/155
+[#99]: https://github.com/philippe-ths/ai-coding-workflow/issues/99
+[#165]: https://github.com/philippe-ths/ai-coding-workflow/issues/165

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.5.0
+Version: 3.5.1
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -52,6 +52,26 @@ present "$T" .ai-policy/scripts/project-validation.sh
 v="$(awk '/^Version:[[:space:]]*/ {print $2; exit}' "$T/ai-workflow.md")"
 if [ "$v" = "$SRC_VERSION" ]; then ok "version bumped to $SRC_VERSION"; else bad "version is '$v', expected $SRC_VERSION"; fi
 
+echo "pre-prefix update (installed 1.0.0 -> $SRC_VERSION, drops un-prefixed skills):"
+T="$(new_target preprefix)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1
+set_version "$T/ai-workflow.md" 1.0.0
+# simulate the superseded un-prefixed skill dirs an old install left behind:
+for s in planning testing failure-analysis issue-creation project-spec-management logging-and-observability; do
+  mkdir -p "$T/.claude/skills/$s" "$T/.agents/skills/$s"
+  echo old > "$T/.claude/skills/$s/SKILL.md"
+  echo old > "$T/.agents/skills/$s/SKILL.md"
+done
+# a genuine local addition under the same vendored path must survive:
+mkdir -p "$T/.claude/skills/my-local-skill"; echo mine > "$T/.claude/skills/my-local-skill/SKILL.md"
+"$UPDATE" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "pre-prefix update exited non-zero"
+for s in planning testing failure-analysis issue-creation project-spec-management logging-and-observability; do
+  absent "$T" ".claude/skills/$s"
+  absent "$T" ".agents/skills/$s"
+done
+present "$T" .claude/skills/my-local-skill/SKILL.md
+present "$T" .claude/skills/aiw-planning/SKILL.md
+
 echo "already up-to-date (no-op):"
 T="$(new_target current)"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1


### PR DESCRIPTION
Closes #165.

## Problem
Upgrading an install that predates the `aiw-` skill-name prefix left the old un-prefixed skill directories (`.claude/skills/planning`, `failure-analysis`, etc.) in place beside the current `aiw-*` skills. The prefix rename (#100, #105) and the project-spec → project-context rename (#99, #107) were recorded only under `### Changed`, never as removable paths, so the updater treated the old directories as local additions and kept them.

## Fix
Records the twelve superseded directories (six skills × `.claude/skills/` + `.agents/skills/`) as `### Removed` paths under a new `3.5.1` CHANGELOG section, so the existing directory-removal reconciliation in `scripts/update.sh` deletes them. **No `update.sh` code change** — its directory-removal logic already handles this correctly once the paths are recorded. Genuine local additions (no current-product counterpart) are still preserved.

Old skill names sourced from git history (tree before the prefix-rename commit `480dff9`).

## Tests
`scripts/test-update.sh` gains a pre-prefix case (install 1.0.0 → current): asserts the old dirs are dropped and a local addition (`my-local-skill`) survives. Full suite: 29/29.

## Merge coordination
⚠️ This PR and #114 (PR for #114) both bump canonical to `3.5.1` and both add a `## 3.5.1` CHANGELOG section. They cannot both merge clean from the same base. Whoever merges second needs a trivial rebase to renumber to `3.5.2`. `lite-monolithic` header intentionally left at `3.5.0` here (its content drift is owned by #114).