### PR TITLE
Add SessionStart drift-reminder hook for project-context.md

### DIFF
--- a/.ai-policy/hooks/check-context-drift.sh
+++ b/.ai-policy/hooks/check-context-drift.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SessionStart hook: reminds the agent when project-context.md may have drifted.
+#
+# It cannot judge drift — that is the agent's job via aiw-project-context-management.
+# It emits a coarse commit-count signal: if the context file has not been touched in
+# CONTEXT_DRIFT_THRESHOLD or more commits, print a reminder on stdout. Both Claude Code
+# and Codex add SessionStart stdout to the agent's context.
+#
+# Advisory only. It must NEVER block or fail a session: every path exits 0, and it
+# stays silent when it cannot measure drift (no git repo, file absent or never committed).
+
+# Resolve config location relative to this script before changing directory.
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || exit 0
+POLICY_ENV="$SCRIPT_DIR/../policy.env"
+
+# An env override (set by the test, or by a caller) wins over policy.env defaults.
+if [ -f "$POLICY_ENV" ]; then
+  # shellcheck disable=SC1090
+  . "$POLICY_ENV" 2>/dev/null || true
+fi
+THRESHOLD="${CONTEXT_DRIFT_THRESHOLD:-10}"
+CONTEXT_FILE="${CONTEXT_FILE:-project-context.md}"
+
+# Only act inside a git work tree; operate from its root so paths are repo-relative.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -n "$ROOT" ] || exit 0
+cd "$ROOT" 2>/dev/null || exit 0
+
+# Nothing to measure if the context file does not exist or was never committed.
+[ -f "$CONTEXT_FILE" ] || exit 0
+LAST="$(git log -1 --format=%H -- "$CONTEXT_FILE" 2>/dev/null)" || exit 0
+[ -n "$LAST" ] || exit 0
+
+# Commits landed since the context file was last updated.
+N="$(git rev-list --count "$LAST"..HEAD 2>/dev/null)" || exit 0
+case "$N" in
+  ''|*[!0-9]*) exit 0 ;;
+esac
+
+if [ "$N" -ge "$THRESHOLD" ]; then
+  cat <<EOF
+NOTE: $CONTEXT_FILE has not been updated in $N commits and may have drifted from the codebase.
+Before starting work, verify it against the current code and refresh it with the aiw-project-context-management skill if stale.
+EOF
+fi
+
+exit 0

--- a/.ai-policy/policy.env
+++ b/.ai-policy/policy.env
@@ -3,3 +3,9 @@ REQUIRE_VALIDATION_BEFORE_COMMIT="true"
 REQUIRE_VALIDATION_BEFORE_PUSH="true"
 VALIDATION_STATE_FILE=".ai-policy/state/validation.status"
 VALIDATION_COMMAND="./.ai-policy/scripts/project-validation.sh"
+
+# The SessionStart drift-reminder hook (check-context-drift.sh) fires when the
+# context file has not been touched in this many commits. Assigned conditionally
+# so a caller (or the hook's test) can override via the environment.
+: "${CONTEXT_DRIFT_THRESHOLD:=10}"
+: "${CONTEXT_FILE:=project-context.md}"

