### PR TITLE
aiw-issue-creation: collapse prohibition list to one class principle (#175)

### DIFF
--- a/.agents/skills/aiw-issue-creation/SKILL.md
+++ b/.agents/skills/aiw-issue-creation/SKILL.md
@@ -21,16 +21,8 @@ Read this file when creating a follow-up or spin-off GitHub issue.
 
 ## What the Issue May Contain
 
-- Reference relevant files by path to locate the concern, so the implementing agent can open current truth in the codebase. Point at the file; never restate, paste, or paraphrase its contents.
+- Reference a relevant file by path to locate the concern. A path locates; carrying the code into the issue pegs it. Do not reproduce what a file says or prescribe how to change it. Both peg the issue to today's implementation and bias whoever picks it up toward an approach that may not fit by then.
 - Optionally, a short list of workflow skills that may help whoever implements it. Frame this as a hint to orient the implementing agent, not a mandate or a prescribed solution.
-
-## What the Issue Must Not Contain
-
-- Do not restate, paste, or paraphrase the contents of any file. A path that locates the concern is allowed (see above); reproducing what the file says is not.
-- Do not include code snippets or implementation approaches.
-- Do not reference specific functions, variables, or line numbers.
-- Do not prescribe how the implementing agent should solve the problem.
-  (Why: A bare path only locates the concern, but restated file contents, an implementation approach, or a function/line reference peg the issue to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
 
 ## Keeping Issues Concise
 

--- a/.claude/skills/aiw-issue-creation/SKILL.md
+++ b/.claude/skills/aiw-issue-creation/SKILL.md
@@ -21,16 +21,8 @@ Read this file when creating a follow-up or spin-off GitHub issue.
 
 ## What the Issue May Contain
 
-- Reference relevant files by path to locate the concern, so the implementing agent can open current truth in the codebase. Point at the file; never restate, paste, or paraphrase its contents.
+- Reference a relevant file by path to locate the concern. A path locates; carrying the code into the issue pegs it. Do not reproduce what a file says or prescribe how to change it. Both peg the issue to today's implementation and bias whoever picks it up toward an approach that may not fit by then.
 - Optionally, a short list of workflow skills that may help whoever implements it. Frame this as a hint to orient the implementing agent, not a mandate or a prescribed solution.
-
-## What the Issue Must Not Contain
-
-- Do not restate, paste, or paraphrase the contents of any file. A path that locates the concern is allowed (see above); reproducing what the file says is not.
-- Do not include code snippets or implementation approaches.
-- Do not reference specific functions, variables, or line numbers.
-- Do not prescribe how the implementing agent should solve the problem.
-  (Why: A bare path only locates the concern, but restated file contents, an implementation approach, or a function/line reference peg the issue to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
 
 ## Keeping Issues Concise
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.7.1 - 2026-07-10
+
+### Changed
+
+- `aiw-issue-creation`: collapsed the four-item "What the Issue Must Not Contain" enumeration and its rationale note into a single class-level principle folded into the "may contain" path guidance. The prohibitions (reproducing file contents, code snippets, function/line references, prescribing an approach) were four instances of one class the skill's own note already named; they now read as one rule built on the leading word "peg", stated once, so the guidance also covers cases the list did not enumerate. Applied identically to `.claude/skills/` and `.agents/skills/`; the lite condensation already stated the class-level form, so only its `Version:` header is synced ([#175]).
+
 ## 3.7.0 - 2026-07-10
 
 ### Added
@@ -391,3 +397,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#114]: https://github.com/philippe-ths/ai-coding-workflow/issues/114
 [#170]: https://github.com/philippe-ths/ai-coding-workflow/issues/170
 [#173]: https://github.com/philippe-ths/ai-coding-workflow/issues/173
+[#175]: https://github.com/philippe-ths/ai-coding-workflow/issues/175

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.0
+Version: 3.7.1
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.0
+Version: 3.7.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.


### PR DESCRIPTION
Closes #175.

Raises `aiw-issue-creation` to the altitude the lite condensation already uses: the four-item "What the Issue Must Not Contain" section and its rationale note collapse into a single class-level principle folded into the "may contain" path guidance.

## Why
Surfaced while testing the new `aiw-prompt-smith` skill on `aiw-issue-creation`. The four prohibitions (reproduce file contents, code snippets, function/line references, prescribe an approach) were four instances of one class the skill's own `(Why:)` note already named. Enumerating instances is the altitude error prompt-smith targets: it breeds length and still misses unlisted cases.

## Change
- `.claude/skills/aiw-issue-creation/SKILL.md` and `.agents/skills/aiw-issue-creation/SKILL.md` (identical): one rule built on the leading word "peg", stating the path-vs-contents boundary once. Skill drops from 40 to 31 lines.
- All four old prohibitions remain covered by entailment (reproduce / carry the code / prescribe).
- `lite-monolithic/ai-workflow.md`: content unchanged (already class-level); `Version:` synced.
- Patch bump 3.7.0 → **3.7.1** with matching CHANGELOG entry.

## Verification
- Full validation gate green (29/29 + all repo-validation sub-suites); manifest, lite-parity, and changelog hook pass.
- End-to-end: installed into a fresh sandbox repo; the collapsed principle ships and the old section is gone.