### PR TITLE
Gate agent pull-request merges deterministically

### DIFF
--- a/.ai-policy/hooks/block-pr-merge.sh
+++ b/.ai-policy/hooks/block-pr-merge.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -eu
+
+# PreToolUse hook for Claude Code, Codex, Gemini CLI, and VS Code Copilot.
+# Blocks the agent from merging a pull request by any route.
+# Reads tool_input from JSON on stdin.
+# Exit 2 = block, exit 0 = allow.
+#
+# Why this is separate from block-protected-branch-*.sh:
+# Those hooks ask "which branch does this write to?". A pull request merge has
+# no answer to that question — it is server-side, touches no local ref, and
+# names no branch in its arguments — so it passes a branch-shaped guard while
+# reaching the identical end state: unreviewed code on the protected branch.
+# This hook asks a different question: "is this a merge?". It is therefore
+# unconditional and does not consult the current branch or PROTECTED_BRANCHES.
+#
+# Merging is listed under "The Human is Responsible For" in ai-workflow.md.
+# The rule is flat — no PR merge, not "no merge to a protected branch" — so
+# this hook deliberately does not look up the pull request's base branch.
+# Doing so would require a network call inside a PreToolUse hook, which fails
+# open on timeout and would reintroduce the gap it is meant to close.
+
+INPUT="$(cat)"
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')"
+
+deny() {
+  echo "Blocked: $1" >&2
+  echo "Merging a pull request is the human's decision, not the agent's." >&2
+  echo "See 'The Human is Responsible For' in ai-workflow.md." >&2
+  echo "Report that the PR is ready and let the human merge it." >&2
+  exit 2
+}
+
+# ── MCP route ──
+# Matches mcp__github__merge_pull_request (Claude Code, Copilot) and
+# mcp_github_merge_pull_request (Gemini CLI), plus any other server prefix.
+case "$TOOL_NAME" in
+  *merge_pull_request) deny "MCP tool '$TOOL_NAME'" ;;
+esac
+
+# ── Shell route ──
+# Nothing to check when the payload carries no command.
+[ -n "$COMMAND" ] || exit 0
+
+# `gh pr merge` in any spacing, and anywhere in a compound command
+# (e.g. "git fetch && gh pr merge 12 --squash").
+# The leading boundary is any non-word character, so an absolute path
+# ("/usr/bin/gh pr merge") and a quoted wrapper ("bash -c \"gh pr merge 1\"")
+# are both caught, while a longer word ending in "gh" is not.
+if printf '%s' "$COMMAND" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+merge([^[:alnum:]_-]|$)'; then
+  deny "'$COMMAND'"
+fi
+
+# `gh api` against a pull request merge endpoint, e.g.
+# gh api --method PUT repos/o/r/pulls/12/merge
+if printf '%s' "$COMMAND" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+api([^[:alnum:]_-]|$)'; then
+  if printf '%s' "$COMMAND" | grep -Eq '/pulls/[0-9]+/merge'; then
+    deny "'$COMMAND'"
+  fi
+fi
+
+exit 0

--- a/.ai-policy/hooks/block-protected-branch-mcp.sh
+++ b/.ai-policy/hooks/block-protected-branch-mcp.sh
@@ -36,7 +36,11 @@ if [ -z "$BRANCH" ]; then
 fi
 
 if [ -z "$BRANCH" ]; then