--- a/.ai-policy/scripts/test-context-drift-hook.sh
+++ b/.ai-policy/scripts/test-context-drift-hook.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for the SessionStart context-drift reminder hook.
+# Builds throwaway git repositories in known states and asserts what the hook
+# prints on stdout. The hook always exits 0, so behaviour is judged by output:
+# a reminder when the context file is at/over the commit threshold, silence otherwise.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HOOK="$ROOT_DIR/.ai-policy/hooks/check-context-drift.sh"
+
+PASS=0
+FAIL=0
+
+assert_reminder() {
+  local label="$1" out="$2"
+  if printf '%s' "$out" | grep -q "project-context.md"; then
+    PASS=$((PASS + 1)); echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected a reminder, got none)"
+  fi
+}
+
+assert_silent() {
+  local label="$1" out="$2"
+  if [ -z "$out" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected silence, got: $out)"
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+# init_repo <dir> — a fresh git repo with identity configured.
+init_repo() {
+  local d="$1"
+  mkdir -p "$d"
+  git -C "$d" init -q .
+  git -C "$d" checkout -q -b main 2>/dev/null || git -C "$d" symbolic-ref HEAD refs/heads/main
+  git -C "$d" config user.email "test@example.invalid"
+  git -C "$d" config user.name "Drift Hook Test"
+  git -C "$d" config commit.gpgsign false
+}
+
+# run_hook <dir> — invoke the hook from inside <dir> with threshold 3.
+run_hook() {
+  ( cd "$1" && CONTEXT_DRIFT_THRESHOLD=3 bash "$HOOK" 2>/dev/null )
+}
+
+# 1. Context file at/over threshold -> reminder.
+R="$SANDBOX/over"; init_repo "$R"
+echo "context" > "$R/project-context.md"
+git -C "$R" add project-context.md && git -C "$R" commit -q -m "add context"
+for i in 1 2 3; do
+  echo "$i" > "$R/file-$i.txt"
+  git -C "$R" add "file-$i.txt" && git -C "$R" commit -q -m "work $i"
+done
+assert_reminder "3 commits behind, threshold 3 -> reminder" "$(run_hook "$R")"
+
+# 2. Context file within threshold -> silent.
+R="$SANDBOX/under"; init_repo "$R"
+echo "context" > "$R/project-context.md"
+git -C "$R" add project-context.md && git -C "$R" commit -q -m "add context"
+echo "x" > "$R/file.txt"
+git -C "$R" add file.txt && git -C "$R" commit -q -m "one commit of work"
+assert_silent "1 commit behind, threshold 3 -> silent" "$(run_hook "$R")"
+
+# 3. No context file -> silent.
+R="$SANDBOX/absent"; init_repo "$R"
+echo "x" > "$R/file.txt"
+git -C "$R" add file.txt && git -C "$R" commit -q -m "no context file here"
+assert_silent "context file absent -> silent" "$(run_hook "$R")"
+
+# 4. Context file present but never committed -> silent (drift is unmeasurable).
+R="$SANDBOX/uncommitted"; init_repo "$R"
+echo "seed" > "$R/seed.txt"
+git -C "$R" add seed.txt && git -C "$R" commit -q -m "seed"
+echo "context" > "$R/project-context.md"   # left untracked
+for i in 1 2 3; do
+  echo "$i" > "$R/file-$i.txt"
+  git -C "$R" add "file-$i.txt" && git -C "$R" commit -q -m "work $i"
+done
+assert_silent "context file never committed -> silent" "$(run_hook "$R")"
+
+# 5. Not a git repository -> silent.
+R="$SANDBOX/nogit"; mkdir -p "$R"
+echo "context" > "$R/project-context.md"
+assert_silent "non-git directory -> silent" "$(run_hook "$R")"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,16 @@
     "deny": []
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/check-context-drift.sh\""
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "mcp__.*github.*",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/warn-codex-mcp-limitation.sh\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/check-context-drift.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.12.0 - 2026-07-17
+
+### Added
+
+- Added a `SessionStart` drift-reminder hook (`.ai-policy/hooks/check-context-drift.sh`) that injects a reminder when `project-context.md` has not been touched in `CONTEXT_DRIFT_THRESHOLD` or more commits (default 10, configurable in `.ai-policy/policy.env`). The workflow already instructs the agent to read `project-context.md` at task start and flag staleness, but that soft instruction is easily skipped, so context drifts unnoticed in frequently-used repos. The hook adds a deterministic commit-count signal in the repo's existing policy-check pattern; it cannot judge drift (that stays with `aiw-project-context-management`) and is advisory only, always exiting 0 and staying silent when it cannot measure drift (no git repo, or the context file is absent or never committed). Wired into `SessionStart` for Claude Code (`.claude/settings.json`) and Codex (`.codex/hooks.json`), the two tools that expose a session-start event; Gemini and Copilot have no such event and keep relying on the task-start rule. Covered by a new sandbox test (`.ai-policy/scripts/test-context-drift-hook.sh`) auto-discovered by `project-validation.sh`. `lite-monolithic/ai-workflow.md` has no policy layer, so its version is bumped to stay in canonical parity with no content change ([#191]).
+
 ## 3.11.0 - 2026-07-16
 
 ### Changed
@@ -440,3 +446,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#185]: https://github.com/philippe-ths/ai-coding-workflow/issues/185
 [#187]: https://github.com/philippe-ths/ai-coding-workflow/issues/187
 [#189]: https://github.com/philippe-ths/ai-coding-workflow/issues/189
+[#191]: https://github.com/philippe-ths/ai-coding-workflow/issues/191

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.11.0
+Version: 3.12.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.11.0
+Version: 3.12.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.15.0
+Version: 1.16.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -84,7 +84,7 @@ Version: 1.15.0
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry).
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry) and `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only).
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.
@@ -115,7 +115,7 @@ Version: 1.15.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, and `test-project-validation.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, and `test-context-drift-hook.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.


### PR DESCRIPTION
Closes #191.

## What
Adds a deterministic `SessionStart` hook (`.ai-policy/hooks/check-context-drift.sh`) that injects a reminder when `project-context.md` has not been touched in `CONTEXT_DRIFT_THRESHOLD` or more commits (default 10, configurable in `.ai-policy/policy.env`).

## Why
The workflow already tells the agent to read `project-context.md` at task start and flag staleness, but that soft instruction is easily skipped, so context drifts unnoticed in frequently-used repos. This surfaces a coarse commit-count signal in the repo's existing policy-check pattern. It does not judge drift (that stays with `aiw-project-context-management`).

## Design
- **Signal:** commits since the context file was last updated, threshold in `policy.env`.
- **Ship scope:** Claude Code (`.claude/settings.json`) and Codex (`.codex/hooks.json`), the two tools with a session-start event. Gemini and Copilot have none and keep relying on the task-start rule.
- **Safety:** advisory only. Always exits 0; silent when it cannot measure drift (no git repo, file absent, or never committed). One shared script; both tools inject `SessionStart` stdout as context.

## Verification
- New sandbox test (`.ai-policy/scripts/test-context-drift-hook.sh`, auto-run by `project-validation.sh`): 5 cases green (at/over threshold, under, absent, never-committed, non-git).
- Installer end-to-end: hook delivered executable, test shipped, wiring present in the target.
- **Live Claude Code session** in an 11-commit-drifted repo received the reminder in-context and quoted it verbatim.
- Full `project-validation.sh` green; manifest integrity OK.

## Bookkeeping
- Canonical `3.11.0 -> 3.12.0` + matching `CHANGELOG.md` entry; lite `Version:` synced for parity.
- `project-context.md` structure line added; its own version `1.15.0 -> 1.16.0`.

A tagged release is warranted after merge (minor bump).