### PR TITLE
Add aiw-prompt-smith skill (#173)

### DIFF
--- a/.agents/skills/aiw-prompt-smith/SKILL.md
+++ b/.agents/skills/aiw-prompt-smith/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: aiw-prompt-smith
+description: Author or repair prompting artifacts, including system prompts, CLAUDE.md, AGENTS.md/AGENT.md files, and other skills. Use when writing any of these from scratch, and especially when one has produced a noticed failure and needs fixing at the cause rather than a narrow patch. Trigger whenever the user is drafting, reviewing, tightening, or debugging a system prompt, a project-instructions file, an agent-instructions file, or a skill, even if they don't say the word "prompt", e.g. "my CLAUDE.md keeps making it do X", "this skill over-triggers", "help me write instructions for the agent", "why does my agent ignore this rule". Prefer this skill over ad-hoc editing whenever the likely fix would otherwise be to just append another rule.
+---
+
+# Prompt Smith
+
+Two jobs, one spine. Use this when **writing** a prompting artifact (system prompt, CLAUDE.md, AGENTS.md/AGENT.md, or another skill) or **repairing** one after it produced a failure you noticed.
+
+The governing idea is **altitude**. Every instruction sits at some level of generality, and most prompt problems are altitude errors. Too low and you write a brittle rule for the one case in front of you, and this is what breeds bloat. Too high and you write something so vague it steers nothing. Aim for the altitude where a competent role or a named concept does the work.
+
+This skill is deliberately small. If your edit makes an artifact longer without making it clearer, you are probably patching the instance, not fixing the class.
+
+## Start here (both modes)
+
+Before writing or editing anything, get three answers. If you are repairing, get a fourth.
+
+1. **Behaviour**: what should the artifact make the model do?
+2. **Failure it prevents**: what goes wrong without this? If nothing, you do not need the instruction.
+3. **One example**: a concrete good-vs-bad pair, ideally an awkward case rather than an easy one.
+4. **(Repair only) Instance or class**: is this a one-off, or a pattern the artifact should handle as a category?
+
+If you cannot answer these, you are not ready to write. Ask, do not guess. A confident wrong instruction costs more than a question.
+
+## Repair mode (a noticed failure)
+
+The default reflex is to append a narrow rule aimed at the exact failure. Resist it. That reflex is what produces prompt bloat, one reasonable-looking line at a time.
+
+- **Diagnose before you edit.** State the underlying cause and classify instance vs class *first*, in words, before touching the text. Reasoning first defeats the reflex patch.
+- **Find the altitude of the fix.** Repair the class the instance belongs to, not the instance. Test any candidate line: *would this still tell the model what to do in a situation you did not foresee?* If not, it is too low, so climb.
+- **Subtraction first.** Before adding anything, look for an existing instruction that is *causing* the failure. Often the fix is removing or rewriting a line, not adding one.
+- **Net-zero, as a forcing question.** Ask "what can come out to make room for this?" You may genuinely need to add, but make addition earn its place instead of being the default.
+
+*Worked repair.* A CLAUDE.md says "always run the tests," and the agent starts running the full suite after every trivial edit. The reflex is to append "but not after comment-only changes", a second rule racing the first. Diagnose instead: the failure is not a missing exception, it is that "always" is the wrong altitude. The instance is "skip tests for comment-only edits"; the class is "the rule over-commands." So the fix is subtraction, not addition: soften the existing line to "run the tests before handing work back." The artifact gets shorter and the behaviour gets righter.
+
+Then apply the shared principles below to whatever you write.
+
+## Write mode (a new artifact)
+
+- **Pull, not push.** A skill is for behaviour that should not live in the always-on system prompt. Keep the always-on footprint tiny and let the skill be pulled in when its description matches. If it belongs in the base prompt, it is not a skill.
+- **One job.** Keep each artifact to a single job and compose several, rather than growing one into a monolith. For a skill, the description header is what triggers it, so write that with the most care.
+- **Trust the model for judgment, constrain it for interfaces.** For anything the model already knows well (a good running coach, clean code, clear writing), name the role or the standard and let its latent knowledge fill in. Do not enumerate every rule the role would follow, because you cannot finish the list, and trying breeds bloat. Specify explicitly only where the model *cannot* know: private facts, exact formats and APIs, current information, safety-critical limits. Delegate the disposition, pin down the interface. This is not licence to under-specify: a vague prompt just inherits the model's bland average.
+
+Then apply the shared principles below.
+
+## Shared principles (both modes)
+
+- **Leading words.** Ground a behaviour in a named concept and reuse that exact phrase at the key steps. A good leading word ("vertical slice", "reason free constrain late", "a good running coach") compresses a paragraph into a term the model already carries, and it surfaces in the model's own reasoning. Check it landed: run the artifact and look for the phrase in the trace. If it is absent, pick a stronger phrase or demonstrate it. Use a leading word a couple of times, not on every line; overused, it is noise again.
+- **Demonstrate, do not just describe.** An adjective leaves room the model fills with its average; an example pins down the hundred small choices the adjective cannot. Show the *hard* case (how the artifact behaves on a refusal, a messy input, being wrong), not the easy one. One good example retires several brittle rules.
+- **Positive framing.** Say what to do, not only what to avoid. "Prefer X" steers better than a pile of "don't"s.
+- **Reason free, constrain late.** If the artifact forces an output format, let the model think in open text first and apply the strict shape at the end. Constraining from the first token starves the reasoning step; even a brief reason alongside the answer recovers most of the loss.
+
+## Before you finish: the elegance check
+
+Read your output once more with fresh eyes:
+
+- Could this be shorter without losing meaning?
+- Is anything a rule that would work better as one example?
+- Did you add without cutting? If so, is the addition really earning its place?
+
+A skill about avoiding bloat that is itself bloated has failed. Hold this one to its own standard.

--- a/.claude/skills/aiw-prompt-smith/SKILL.md
+++ b/.claude/skills/aiw-prompt-smith/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: aiw-prompt-smith
+description: Author or repair prompting artifacts, including system prompts, CLAUDE.md, AGENTS.md/AGENT.md files, and other skills. Use when writing any of these from scratch, and especially when one has produced a noticed failure and needs fixing at the cause rather than a narrow patch. Trigger whenever the user is drafting, reviewing, tightening, or debugging a system prompt, a project-instructions file, an agent-instructions file, or a skill, even if they don't say the word "prompt", e.g. "my CLAUDE.md keeps making it do X", "this skill over-triggers", "help me write instructions for the agent", "why does my agent ignore this rule". Prefer this skill over ad-hoc editing whenever the likely fix would otherwise be to just append another rule.
+---
+
+# Prompt Smith
+
+Two jobs, one spine. Use this when **writing** a prompting artifact (system prompt, CLAUDE.md, AGENTS.md/AGENT.md, or another skill) or **repairing** one after it produced a failure you noticed.
+
+The governing idea is **altitude**. Every instruction sits at some level of generality, and most prompt problems are altitude errors. Too low and you write a brittle rule for the one case in front of you, and this is what breeds bloat. Too high and you write something so vague it steers nothing. Aim for the altitude where a competent role or a named concept does the work.
+
+This skill is deliberately small. If your edit makes an artifact longer without making it clearer, you are probably patching the instance, not fixing the class.
+
+## Start here (both modes)
+
+Before writing or editing anything, get three answers. If you are repairing, get a fourth.
+
+1. **Behaviour**: what should the artifact make the model do?
+2. **Failure it prevents**: what goes wrong without this? If nothing, you do not need the instruction.
+3. **One example**: a concrete good-vs-bad pair, ideally an awkward case rather than an easy one.
+4. **(Repair only) Instance or class**: is this a one-off, or a pattern the artifact should handle as a category?
+
+If you cannot answer these, you are not ready to write. Ask, do not guess. A confident wrong instruction costs more than a question.
+
+## Repair mode (a noticed failure)
+
+The default reflex is to append a narrow rule aimed at the exact failure. Resist it. That reflex is what produces prompt bloat, one reasonable-looking line at a time.
+
+- **Diagnose before you edit.** State the underlying cause and classify instance vs class *first*, in words, before touching the text. Reasoning first defeats the reflex patch.
+- **Find the altitude of the fix.** Repair the class the instance belongs to, not the instance. Test any candidate line: *would this still tell the model what to do in a situation you did not foresee?* If not, it is too low, so climb.
+- **Subtraction first.** Before adding anything, look for an existing instruction that is *causing* the failure. Often the fix is removing or rewriting a line, not adding one.
+- **Net-zero, as a forcing question.** Ask "what can come out to make room for this?" You may genuinely need to add, but make addition earn its place instead of being the default.
+
+*Worked repair.* A CLAUDE.md says "always run the tests," and the agent starts running the full suite after every trivial edit. The reflex is to append "but not after comment-only changes", a second rule racing the first. Diagnose instead: the failure is not a missing exception, it is that "always" is the wrong altitude. The instance is "skip tests for comment-only edits"; the class is "the rule over-commands." So the fix is subtraction, not addition: soften the existing line to "run the tests before handing work back." The artifact gets shorter and the behaviour gets righter.
+
+Then apply the shared principles below to whatever you write.
+
+## Write mode (a new artifact)
+
+- **Pull, not push.** A skill is for behaviour that should not live in the always-on system prompt. Keep the always-on footprint tiny and let the skill be pulled in when its description matches. If it belongs in the base prompt, it is not a skill.
+- **One job.** Keep each artifact to a single job and compose several, rather than growing one into a monolith. For a skill, the description header is what triggers it, so write that with the most care.
+- **Trust the model for judgment, constrain it for interfaces.** For anything the model already knows well (a good running coach, clean code, clear writing), name the role or the standard and let its latent knowledge fill in. Do not enumerate every rule the role would follow, because you cannot finish the list, and trying breeds bloat. Specify explicitly only where the model *cannot* know: private facts, exact formats and APIs, current information, safety-critical limits. Delegate the disposition, pin down the interface. This is not licence to under-specify: a vague prompt just inherits the model's bland average.
+
+Then apply the shared principles below.
+
+## Shared principles (both modes)
+
+- **Leading words.** Ground a behaviour in a named concept and reuse that exact phrase at the key steps. A good leading word ("vertical slice", "reason free constrain late", "a good running coach") compresses a paragraph into a term the model already carries, and it surfaces in the model's own reasoning. Check it landed: run the artifact and look for the phrase in the trace. If it is absent, pick a stronger phrase or demonstrate it. Use a leading word a couple of times, not on every line; overused, it is noise again.
+- **Demonstrate, do not just describe.** An adjective leaves room the model fills with its average; an example pins down the hundred small choices the adjective cannot. Show the *hard* case (how the artifact behaves on a refusal, a messy input, being wrong), not the easy one. One good example retires several brittle rules.
+- **Positive framing.** Say what to do, not only what to avoid. "Prefer X" steers better than a pile of "don't"s.
+- **Reason free, constrain late.** If the artifact forces an output format, let the model think in open text first and apply the strict shape at the end. Constraining from the first token starves the reasoning step; even a brief reason alongside the answer recovers most of the loss.
+
+## Before you finish: the elegance check
+
+Read your output once more with fresh eyes:
+
+- Could this be shorter without losing meaning?
+- Is anything a rule that would work better as one example?
+- Did you add without cutting? If so, is the addition really earning its place?
+
+A skill about avoiding bloat that is itself bloated has failed. Hold this one to its own standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.7.0 - 2026-07-10
+
+### Added
+
+- `aiw-prompt-smith` skill added to `.claude/skills/` and `.agents/skills/`: a meta-authoring skill for writing and repairing prompting artifacts (system prompts, `CLAUDE.md`, `AGENTS.md`/`AGENT.md`, and other skills). It is organised around *altitude* — fixing the class an instance belongs to rather than appending a narrow rule per failure — and covers a write mode and a repair mode over a shared set of principles. It ships in the full profile to all four tools and is pulled by its description rather than wired into the numbered task flow, like `aiw-issue-creation`. The `lite-monolithic` condensation is unchanged in content because prompt-smith is orthogonal to the coding task flow it condenses; only its `Version:` header is synced to the canonical anchor ([#173]).
+
 ## 3.6.0 - 2026-06-18
 
 ### Added
@@ -384,3 +390,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#165]: https://github.com/philippe-ths/ai-coding-workflow/issues/165
 [#114]: https://github.com/philippe-ths/ai-coding-workflow/issues/114
 [#170]: https://github.com/philippe-ths/ai-coding-workflow/issues/170
+[#173]: https://github.com/philippe-ths/ai-coding-workflow/issues/173

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.6.0
+Version: 3.7.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.6.0
+Version: 3.7.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.14.0
+Version: 1.15.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -76,7 +76,7 @@ Version: 1.14.0
 - `design/`: maintenance documentation for the repository; `design/decisions/` holds concern-scoped rationale files and `design/research/` holds primary-source notes with stable anchor IDs.
 - `observations/observed-ai-failings.md`: log of concrete AI agent failure patterns observed in real sessions.
 - `observations/workflow-reviews/`: archived periodic review outputs, each named by date.
-- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-ground-truth`, `aiw-github`, `aiw-failure-analysis`, `aiw-issue-creation`, `aiw-testing`, `aiw-verification`, `aiw-performance-profiling`, `aiw-security-testing`, `aiw-project-context-management`), each self-contained in a `SKILL.md` file.
+- `.agents/skills/`: cross-platform skill definitions (`aiw-planning`, `aiw-ground-truth`, `aiw-github`, `aiw-failure-analysis`, `aiw-issue-creation`, `aiw-testing`, `aiw-verification`, `aiw-performance-profiling`, `aiw-security-testing`, `aiw-project-context-management`, `aiw-prompt-smith`), each self-contained in a `SKILL.md` file.
 - `.claude/skills/`: Claude Code skill definitions (same skills as `.agents/skills/`), each self-contained in a `SKILL.md` file.
 - `.github/copilot-instructions.md`: VS Code Copilot agent instructions pointing to `ai-workflow.md` and `project-context.md`.
 - `AGENTS.md`: Codex agent instructions; structure mirrors `.github/copilot-instructions.md`.


### PR DESCRIPTION
Closes #173.

Brings the `prompt-smith` skill in as an `aiw-*` product skill.

## What ships
- `aiw-prompt-smith/SKILL.md` in both `.claude/skills/` and `.agents/skills/` (byte-identical). Content is the source verbatim; `name:` → `aiw-prompt-smith` and H1 → `# Prompt Smith` to match repo convention.
- A meta-authoring skill for writing and repairing prompting artifacts (system prompts, `CLAUDE.md`, `AGENTS.md`/`AGENT.md`, other skills), organised around **altitude** with a write mode and a repair mode over shared principles.
- Pulled by its description rather than wired into the numbered task flow, like `aiw-issue-creation`.

## Versioning / bookkeeping
- Minor bump: `ai-workflow.md` 3.6.0 → **3.7.0**, matching CHANGELOG entry.
- `lite-monolithic/ai-workflow.md`: **content unchanged** (prompt-smith is orthogonal to the coding task flow lite condenses); only its `Version:` header is synced to the canonical anchor per the parity rule.
- `project-context.md`: added to the `.agents/skills/` enumeration; own version 1.14.0 → 1.15.0.
- No `install-manifest.json` change — the manifest classifies `.claude/` and `.agents/skills/` as product by directory.

## Verification
- Full validation gate green (29/29 + all repo-validation sub-suites, manifest integrity OK, lite parity OK).
- **End-to-end**: installed into four fresh sandbox repos (claude/codex/gemini/copilot, full profile); the skill lands in every one with frontmatter intact.

A tagged release is due for this minor bump (post-merge, per maintenance rule).