### PR TITLE
Trim skill intros that restate the frontmatter description (#180)

### DIFF
--- a/.agents/skills/aiw-github/SKILL.md
+++ b/.agents/skills/aiw-github/SKILL.md
@@ -5,8 +5,6 @@ description: "Rules for every GitHub and git history action during a task: start
 
 # GitHub Workflow
 
-Read this file before every GitHub or git history action: starting work on an issue, switching branches, rebasing, committing, pushing, opening a pull request, post-merge cleanup, or responding to a parent or sub-issue hierarchy.
-
 ## Why this skill exists
 
 GitHub actions touch shared state. Each one becomes visible to others the moment it lands, and approval for one is not approval for another. Branch operations can silently lose untracked files. Issues anchor scope; without one, work drifts and commits lose traceability. This skill keeps each action gated by explicit human approval, anchored to an issue, and safe against working-tree surprises.

--- a/.agents/skills/aiw-ground-truth/SKILL.md
+++ b/.agents/skills/aiw-ground-truth/SKILL.md
@@ -5,7 +5,7 @@ description: "Establishes where trusted inputs and expected outputs come from du
 
 # Ground Truth
 
-Read this file before generating, sourcing, or reusing any input or expected output that a test or validation will compare against. Read it again whenever the task's modality is unclear, when the agent is about to invent example data, or when reusing fixtures from earlier in the session.
+Read this file again whenever the task's modality is unclear, when the agent is about to invent example data, or when reusing fixtures from earlier in the session.
 
 ## Why This Skill Exists
 

--- a/.agents/skills/aiw-performance-profiling/SKILL.md
+++ b/.agents/skills/aiw-performance-profiling/SKILL.md
@@ -5,8 +5,7 @@ description: "Automated performance and UI-state-transition coverage rules. Use 
 
 # Performance Profiling and Latency Coverage
 
-Read this file when the change touches runtime paths where speed or responsiveness matters.
-This file contains rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
+Rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
 
 ## Related Workflow Sections
 
@@ -19,17 +18,15 @@ This skill works alongside these workflow sections. Consult them when writing pe
 
 ## When This Skill Applies
 
-Load this skill when the change does any of the following:
+The description names the broad triggers. Add these to what counts:
 
-- Touches code paths where runtime speed affects usability.
-- Introduces or modifies caching, memoisation, debouncing, or throttling.
-- Adds or modifies a data-processing loop over non-trivial input.
-- Converts a synchronous path to asynchronous or vice versa.
-- Affects any other path where latency or throughput is a stated requirement.
+- Introducing or modifying caching, memoisation, debouncing, or throttling.
+- Converting a synchronous path to asynchronous or vice versa.
+- Any path where latency or throughput is a stated requirement.
 
-Examples of platform-specific paths that fall under the first trigger: UI state transitions, reactive subscriptions, view-layer rerenders, manual state resets, session invalidation, and UI decorators or wrappers that affect render frequency. The trigger list itself is project-agnostic; treat platform examples as illustrations rather than the boundary of the rule.
+Platform-specific paths that commonly trigger this skill: UI state transitions, reactive subscriptions, view-layer rerenders, manual state resets, session invalidation, and UI decorators or wrappers that affect render frequency. The trigger list is project-agnostic; treat platform examples as illustrations rather than the boundary of the rule.
 
-If any of these apply and no automated performance coverage exists for the affected path, add coverage as part of the change.
+If a trigger applies and no automated performance coverage exists for the affected path, add coverage as part of the change.
 
 ## Rules
 

--- a/.agents/skills/aiw-planning/SKILL.md
+++ b/.agents/skills/aiw-planning/SKILL.md
@@ -9,13 +9,7 @@ Read this file when producing or revising an implementation plan at the start of
 
 ## Where This Skill Sits in the Workflow
 
-Planning runs at the start of every task, before any implementation. It establishes what currently works in the codebase, classifies the task, names the oracle, and produces an implementation plan with high-level testing and verification expectations.
-
-The plan does not reproduce the rules of the other four skills. It identifies what each skill will need to address during implementation and defers the mechanics to them. The plan is the entry point; aiw-ground-truth, aiw-testing, and aiw-verification are invoked as the work proceeds. If a "done" claim is later contradicted, aiw-failure-analysis runs and may re-plan.
-
-## The Full Skill Sequence
-
-For orientation, the skills are invoked across a task in roughly this order:
+Planning is step 2 of the task sequence. The plan does not reproduce the rules of the other skills; it identifies what each will need to address during implementation and defers the mechanics to them. The full sequence, for orientation:
 
 1. **aiw-github** at task start: confirm the GitHub issue, read it and its comments, create or switch to an issue-scoped branch.
 2. **aiw-planning** (this skill): establish the codebase baseline, classify the modality, name the oracle, produce the plan for human review.

--- a/.agents/skills/aiw-security-testing/SKILL.md
+++ b/.agents/skills/aiw-security-testing/SKILL.md
@@ -18,7 +18,7 @@ This skill works alongside these workflow sections. Consult them when writing se
 
 ## When This Skill Applies
 
-The triggers below are broader than they look: any change to input handling, even a cosmetic one, can cross a trust boundary. Err toward invoking the skill rather than under-invoking it — the cost of an unneeded security review is small, the cost of a missed boundary is not.
+The triggers below are broader than they look: any change to input handling, even a cosmetic one, can cross a trust boundary.
 
 Load this skill when the change does any of the following:
 

--- a/.claude/skills/aiw-github/SKILL.md
+++ b/.claude/skills/aiw-github/SKILL.md
@@ -5,8 +5,6 @@ description: "Rules for every GitHub and git history action during a task: start
 
 # GitHub Workflow
 
-Read this file before every GitHub or git history action: starting work on an issue, switching branches, rebasing, committing, pushing, opening a pull request, post-merge cleanup, or responding to a parent or sub-issue hierarchy.
-
 ## Why this skill exists
 
 GitHub actions touch shared state. Each one becomes visible to others the moment it lands, and approval for one is not approval for another. Branch operations can silently lose untracked files. Issues anchor scope; without one, work drifts and commits lose traceability. This skill keeps each action gated by explicit human approval, anchored to an issue, and safe against working-tree surprises.

--- a/.claude/skills/aiw-ground-truth/SKILL.md
+++ b/.claude/skills/aiw-ground-truth/SKILL.md
@@ -5,7 +5,7 @@ description: "Establishes where trusted inputs and expected outputs come from du
 
 # Ground Truth
 
-Read this file before generating, sourcing, or reusing any input or expected output that a test or validation will compare against. Read it again whenever the task's modality is unclear, when the agent is about to invent example data, or when reusing fixtures from earlier in the session.
+Read this file again whenever the task's modality is unclear, when the agent is about to invent example data, or when reusing fixtures from earlier in the session.
 
 ## Why This Skill Exists
 

--- a/.claude/skills/aiw-performance-profiling/SKILL.md
+++ b/.claude/skills/aiw-performance-profiling/SKILL.md
@@ -5,8 +5,7 @@ description: "Automated performance and UI-state-transition coverage rules. Use 
 
 # Performance Profiling and Latency Coverage
 
-Read this file when the change touches runtime paths where speed or responsiveness matters.
-This file contains rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
+Rules for writing automated performance and UI-state-transition tests before deferring to manual verification.
 
 ## Related Workflow Sections
 
@@ -19,17 +18,15 @@ This skill works alongside these workflow sections. Consult them when writing pe
 
 ## When This Skill Applies
 
-Load this skill when the change does any of the following:
+The description names the broad triggers. Add these to what counts:
 
-- Touches code paths where runtime speed affects usability.
-- Introduces or modifies caching, memoisation, debouncing, or throttling.
-- Adds or modifies a data-processing loop over non-trivial input.
-- Converts a synchronous path to asynchronous or vice versa.
-- Affects any other path where latency or throughput is a stated requirement.
+- Introducing or modifying caching, memoisation, debouncing, or throttling.
+- Converting a synchronous path to asynchronous or vice versa.
+- Any path where latency or throughput is a stated requirement.
 
-Examples of platform-specific paths that fall under the first trigger: UI state transitions, reactive subscriptions, view-layer rerenders, manual state resets, session invalidation, and UI decorators or wrappers that affect render frequency. The trigger list itself is project-agnostic; treat platform examples as illustrations rather than the boundary of the rule.
+Platform-specific paths that commonly trigger this skill: UI state transitions, reactive subscriptions, view-layer rerenders, manual state resets, session invalidation, and UI decorators or wrappers that affect render frequency. The trigger list is project-agnostic; treat platform examples as illustrations rather than the boundary of the rule.
 
-If any of these apply and no automated performance coverage exists for the affected path, add coverage as part of the change.
+If a trigger applies and no automated performance coverage exists for the affected path, add coverage as part of the change.
 
 ## Rules
 

--- a/.claude/skills/aiw-planning/SKILL.md
+++ b/.claude/skills/aiw-planning/SKILL.md
@@ -9,13 +9,7 @@ Read this file when producing or revising an implementation plan at the start of
 
 ## Where This Skill Sits in the Workflow
 
-Planning runs at the start of every task, before any implementation. It establishes what currently works in the codebase, classifies the task, names the oracle, and produces an implementation plan with high-level testing and verification expectations.
-
-The plan does not reproduce the rules of the other four skills. It identifies what each skill will need to address during implementation and defers the mechanics to them. The plan is the entry point; aiw-ground-truth, aiw-testing, and aiw-verification are invoked as the work proceeds. If a "done" claim is later contradicted, aiw-failure-analysis runs and may re-plan.
-
-## The Full Skill Sequence
-
-For orientation, the skills are invoked across a task in roughly this order:
+Planning is step 2 of the task sequence. The plan does not reproduce the rules of the other skills; it identifies what each will need to address during implementation and defers the mechanics to them. The full sequence, for orientation:
 
 1. **aiw-github** at task start: confirm the GitHub issue, read it and its comments, create or switch to an issue-scoped branch.
 2. **aiw-planning** (this skill): establish the codebase baseline, classify the modality, name the oracle, produce the plan for human review.

--- a/.claude/skills/aiw-security-testing/SKILL.md
+++ b/.claude/skills/aiw-security-testing/SKILL.md
@@ -18,7 +18,7 @@ This skill works alongside these workflow sections. Consult them when writing se
 
 ## When This Skill Applies
 
-The triggers below are broader than they look: any change to input handling, even a cosmetic one, can cross a trust boundary. Err toward invoking the skill rather than under-invoking it — the cost of an unneeded security review is small, the cost of a missed boundary is not.
+The triggers below are broader than they look: any change to input handling, even a cosmetic one, can cross a trust boundary.
 
 Load this skill when the change does any of the following:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.7.3 - 2026-07-13
+
+### Changed
+
+- Trimmed skill-body openings that restated the frontmatter `description` the loader already matches on, so the body starts at what it uniquely adds. `aiw-github` lost its intro line outright (pure restatement of the description's action enumeration, already the section headings below). `aiw-ground-truth`, `aiw-performance-profiling`, and `aiw-security-testing` kept only the part beyond the description (the re-entry trigger, the added scope of sync/async conversion and stated latency requirement plus platform examples, and the "broader than they look" amplification), dropping the trigger-recap framing. `aiw-planning` collapsed its two adjacent orientation sections ("Where This Skill Sits" and "The Full Skill Sequence") into one, keeping the numbered sequence and the defers-to-other-skills principle. No trigger or rule intent was lost. Surfaced by running the `aiw-prompt-smith` skill across the skill set. Applied identically to `.claude/skills/` and `.agents/skills/`; the lite condensation carries no skill intros, so only its `Version:` header is synced ([#180]).
+
 ## 3.7.2 - 2026-07-11
 
 ### Changed
@@ -405,3 +411,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#173]: https://github.com/philippe-ths/ai-coding-workflow/issues/173
 [#175]: https://github.com/philippe-ths/ai-coding-workflow/issues/175
 [#178]: https://github.com/philippe-ths/ai-coding-workflow/issues/178
+[#180]: https://github.com/philippe-ths/ai-coding-workflow/issues/180

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.2
+Version: 3.7.3
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.2
+Version: 3.7.3
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.


### PR DESCRIPTION
Closes #180.

## What
Trims skill-body openings that restated the frontmatter `description` the loader already matches on, so each body starts at what it uniquely adds. Same subtraction discipline as #179.

- **aiw-github** — intro line deleted (its 8-item action list is verbatim in the frontmatter and is the section headings below).
- **aiw-ground-truth** — dropped the restated first sentence; kept the re-entry trigger.
- **aiw-performance-profiling** — dropped the intro line and the two bullets that restate description terms; kept the added scope (sync/async, stated latency), platform examples, and the coverage rule.
- **aiw-security-testing** — dropped the "Err toward invoking…" framing sentence; kept the amplification and the trigger bullet list.
- **aiw-planning** — collapsed the two adjacent orientation sections into one, keeping the numbered sequence and the defers-to-other-skills principle.

Applied identically to `.claude/skills/` and `.agents/skills/`. Version 3.7.2 → 3.7.3; lite header synced (no skill intros to change).

## Verification
- **Blind differential reads** of all five skills (fresh agents, old vs new): unanimous *nothing lost* — every removed line is verbatim in the frontmatter or preserved in a surviving section.
- **Behavioural probes** on the two reworded files (performance, planning), old vs new, blind to variant: no divergence. The performance file still puts a UI-rerender task in scope after the "usability" bullet was removed; the planning file still conveys the defers-to-other-skills principle.
- Policy validation green (29 passed); `.claude`/`.agents` mirrors byte-identical.

## Not in this PR (flagged)
`aiw-planning`'s numbered sequence is a second copy of `ai-workflow.md`'s Task Flow — the same duplication class, at file-to-file scope. Left alone here because #180 scopes the planning work to the two-section collapse, and pointing to `ai-workflow.md` instead would risk losing the skill-level annotations the sequence carries. Worth a follow-up decision.