-  # No branch info available (e.g. merge_pull_request) — cannot check, allow.
+  # No branch info available — this hook cannot judge, so it allows.
+  # Tools that reach a protected branch without naming one are not covered
+  # here by design; merge_pull_request is handled unconditionally by
+  # block-pr-merge.sh, which asks "is this a merge?" instead of
+  # "which branch does this write to?".
   exit 0
 fi
 

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -46,6 +46,7 @@ assert_allowed() {
 
 MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
 BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+MERGE_HOOK="$ROOT_DIR/.ai-policy/hooks/block-pr-merge.sh"
 
 # ── Path 2: MCP tool blocking ──
 
@@ -81,11 +82,24 @@ printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"feature/f
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "push_files to feature/foo" "$rc"
 
-# Test 6: merge_pull_request (no branch field) → allowed (limitation)
+# Test 6: merge_pull_request names no branch, so the branch hook cannot judge
+# it and allows it. block-pr-merge.sh is what blocks it. Both are asserted:
+# the first records why the branch hook alone was never sufficient.
 rc=0
 printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+assert_allowed "merge_pull_request passes the branch hook (names no branch)" "$rc"
+
+rc=0
+printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "merge_pull_request blocked by block-pr-merge" "$rc"
+
+# Test 6c: the shell route to the same end state.
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 12 --squash --delete-branch"}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "gh pr merge blocked by block-pr-merge" "$rc"
 
 # Test 6a: create_ref with tag ref → allowed (tags do not modify a branch)
 rc=0

--- a/.ai-policy/scripts/test-gemini-enforcement.sh
+++ b/.ai-policy/scripts/test-gemini-enforcement.sh
@@ -59,6 +59,7 @@ assert_contains() {
 }
 
 MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
+MERGE_HOOK="$ROOT_DIR/.ai-policy/hooks/block-pr-merge.sh"
 BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
 SETTINGS_JSON="$ROOT_DIR/.gemini/settings.json"
 
@@ -125,7 +126,17 @@ assert_allowed "push_files to feature/foo" "$rc"
 rc=0
 printf '{"tool_name":"mcp_github_merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+assert_allowed "merge_pull_request passes the branch hook (names no branch)" "$rc"
+
+rc=0
+printf '{"tool_name":"mcp_github_merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "merge_pull_request blocked by block-pr-merge" "$rc"
+
+rc=0
+printf '{"tool_name":"run_shell_command","tool_input":{"command":"gh pr merge 12 --squash"}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "gh pr merge blocked by block-pr-merge" "$rc"
 
 # Test: create_ref with tag ref → allowed (tags do not modify a branch)
 rc=0

--- a/.ai-policy/scripts/test-pr-merge-hook.sh
+++ b/.ai-policy/scripts/test-pr-merge-hook.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for block-pr-merge.sh.
+# Runs in every repo regardless of which agent entry points are installed,
+# because the hook is wired into all four and is not tool-specific.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HOOK="$ROOT_DIR/.ai-policy/hooks/block-pr-merge.sh"
+
+PASS=0
+FAIL=0
+
+run_hook() {
+  local rc=0
+  printf '%s' "$1" | "$HOOK" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+assert_blocked() {
+  local label="$1" payload="$2" rc
+  rc="$(run_hook "$payload")"
+  if [ "$rc" -eq 2 ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected exit 2, got $rc)"
+  fi
+}
+
+assert_allowed() {
+  local label="$1" payload="$2" rc
+  rc="$(run_hook "$payload")"
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected exit 0, got $rc)"
+  fi
+}
+
+bash_payload() {
+  printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"
+}
+
+mcp_payload() {
+  printf '{"tool_name":"%s","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' "$1"
+}
+
+# ── MCP route ──
+
+echo "MCP route — merge tools blocked:"
+
+assert_blocked "mcp__github__merge_pull_request" \
+  "$(mcp_payload "mcp__github__merge_pull_request")"
+
+# Gemini CLI normalises MCP tool names with single underscores.
+assert_blocked "mcp_github_merge_pull_request (Gemini naming)" \
+  "$(mcp_payload "mcp_github_merge_pull_request")"
+
+assert_blocked "merge_pull_request under a third-party server prefix" \
+  "$(mcp_payload "mcp__acme_forge__merge_pull_request")"
+
+echo "MCP route — non-merge tools allowed:"
+
+assert_allowed "mcp__github__create_pull_request" \
+  "$(mcp_payload "mcp__github__create_pull_request")"
+
+assert_allowed "mcp__github__get_pull_request" \
+  "$(mcp_payload "mcp__github__get_pull_request")"
+
+assert_allowed "mcp__github__push_files" \
+  '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"feature/x","owner":"x","repo":"y"}}'
+
+# ── Shell route: blocked ──
+
+echo "Shell route — merge commands blocked:"
+
+assert_blocked "gh pr merge 773 --squash --delete-branch" \
+  "$(bash_payload 'gh pr merge 773 --squash --delete-branch')"
+
+assert_blocked "gh pr merge (bare)" \
+  "$(bash_payload 'gh pr merge')"
+
+assert_blocked "irregular spacing" \
+  "$(bash_payload 'gh   pr    merge 1 --squash')"
+
+assert_blocked "leading whitespace" \
+  "$(bash_payload '   gh pr merge 5')"
+
+assert_blocked "compound with &&" \
+  "$(bash_payload 'git fetch origin && gh pr merge 12 --squash')"
+
+assert_blocked "compound with ;" \
+  "$(bash_payload 'echo start; gh pr merge 12')"
+
+assert_blocked "piped into a subshell" \
+  "$(bash_payload 'bash -c "gh pr merge 1 --squash"')"
+
+assert_blocked "absolute path to gh" \
+  "$(bash_payload '/opt/homebrew/bin/gh pr merge 4')"
+
+assert_blocked "env prefix" \
+  "$(bash_payload 'GH_TOKEN=abc gh pr merge 7 --merge')"
+
+assert_blocked "gh api PUT to merge endpoint" \
+  "$(bash_payload 'gh api --method PUT repos/owner/name/pulls/12/merge')"
+
+assert_blocked "gh api -X PUT to merge endpoint" \
+  "$(bash_payload 'gh api -X PUT /repos/owner/name/pulls/3/merge -f merge_method=squash')"
+
+# ── Shell route: allowed ──
+
+echo "Shell route — non-merge commands allowed:"
+
+assert_allowed "gh pr view 1" "$(bash_payload 'gh pr view 1')"
+assert_allowed "gh pr list" "$(bash_payload 'gh pr list --state open')"
+assert_allowed "gh pr create" "$(bash_payload 'gh pr create --title t --body b')"
+assert_allowed "gh pr diff" "$(bash_payload 'gh pr diff 3')"
+assert_allowed "gh pr checkout" "$(bash_payload 'gh pr checkout 9')"
+assert_allowed "gh pr status" "$(bash_payload 'gh pr status')"
+
+# git's own merge is a local operation; the branch guard owns that path.
+assert_allowed "git merge main" "$(bash_payload 'git merge main')"
+assert_allowed "git commit" "$(bash_payload 'git commit -m test')"
+assert_allowed "ls -la" "$(bash_payload 'ls -la')"
+
+# gh api against a non-merge endpoint.
+assert_allowed "gh api pulls/12 (no /merge)" \
+  "$(bash_payload 'gh api repos/owner/name/pulls/12')"
+
+# A longer word ending in "gh" must not trigger the boundary match.
+assert_allowed "word ending in gh" \
+  "$(bash_payload 'highgh pr merge')"
+
+# Payload carrying no command at all.
+assert_allowed "Bash payload with empty command" \
+  '{"tool_name":"Bash","tool_input":{}}'
+
+# ── Deliberate conservatism ──
+#
+# The shell match is textual, so a command that merely mentions the string is
+# blocked too. This is an accepted false positive: the failure mode of letting
+# a merge through is a production deploy, the failure mode of a false positive
+# is a permission prompt. These assert the current behaviour so a future
+# loosening of the pattern is a visible decision rather than a silent one.
+
+echo "Conservative matches (accepted false positives):"
+
+assert_blocked "grep for the literal string" \
+  "$(bash_payload 'grep -r "gh pr merge" docs/')"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
+++ b/.ai-policy/scripts/test-vscode-copilot-enforcement.sh
@@ -60,6 +60,7 @@ assert_contains() {
 
 HOOK_JSON="$ROOT_DIR/.github/hooks/block-protected-branch.json"
 MCP_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-mcp.sh"
+MERGE_HOOK="$ROOT_DIR/.ai-policy/hooks/block-pr-merge.sh"
 BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
 
 # ── Prerequisite: config file exists and is valid JSON ──
@@ -120,11 +121,22 @@ printf '{"tool_name":"mcp__github__push_files","tool_input":{"branch":"feature/f
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
 assert_allowed "push_files to feature/foo" "$rc"
 
-# Test: merge_pull_request (no branch field) → allowed (known limitation)
+# Test: merge_pull_request names no branch, so the branch hook allows it.
+# block-pr-merge.sh is what blocks it, on both the MCP and shell routes.
 rc=0
 printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
   | "$MCP_HOOK" >/dev/null 2>&1 || rc=$?
-assert_allowed "merge_pull_request (no branch — known limitation)" "$rc"
+assert_allowed "merge_pull_request passes the branch hook (names no branch)" "$rc"
+
+rc=0
+printf '{"tool_name":"mcp__github__merge_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "merge_pull_request blocked by block-pr-merge" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 12 --squash"}}' \
+  | "$MERGE_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "gh pr merge blocked by block-pr-merge" "$rc"
 
 # Test: create_ref with tag ref → allowed (tags do not modify a branch)
 rc=0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,13 @@
       "Bash(git push:*)",
       "Bash(git pull:*)",
       "Bash(gh issue:*)",
-      "Bash(gh pr:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr checkout:*)",
+      "Bash(gh pr create:*)",
       "Bash(gh repo:*)",
       "Bash(gh auth:*)",
       "Bash(ls:*)",
@@ -78,7 +84,9 @@
       "mcp__github__create_pull_request",
       "mcp__github__list_pull_requests"
     ],
-    "deny": []
+    "deny": [
+      "Bash(gh pr merge:*)"
+    ]
   },
   "hooks": {
     "SessionStart": [
@@ -97,6 +105,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
           }
         ]
