### PR TITLE
Route work to sub-agents and name built-in tools across the workflow

### DIFF
--- a/.agents/skills/aiw-ground-truth/SKILL.md
+++ b/.agents/skills/aiw-ground-truth/SKILL.md
@@ -82,7 +82,8 @@ When the modality requires a trust level higher than what is currently available
 
 - Do not invent a substitute.
 - Do not downgrade silently to a lower trust level.
-- Stop and ask the user.
+- Exhaust the real sources you can reach yourself first: fan out read-only search sub-agents to find real artifacts, callers, and prior examples across the codebase, and use web search for external ground truth the codebase cannot show, such as an upstream format, a library's documented semantics, or how a third-party system actually responds. This widens the net for *real* ground truth; it never licenses inventing one.
+- When the real source genuinely cannot be reached, stop and ask the user.
 
 Use language that names what is missing, why it matters, and what would unblock the work. For example:
 

--- a/.agents/skills/aiw-planning/SKILL.md
+++ b/.agents/skills/aiw-planning/SKILL.md
@@ -24,6 +24,8 @@ This skill owns step 2. The overview exists so the full sequence is visible at a
 
 Before drafting the plan, establish what the codebase currently does, what the test infrastructure tells you, and what is actually being asked. The plan depends on these facts.
 
+When establishing what the codebase does spans several files or areas, route the reconnaissance to parallel read-only search sub-agents rather than reading serially, and synthesise their findings yourself. The map you plan against must be one you built in the main loop, not one you accepted unread.
+
 ### Read project context
 
 - If `project-context.md` exists in the repository, read it as part of the baseline check.

--- a/.agents/skills/aiw-verification/SKILL.md
+++ b/.agents/skills/aiw-verification/SKILL.md
@@ -56,6 +56,8 @@ Run the full system end-to-end, on real ground-truth artifacts where the modalit
 
 End-to-end execution is cheap for an agent. Humans optimise testing practice to avoid the cost of standing up the full system, restarting services, or waiting for slow runs. The agent does not pay those costs the same way and should not inherit human shortcuts. When in doubt, run the whole thing. (Why: the cost of a missed regression dwarfs the cost of one more end-to-end run.)
 
+Drive that end-to-end run with a fresh sub-agent, one that did not write the change and carries none of its context, and have it report what it observed. You are the worst verifier of your own change: you exercise what you expected to build and read the output through the same assumptions that shaped the code, the self-referential loop aiw-ground-truth exists to break, reappearing at verification time. A clean-context agent reaches the surface a real user would. Weigh its report in the main loop as evidence, not a verdict.
+
 If end-to-end execution is impractical for a specific change, name why in the justification step's part 3 and treat the unverified end-to-end path as a known risk.
 
 ## Reading Runtime Output

--- a/.claude/skills/aiw-ground-truth/SKILL.md
+++ b/.claude/skills/aiw-ground-truth/SKILL.md
@@ -82,7 +82,8 @@ When the modality requires a trust level higher than what is currently available
 
 - Do not invent a substitute.
 - Do not downgrade silently to a lower trust level.
-- Stop and ask the user.
+- Exhaust the real sources you can reach yourself first: fan out read-only search sub-agents to find real artifacts, callers, and prior examples across the codebase, and use web search for external ground truth the codebase cannot show, such as an upstream format, a library's documented semantics, or how a third-party system actually responds. This widens the net for *real* ground truth; it never licenses inventing one.
+- When the real source genuinely cannot be reached, stop and ask the user.
 
 Use language that names what is missing, why it matters, and what would unblock the work. For example:
 

--- a/.claude/skills/aiw-planning/SKILL.md
+++ b/.claude/skills/aiw-planning/SKILL.md
@@ -24,6 +24,8 @@ This skill owns step 2. The overview exists so the full sequence is visible at a
 
 Before drafting the plan, establish what the codebase currently does, what the test infrastructure tells you, and what is actually being asked. The plan depends on these facts.
 
+When establishing what the codebase does spans several files or areas, route the reconnaissance to parallel read-only search sub-agents rather than reading serially, and synthesise their findings yourself. The map you plan against must be one you built in the main loop, not one you accepted unread.
+
 ### Read project context
 
 - If `project-context.md` exists in the repository, read it as part of the baseline check.

--- a/.claude/skills/aiw-verification/SKILL.md
+++ b/.claude/skills/aiw-verification/SKILL.md
@@ -56,6 +56,8 @@ Run the full system end-to-end, on real ground-truth artifacts where the modalit
 
 End-to-end execution is cheap for an agent. Humans optimise testing practice to avoid the cost of standing up the full system, restarting services, or waiting for slow runs. The agent does not pay those costs the same way and should not inherit human shortcuts. When in doubt, run the whole thing. (Why: the cost of a missed regression dwarfs the cost of one more end-to-end run.)
 
