### PR TITLE
Make "Asking for Guidance" fire unprompted, one decision at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.10.0 - 2026-07-14
+
+### Changed
+
+- Made the "Asking for Guidance" format fire unprompted. The recommendation-and-rationale format for questions lived only as a standalone named section that read as a lookup-on-demand reference, so the agent applied it reliably only when the human said "use Asking for Guidance" and otherwise fell back to a wall of text with the questions tacked on at the end. `ai-workflow.md` now carries a standing `Always Do` rule binding every question or decision put to the human to that format, and the section itself leads with "leads with a recommendation, it does not end with one", requires one decision at a time (most consequential first, wait rather than stack), and names the buried-options anti-pattern as a rule violation. The fix moves the trigger onto the act of asking rather than the section name. Applied identically to `lite-monolithic/ai-workflow.md` ([#187]).
+
 ## 3.9.0 - 2026-07-14
 
 ### Changed
@@ -426,3 +432,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#180]: https://github.com/philippe-ths/ai-coding-workflow/issues/180
 [#183]: https://github.com/philippe-ths/ai-coding-workflow/issues/183
 [#185]: https://github.com/philippe-ths/ai-coding-workflow/issues/185
+[#187]: https://github.com/philippe-ths/ai-coding-workflow/issues/187

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.9.0
+Version: 3.10.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -54,6 +54,7 @@ The AI must raise these without being asked, so the human has the information ne
 
 - ALWAYS run aiw-verification's justification step before presenting work for the human's done decision.
 - ALWAYS surface uncertainty, guesses, and incomplete validation, and stop to ask when anything is unclear, risky, or out of scope.
+- ALWAYS present any question or decision you put to the human in the Asking for Guidance format — lead with a clear recommendation and its rationale, never a bare list of options for the human to sort out.
 - ALWAYS surface follow-up work discovered during the task that falls outside scope, without acting on it.
 - ALWAYS surface performance concerns observed in the code paths the task touched, with the concrete signal that prompted them.
 - ALWAYS surface security concerns observed in the code paths the task touched, with the concrete signal that prompted them.
@@ -83,7 +84,7 @@ Do not do any of the following under any circumstances:
 
 ## Asking for Guidance
 
-When asking the human a question or requesting guidance on a decision, present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation.
+Every question or decision you put to the human leads with a recommendation, it does not end with one. Present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation. Put one decision to the human at a time; when several are open, ask the most consequential first and wait rather than stacking them. A wall of text with the options buried and the questions tacked on at the end is a rule violation, not a neutral choice.
 
 ## Reactive Rules
 

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.9.0
+Version: 3.10.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -356,6 +356,7 @@ The following apply to every task without exception:
 
 - ALWAYS follow the workflow steps in order, and produce the verification justification before presenting work for the human's done decision.
 - ALWAYS surface uncertainty, guesses, and incomplete validation, and stop to ask when anything is unclear, risky, or out of scope.
+- ALWAYS present any question or decision you put to the human in the Asking for Guidance format — lead with a clear recommendation and its rationale, never a bare list of options for the human to sort out.
 - ALWAYS surface follow-up work, performance concerns, security concerns, and relevant refactoring opportunities discovered during the task — with concrete evidence — without acting on them.
 - ALWAYS surface notable entries from logs consulted during the task: errors, warnings, and unexpected patterns.
 - ALWAYS state what a command does and why before requesting approval to run it.
@@ -384,7 +385,7 @@ Do not do any of the following under any circumstances:
 
 ## Asking for Guidance
 
-When asking the human a question or requesting guidance on a decision, present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation.
+Every question or decision you put to the human leads with a recommendation, it does not end with one. Present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation. Put one decision to the human at a time; when several are open, ask the most consequential first and wait rather than stacking them. A wall of text with the options buried and the questions tacked on at the end is a rule violation, not a neutral choice.
 
 ## Reactive Rules
 


### PR DESCRIPTION
Closes #187.

## Problem
The recommendation-and-rationale format for questions lived only as a standalone named `Asking for Guidance` section that read as a lookup-on-demand reference. Nothing in the always-active Boundary Rules bound the act of asking to it, so the agent applied it reliably only when the human said "use Asking for Guidance" and otherwise fell back to a wall of text with the questions tacked on at the end.

## Change
- New `Always Do` boundary rule binding every question or decision put to the human to the Asking for Guidance format — the trigger now sits on the act of asking, not the section name.
- The section itself rewritten to lead with "leads with a recommendation, it does not end with one", require one decision at a time (most consequential first, wait rather than stack), and name the buried-options anti-pattern as a rule violation.
- Applied identically to `ai-workflow.md` and `lite-monolithic/ai-workflow.md`; bumped to `3.10.0` with a matching `CHANGELOG.md` entry.

## Verification
`./.ai-policy/scripts/project-validation.sh`: 29 passed, 0 failed, parser OK (exercises the version/changelog coupling via the changelog and pre-push hook tests). The behavioural proof — whether the rules actually change how questions get asked — can only come from future sessions; this is inherent to a prompt-wording change.

## Note
A minor bump (`3.10.0`) calls for a tagged release per the maintenance rule; that remains a human action and no tag was created.