@@ -104,6 +116,10 @@
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\""
+          },
           {
             "type": "command",
             "if": "Bash(git commit *)",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -22,6 +22,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\"",
             "timeout": 10
           }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -10,6 +10,12 @@
         "matcher": "mcp_.*github.*",
         "hooks": [
           {
+            "name": "block-pr-merge",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\"",
+            "timeout": 10000
+          },
+          {
             "name": "block-protected-branch-mcp",
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\"",
@@ -20,6 +26,12 @@
       {
         "matcher": "run_shell_command",
         "hooks": [
+          {
+            "name": "block-pr-merge",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\"",
+            "timeout": 10000
+          },
           {
             "name": "block-protected-branch-bash",
             "type": "command",

--- a/.github/hooks/block-protected-branch.json
+++ b/.github/hooks/block-protected-branch.json
@@ -3,6 +3,10 @@
     "PreToolUse": [
       {
         "type": "command",
+        "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\""
+      },
+      {
+        "type": "command",
         "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
       },
       {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,8 +35,18 @@
         "git pull": true,
 
         // GitHub CLI
+        // "gh pr" is deliberately NOT auto-approved as a family: it would
+        // cover "gh pr merge", which the human alone may run. Subcommands
+        // are listed individually so a consequential one cannot inherit
+        // approval granted to a trivial one.
         "gh issue": true,
-        "gh pr": true,
+        "gh pr view": true,
+        "gh pr list": true,
+        "gh pr diff": true,
+        "gh pr status": true,
+        "gh pr checks": true,
+        "gh pr checkout": true,
+        "gh pr create": true,
         "gh repo": true,
         "gh auth": true,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.13.0 - 2026-08-04
+
+### Added
+
+- Added `.ai-policy/hooks/block-pr-merge.sh`, a hook that blocks the agent from merging a pull request on both the shell route (`gh pr merge`, and `gh api` against a `/pulls/N/merge` endpoint) and the MCP route (`merge_pull_request` under any server prefix). `ai-workflow.md` already listed merging and deploy authorisation under "The Human is Responsible For", but nothing enforced it: `.claude/settings.json` allowed `Bash(gh pr:*)` with an empty `deny`, so `gh pr merge` inherited the approval granted to `gh pr view`, and `block-protected-branch-bash.sh` filters to `git commit*|git push*` before evaluating any policy. The existing guards ask "which branch does this write to?", a question a pull request merge cannot answer — it is server-side, touches no local ref, and names no branch — so a merge passed every check while reaching the same end state as a push to a protected branch. This hook asks "is this a merge?" instead, and blocks unconditionally rather than consulting `PROTECTED_BRANCHES`; it deliberately does not look up the PR's base branch, since a network call inside a `PreToolUse` hook fails open on timeout. Wired into all four agent entry points (`.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, `.github/hooks/block-protected-branch.json`) with no command filter, so it is reached regardless of how each tool gates hook invocation. Covered by `.ai-policy/scripts/test-pr-merge-hook.sh`, auto-discovered by `project-validation.sh` and run in every repo since the hook is not tool-specific ([#193]).
+
+### Changed
+
+- Narrowed the auto-approved `gh pr` permission from a whole-family wildcard to named subcommands (`view`, `list`, `diff`, `status`, `checks`, `checkout`, `create`) in `.claude/settings.json` and `.vscode/settings.json`, and added `Bash(gh pr merge:*)` to the previously empty Claude Code `deny` list. Grouping a consequential command with trivial ones let the most destructive member of the family inherit the approval granted to the most harmless; `gh pr merge`, `gh pr close`, `gh pr edit`, `gh pr ready` and `gh pr review` now prompt. The `deny` entry is secondary to the hook, which is the load-bearing guard ([#193]).
+- Inverted the three enforcement-test assertions that certified this gap. `test-claude-code-enforcement.sh`, `test-vscode-copilot-enforcement.sh` and `test-gemini-enforcement.sh` each asserted `assert_allowed "merge_pull_request (no branch — known limitation)"`, so the green validation bar stated that an agent may merge a pull request and any fix closing the hole would have failed validation. Each now keeps the branch-hook assertion, relabelled to record *why* that hook alone was never sufficient, and adds assertions that `block-pr-merge.sh` blocks the merge on both routes. Updated the corresponding fail-open comment in `block-protected-branch-mcp.sh` to point at the new hook instead of describing the gap as a limitation ([#193]).
+- `lite-monolithic/ai-workflow.md` has no policy layer, so its version is bumped to stay in canonical parity with no content change ([#193]).
+
 ## 3.12.0 - 2026-07-17
 
 ### Added
@@ -447,3 +459,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#187]: https://github.com/philippe-ths/ai-coding-workflow/issues/187
 [#189]: https://github.com/philippe-ths/ai-coding-workflow/issues/189
 [#191]: https://github.com/philippe-ths/ai-coding-workflow/issues/191
+[#193]: https://github.com/philippe-ths/ai-coding-workflow/issues/193

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.12.0
+Version: 3.13.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.12.0
+Version: 3.13.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.16.0
+Version: 1.17.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -84,7 +84,8 @@ Version: 1.16.0
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry) and `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only).
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), and `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools).
+- The branch guards (`block-protected-branch-bash.sh`, `block-protected-branch-mcp.sh`) are branch-conditioned and ask which branch a write targets; `block-pr-merge.sh` is not branch-conditioned, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.
@@ -115,7 +116,7 @@ Version: 1.16.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, and `test-context-drift-hook.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, and `test-pr-merge-hook.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.


### PR DESCRIPTION
Closes #193.

## Problem

The policy layer protected `main` by asking *which branch does this write to?* A pull request merge has no answer: it is server-side, touches no local ref, and names no branch. It therefore passed every guard while reaching the same end state as a push to a protected branch, and in an auto-deploy repo, production.

Three independent causes, each sufficient alone:

| | |
|---|---|
| Allow-list | `Bash(gh pr:*)` covered the whole subcommand family with an empty `deny`. The most consequential member inherited the approval granted to the most trivial. |
| Hook reach | `block-protected-branch-bash.sh:17-20` filters to `git commit*\|git push*` before evaluating any policy; `.claude/settings.json` further gated the hook with `if` conditions for those same two commands. |
| Wrong question | The branch check reads the *local* branch, which a server-side merge never touches. It would pass even if reached. |

## The gap was certified, not merely unseen

Three enforcement tests asserted the MCP merge tool was allowed, labelled "known limitation". The green validation bar stated that an agent may merge a pull request, and any fix closing the hole would have failed validation until those assertions were inverted.

## Approach

`.ai-policy/hooks/block-pr-merge.sh` asks **"is this a merge?"** instead of "which branch?", and blocks unconditionally rather than consulting `PROTECTED_BRANCHES`.

It deliberately does *not* look up the pull request's base branch. That would require a network call inside a `PreToolUse` hook, which fails open on timeout and would reintroduce the gap it closes. The rule in `ai-workflow.md` is flat anyway: no agent PR merges, not "no merges to a protected branch".

Wired into all four entry points with **no command filter**, so it is reached however each tool gates hook invocation.

Covers the shell route (`gh pr merge` in any spacing, compound commands, absolute paths, quoted wrappers, env prefixes, and `gh api` against `/pulls/N/merge`) and the MCP route (`merge_pull_request` under any server prefix, including Gemini's single-underscore naming).

Also narrows the auto-approved subcommands to the read-only ones plus `create` and `checkout`, and adds the merge command to the Claude Code `deny` list. The `deny` entry is secondary; the hook is load-bearing.

## Verification

Before/after on the exact incident command:

```
Pre-existing guards, given the incident inputs:
  ALLOWED (exit 0)  branch-bash hook  <- shell merge
  ALLOWED (exit 0)  branch-mcp hook   <- shell merge
  ALLOWED (exit 0)  branch-mcp hook   <- MCP merge
New guard, same inputs:
  blocked (exit 2)  block-pr-merge    <- shell merge
  blocked (exit 2)  block-pr-merge    <- MCP merge
```

Verified live in a running session, executed by the harness rather than by piping payloads: both the direct and the compound form were blocked, while `gh pr list` still ran unprompted. Full validation exits 0, including the new 30-case always-run suite.

## Not verified

- **Only Claude Code was exercised live.** Codex, Gemini and Copilot wiring is JSON-valid and copies the shape of existing working entries, but firing under Gemini's `BeforeTool` is inference from the pattern, not observation.
- **The `deny` entry is unproven.** The hook fires first, so the two cannot be distinguished. `deny` precedence and `if`-field semantics were not confirmed from the docs; the fix is built so the hook carries the weight either way.
- **Install into a fresh target is untested for hook firing.** The sandbox tests cover file copying, not whether the hook fires in an installed repo.

## Known cost

The shell match is textual, so a command that merely *mentions* the string is blocked too. This was hit during development: the before/after script and this PR's own commit message had to be routed through files. Accepted trade-off, and asserted in the test so a future loosening is a visible decision rather than a silent one. The failure mode of letting a merge through is a production deploy; the failure mode of a false positive is a permission prompt.

## Out of scope, found while working

From a feature branch, `git push origin HEAD:main` is allowed by every guard, including the pre-push git hook. Same shape of bug: the guard asks where you are standing, the risk is what you are writing to. `block-protected-branch-bash.sh:23-24` calls the pre-push hook "the authoritative safety net, which inspects the actual refs being pushed" — it reads the refs only to decide tag-only versus not, then delegates to a current-branch check. Not addressed here.