+Drive that end-to-end run with a fresh sub-agent, one that did not write the change and carries none of its context, and have it report what it observed. You are the worst verifier of your own change: you exercise what you expected to build and read the output through the same assumptions that shaped the code, the self-referential loop aiw-ground-truth exists to break, reappearing at verification time. A clean-context agent reaches the surface a real user would. Weigh its report in the main loop as evidence, not a verdict.
+
 If end-to-end execution is impractical for a specific change, name why in the justification step's part 3 and treat the unverified end-to-end path as a known risk.
 
 ## Reading Runtime Output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.8.0 - 2026-07-13
+
+### Changed
+
+- Reframed the workflow's stance on sub-agents from a single cost-to-justify warning into positive routing guidance, and named the built-in tools at the skill moments where fan-out or clean context pays. `ai-workflow.md` Resource Discipline now routes work to a sub-agent by its shape (broad multi-file search, mechanical or parallelisable work, distillable output, isolated parallel edits) while keeping judgment, design, and review of every returned result in the main loop. Skill triggers added at their fan-out moments: `aiw-planning` routes multi-area codebase reconnaissance to parallel read-only search sub-agents; `aiw-ground-truth` exhausts real sources via search sub-agents and web search before falling back to asking the user; `aiw-verification` folds a fresh clean-context sub-agent into its mandatory end-to-end run, on the leading idea that you are the worst verifier of your own change. Every trigger carries the main-loop-review guard inline, so encouragement does not become blind deference. Concrete Claude Code tool names (Explore, general-purpose, worktree isolation, web search) live in `CLAUDE.md` only; the mirrored skills stay capability-framed and identical across `.claude/skills/` and `.agents/skills/`. Design input drawn from the maintainer's knowledge base; the KB itself does not ship. Re-condensed into `lite-monolithic/ai-workflow.md` ([#183]).
+
 ## 3.7.3 - 2026-07-13
 
 ### Changed
@@ -412,3 +418,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#175]: https://github.com/philippe-ths/ai-coding-workflow/issues/175
 [#178]: https://github.com/philippe-ths/ai-coding-workflow/issues/178
 [#180]: https://github.com/philippe-ths/ai-coding-workflow/issues/180
+[#183]: https://github.com/philippe-ths/ai-coding-workflow/issues/183

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,14 @@
 @ai-workflow.md
 @project-context.md
 
-You must confirm you have read both files and can invoke the "aiw-*" project skills before responding. 
+You must confirm you have read both files and can invoke the "aiw-*" project skills before responding.
+
+## Sub-agents and tools (Claude Code)
+
+The workflow's routing guidance maps to these Claude Code tools. Route work out by its shape; review every returned result in the main loop.
+
+- Broad multi-file search or reconnaissance: the Explore agent (read-only, fans out without flooding your context).
+- Multi-step research or delegated implementation: the general-purpose agent.
+- Parallel edits that would conflict: sub-agents with worktree isolation.
+- Prior art or external ground truth the codebase cannot show: web search.
+- Clean-context verification: a fresh general-purpose agent that did not write the code.

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.3
+Version: 3.8.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -43,7 +43,8 @@ Protect your context window and the human's quota — but never by doing less th
 
 - Efficiency governs *how* you discharge a required step, never *whether*. Never skip, weaken, or defer a required step to save context or quota.
 - Read and search narrowly; pull whole files or broad output dumps into context only when you need them.
-- A subagent spends quota for parallelism or clean context — use one when it earns that cost, not as a reflex to empty your own context window.
+- Route work to a sub-agent by its shape: broad multi-file search, mechanical or parallelisable work, output you would only distil, or parallel edits that need isolation. Reaching for one on that work is the disciplined move, not an indulgence to justify.
+- Keep judgment, design, and the review of every returned result in the main loop. A sub-agent's result is evidence to weigh, never a verdict to accept unread. A thin brief returns confident, wrong work, and an orchestrator that defers inherits the error.
 
 ## Boundary Rules
 

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.7.3
+Version: 3.8.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -175,8 +175,9 @@ Protect your context window and the human's quota — but never by doing less th
 - Efficiency governs how you discharge a required step, never whether. Never skip, weaken, or defer a required step to save context or quota.
   (Why: An efficiency directive is easy to misread as licence to thin verification, ground truth, or failure analysis; the cost saving is illusory when it lets a defect through.)
 - Read and search narrowly; pull whole files or broad output dumps into context only when you need them.
-- A subagent spends quota for parallelism or clean context. Use one when it earns that cost, not as a reflex to empty your own context window.
-  (Why: Offloading to a subagent keeps the main context lean but multiplies total tokens; spawning to empty context rather than for real leverage maximises spend.)
+- Route work to a sub-agent by its shape: broad multi-file search, mechanical or parallelisable work, output you would only distil, or parallel edits that need isolation. Reaching for one on that work is the disciplined move, not an indulgence to justify.
+- Keep judgment, design, and the review of every returned result in the main loop. A sub-agent's result is evidence to weigh, never a verdict to accept unread.
+  (Why: routing down in capability re-introduces blind deference and context loss. A thin brief returns confident, wrong work, and an orchestrator that rubber-stamps it inherits the error.)
 
 ## Scope Control
 
@@ -239,6 +240,8 @@ If part 1 surfaces something part 2 does not cover, the change is not verified: 
 Evidence runs from weak to strong: static checks < unit tests < integration tests < end-to-end on synthetic input < end-to-end on real artifacts < a before/after diff against captured behaviour. Name the level you reached, not just "tests pass."
 
 Run the full system end-to-end on real inputs for: changes to data flowing between processes or pipeline stages; changes to an external tool or library interface; any Refactor or Migrate claiming behaviour preservation; any Delete. If end-to-end is impractical, say so and treat the unverified path as a known risk.
+
+Drive that end-to-end run with a fresh sub-agent, one that did not write the code and carries none of its context, and have it report what it observed; you are the worst verifier of your own change. Weigh its report in the main loop as evidence, not a verdict.
 
 Exit code 0 is not success. Inspect the actual output: confirm the change's effect appears, scan logs for unexpected warnings and errors, and notice silence — a run that produces fewer outputs or skips a path that should have executed is a verification failure, not a pass.
 


### PR DESCRIPTION
Closes #183.

## Problem
Across `ai-workflow.md` and all 11 `aiw-*` skills, sub-agents were mentioned exactly once, framed as a cost to justify rather than a capability to reach for. No skill named Explore/broad-search sub-agents, worktree isolation, web search, or a fresh-context verifier. The maintainer had to say "use sub-agents effectively" on nearly every task.

## Change
Two altitudes:
1. **`ai-workflow.md` Resource Discipline** reframed from a cost-to-justify warning into positive **routing-by-shape** guidance: route broad/mechanical/parallel/dirty-context work out; keep judgment, design, and review of every returned result in the main loop.
2. **Skill triggers** at their fan-out moments, each carrying the main-loop-review guard inline:
   - `aiw-planning` — parallel read-only reconnaissance instead of serial reads.
   - `aiw-ground-truth` — search sub-agents + web search for external ground truth before falling back to asking the user.
   - `aiw-verification` — a fresh clean-context sub-agent folded into the mandatory end-to-end run ("you are the worst verifier of your own change").

Concrete Claude Code tool names live in `CLAUDE.md` only; the mirrored skills stay capability-framed and byte-identical across `.claude/skills/` and `.agents/skills/`. Lite re-condensed; version bumped to 3.8.0. Design input drawn from the maintainer's KB; the KB itself does not ship.

## Testing
A cwd-isolated headless A/B (a git worktree of `main` = baseline vs this branch = treatment, `claude -p` per arm so each auto-loads its own workflow version):

- **No harm.** Zero over-delegation in either arm; on a trivial one-line task the treatment uses "route by shape" to justify *not* fanning out (the over-correction risk, checked and clear).
- **Fresh-agent verification is the net-new behavior** and is causal: with the `aiw-verification` skill loaded, it fires **3/3 in treatment vs 0/3 in baseline**.
- Much of the other "reaching" (reconnaissance fan-out, refusing to invent ground truth) is base-model competence the change mainly reframes; the reframing does no harm and sharpens the discipline.

Two testing caveats worth noting: a first A/B was invalidated by ambient-context contamination (Workflow sub-agents inherited the treatment `CLAUDE.md`), fixed with cwd-isolated headless runs; and skill-body edits only manifest when the skill is loaded, so an early "under-triggers" reading was a measurement artifact.

## Notes for the reviewer
- This is a minor bump, so it may warrant a tagged release.
- Deferred out of scope (own follow-up): sub-agent triggers for `aiw-failure-analysis` (parallel hypothesis testing) and `aiw-github` (fan-out review of a large diff).