### PR TITLE
Check the ref being pushed, not the branch being stood on

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-bash.sh
+++ b/.ai-policy/hooks/block-protected-branch-bash.sh
@@ -20,8 +20,12 @@ case "$COMMAND" in
 esac
 
 # Tag-only pushes do not modify a branch and are allowed on protected branches.
-# The authoritative safety net is the pre-push git hook, which inspects the
-# actual refs being pushed. This is a usability-layer heuristic.
+# The authoritative safety net is check-push-refs.sh, invoked by the pre-push
+# git hook, which inspects the resolved refs git is actually about to write.
+# Everything in this file is a usability-layer heuristic working from a command
+# string: it fires before the command runs, so it gives a better error, but it
+# can be defeated by shell constructs it cannot parse. When the two disagree,
+# the pre-push check is correct.
 is_tag_push() {
   local cmd="$1"
   # git commit never creates a tag push; only applies to push commands.
@@ -74,6 +78,57 @@ is_tag_push() {
 
 if is_tag_push "$COMMAND"; then
   exit 0
+fi
+
+# Does an explicit refspec name a protected branch as its target?
+# `git push origin HEAD:main` writes to a protected branch while the current
+# branch is unprotected, so the current-branch check below cannot see it.
+targets_protected_branch() {
+  local cmd="$1"
+  case "$cmd" in
+    git\ push*) ;;
+    *) return 1 ;;
+  esac
+
+  local args
+  args="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]*git[[:space:]]+push[[:space:]]*//')"
+
+  local seen_remote=false target
+  for token in $args; do
+    # Skip flags. A flag taking a separate value can shift the positional
+    # count and cause a miss; check-push-refs.sh is the backstop for that.
+    case "$token" in
+      -*) continue ;;
+    esac
+
+    # The first positional is the remote, not a refspec.
+    if [ "$seen_remote" = false ]; then
+      seen_remote=true
+      continue
+    fi
+
+    # Refspec forms: <dst>, <src>:<dst>, :<dst> (delete), +<src>:<dst> (force).
+    target="${token#+}"
+    case "$target" in
+      *:*) target="${target##*:}" ;;
+    esac
+    target="${target#refs/heads/}"
+
+    for protected in $PROTECTED_BRANCHES; do
+      if [ "$target" = "$protected" ]; then
+        return 0
+      fi
+    done
+  done
+
+  return 1
+}
+
+if targets_protected_branch "$COMMAND"; then
+  echo "Blocked: '$COMMAND' targets protected branch." >&2
+  echo "The refspec writes to a protected branch even though the current branch is not one." >&2
+  echo "Open a pull request instead; merging it is the human's decision." >&2
+  exit 2
 fi
 
 CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"

--- a/.ai-policy/scripts/check-push-refs.sh
+++ b/.ai-policy/scripts/check-push-refs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -eu
+
+# Authoritative protected-branch check for pushes.
+# Reads git's pre-push stdin format, one line per ref:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# Blocks when any remote_ref names a protected branch.
+# Exit 2 = block, exit 0 = allow.
+#
+# This asks "what is being written to?" rather than "where am I standing?".
+# check-protected-branch.sh asks the second question, which a refspec push
+# answers incorrectly: `git push origin HEAD:main` from a feature branch
+# writes to a protected branch while standing on an unprotected one.
+# Only the pre-push hook receives the resolved refs, so this is the only
+# place the real target can be checked rather than guessed from a command
+# string.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1091
+. "$ROOT_DIR/.ai-policy/policy.env"
+
+BLOCKED=""
+
+# The `|| [ -n ... ]` clause processes a final line with no trailing newline.
+# Without it, `read` returns non-zero on that line and the loop body is
+# skipped, silently allowing the very ref being checked.
+while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha \
+  || [ -n "${remote_ref:-}" ]; do
+  [ -z "${remote_ref:-}" ] && continue
+
+  # Only branch refs can be a protected branch. Tags are handled by the caller.
+  case "$remote_ref" in
+    refs/heads/*) branch="${remote_ref#refs/heads/}" ;;
+    *) continue ;;
+  esac
+
+  for protected in $PROTECTED_BRANCHES; do
+    if [ "$branch" = "$protected" ]; then
+      BLOCKED="$BLOCKED $branch"
+    fi
+  done
+done
+
+if [ -n "$BLOCKED" ]; then
+  echo "Blocked: push targets protected branch(es):$BLOCKED" >&2
+  echo "The ref being pushed, not the branch you are standing on, is what matters here." >&2
+  echo "Open a pull request instead; merging it is the human's decision." >&2
+  exit 2
+fi
+
+exit 0

--- a/.ai-policy/scripts/test-pre-push-hook.sh
+++ b/.ai-policy/scripts/test-pre-push-hook.sh
@@ -43,6 +43,16 @@ exit 2
 STUB
 chmod +x .ai-policy/scripts/check-protected-branch.sh
 
+# Stub: check-push-refs.sh — allows by default so the tests below exercise
+# pre-push's own tag-vs-branch logic. Its real behaviour is covered by
+# test-push-refs.sh; the final test here swaps this stub to prove the wiring.
+cat > .ai-policy/scripts/check-push-refs.sh <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+STUB
+chmod +x .ai-policy/scripts/check-push-refs.sh
+
 # Stub: check-validation.sh — not invoked because REQUIRE_VALIDATION_BEFORE_PUSH=false.
 cat > .ai-policy/scripts/check-validation.sh <<'STUB'
 #!/usr/bin/env bash
@@ -113,6 +123,42 @@ assert_exit "tag deletion skips branch check" 0 "$rc"
 rc=0
 printf '' | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
 assert_exit "empty stdin invokes branch check" 2 "$rc"
+
+# 8. The ref-target check is actually wired in, and runs even for a tag-only
+# push (it needs no tag guard of its own, so it must not be skipped). Swap the
+# stub for one with a distinctive exit code and confirm pre-push propagates it.
+cat > .ai-policy/scripts/check-push-refs.sh <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 3
+STUB
+chmod +x .ai-policy/scripts/check-push-refs.sh
+
+rc=0
+printf 'refs/heads/feature abc refs/heads/feature def\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "branch push reaches check-push-refs" 3 "$rc"
+
+rc=0
+printf 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000000000\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "tag-only push also reaches check-push-refs" 3 "$rc"
+
+# 9. The refs reach the check on stdin rather than arriving empty.
+cat > .ai-policy/scripts/check-push-refs.sh <<'STUB'
+#!/usr/bin/env bash
+input="$(cat)"
+case "$input" in
+  *refs/heads/main*) exit 4 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x .ai-policy/scripts/check-push-refs.sh
+
+rc=0
+printf 'HEAD abc refs/heads/main def\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "push refs are piped to check-push-refs" 4 "$rc"
 
 # ── Summary ──
 

--- a/.ai-policy/scripts/test-push-refs.sh
+++ b/.ai-policy/scripts/test-push-refs.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests that a push targeting a protected branch is blocked regardless of
+# which branch the pusher is standing on.
+#
+# Two layers are covered:
+#   check-push-refs.sh          — authoritative, reads resolved refs
+#   block-protected-branch-bash — heuristic, reads the command string
+#
+# Runs in every repo; neither layer is tool-specific.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+REFS_CHECK="$ROOT_DIR/.ai-policy/scripts/check-push-refs.sh"
+BASH_HOOK="$ROOT_DIR/.ai-policy/hooks/block-protected-branch-bash.sh"
+
+PASS=0
+FAIL=0
+
+judge() { # label, expected, actual
+  if [ "$3" -eq "$2" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $1"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $1 (expected exit $2, got $3)"
+  fi
+}
+
+refs_exit() {
+  local rc=0
+  printf '%s\n' "$1" | "$REFS_CHECK" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+cmd_exit() {
+  local rc=0
+  printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)" \
+    | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# ── Layer 1: check-push-refs.sh, the authoritative check ──
+#
+# Every case here is evaluated with no reference to the current branch, which
+# is the whole point: these must block from a feature branch.
+
+echo "check-push-refs.sh — protected targets blocked:"
+
+judge "push to refs/heads/main" 2 \
+  "$(refs_exit 'HEAD abc refs/heads/main def')"
+
+judge "push to refs/heads/master" 2 \
+  "$(refs_exit 'refs/heads/feature abc refs/heads/master def')"
+
+judge "force-push to main (same ref shape)" 2 \
+  "$(refs_exit 'refs/heads/feature abc refs/heads/main def')"
+
+judge "delete remote main (zero local sha)" 2 \
+  "$(refs_exit '(delete) 0000000000000000000000000000000000000000 refs/heads/main abc')"
+
+judge "mixed refs, one protected" 2 \
+  "$(printf 'refs/heads/feature abc refs/heads/feature def\nrefs/heads/main abc refs/heads/main def' | { rc=0; "$REFS_CHECK" >/dev/null 2>&1 || rc=$?; echo "$rc"; })"
+
+echo "check-push-refs.sh — everything else allowed:"
+
+judge "push to a feature branch" 0 \
+  "$(refs_exit 'refs/heads/feature/x abc refs/heads/feature/x def')"
+
+judge "tag push" 0 \
+  "$(refs_exit 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000000000')"
+
+judge "tag deletion" 0 \
+  "$(refs_exit '(delete) 0000000000000000000000000000000000000000 refs/tags/v1.0.0 abc')"
+
+judge "branch whose name merely contains a protected name" 0 \
+  "$(refs_exit 'refs/heads/mainline abc refs/heads/mainline def')"
+
+judge "empty input" 0 "$(refs_exit '')"
+
+# ── Layer 2: the command-string heuristic ──
+#
+# These run on whatever branch the suite happens to be on. Assertions are
+# written so they hold either way: a protected refspec must block regardless,
+# and the allowed cases are only asserted when the current branch is not
+# protected (on a protected branch the current-branch rule blocks them, which
+# is correct and is covered by the enforcement suites).
+
+echo "block-protected-branch-bash — protected refspec blocked from any branch:"
+
+judge "git push origin HEAD:main" 2 "$(cmd_exit 'git push origin HEAD:main')"
+judge "git push origin main" 2 "$(cmd_exit 'git push origin main')"
+judge "git push origin feature:main" 2 "$(cmd_exit 'git push origin feature:main')"
+judge "git push --force origin HEAD:refs/heads/main" 2 \
+  "$(cmd_exit 'git push --force origin HEAD:refs/heads/main')"
+judge "git push origin +HEAD:main (force refspec)" 2 \
+  "$(cmd_exit 'git push origin +HEAD:main')"
+judge "git push origin :main (delete remote main)" 2 \
+  "$(cmd_exit 'git push origin :main')"
+judge "git push origin HEAD:master" 2 "$(cmd_exit 'git push origin HEAD:master')"
+judge "git push origin main:refs/heads/main" 2 \
+  "$(cmd_exit 'git push origin main:refs/heads/main')"
+
+CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"
+IS_PROTECTED=false
+# shellcheck disable=SC1091
+. "$ROOT_DIR/.ai-policy/policy.env"
+for protected in $PROTECTED_BRANCHES; do
+  [ "$CURRENT_BRANCH" = "$protected" ] && IS_PROTECTED=true
+done
+
+if [ "$IS_PROTECTED" = "true" ]; then
+  echo "block-protected-branch-bash — non-protected targets (skipped: on $CURRENT_BRANCH)"
+else
+  echo "block-protected-branch-bash — non-protected targets allowed (on $CURRENT_BRANCH):"
+
+  judge "git push origin feature/x" 0 "$(cmd_exit 'git push origin feature/x')"
+  judge "git push -u origin feature/x" 0 "$(cmd_exit 'git push -u origin feature/x')"
+  judge "git push (no refspec)" 0 "$(cmd_exit 'git push')"
+  judge "git push origin (remote only)" 0 "$(cmd_exit 'git push origin')"
+  judge "branch merely containing a protected name" 0 \
+    "$(cmd_exit 'git push origin HEAD:mainline')"
+  judge "tag push still allowed" 0 "$(cmd_exit 'git push origin --tags')"
+  judge "tag refspec still allowed" 0 \
+    "$(cmd_exit 'git push origin refs/tags/v1.0.0')"
+  judge "git push origin tag v1.0.0 still allowed" 0 \
+    "$(cmd_exit 'git push origin tag v1.0.0')"
+  judge "git commit untouched" 0 "$(cmd_exit 'git commit -m test')"
+  judge "non-git command untouched" 0 "$(cmd_exit 'ls -la')"
+fi
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -23,6 +23,14 @@ done <<EOF
 $PUSH_REFS
 EOF
 
+# Authoritative check: does any ref being pushed target a protected branch?
+# This runs first and unconditionally. Tag refs pass it by construction, so it
+# needs no tag-only guard of its own.
+printf '%s\n' "$PUSH_REFS" | "$ROOT_DIR/.ai-policy/scripts/check-push-refs.sh"
+
+# Usability check: are we standing on a protected branch? Narrower than the
+# check above and kept for the plain `git push` case, where no refspec is
+# given and the target is implied by the current branch.
 if [ "$HAS_ANY_REF" = "false" ] || [ "$TAG_ONLY" = "false" ]; then
   "$ROOT_DIR/.ai-policy/scripts/check-protected-branch.sh"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.14.0 - 2026-08-05
+
+### Added
+
+- Added `.ai-policy/scripts/check-push-refs.sh`, invoked by `.githooks/pre-push`, which blocks a push when any ref being pushed targets a protected branch. Every existing guard asked "where am I standing?" rather than "what am I writing to", so from a feature branch `git push origin HEAD:main` was allowed by all of them: the agent hook checked the current branch, and the pre-push hook read the refs only to decide whether the push was tag-only before delegating to a current-branch check. This is the same design flaw as [#193] on a route [#194] did not close, and unlike a pull request merge the target is named explicitly in the command, so nothing but the absence of a refspec check let it through. The pre-push hook is the only layer that receives git's resolved refs, so it is the only place the real target can be checked rather than guessed; the new script runs there, first and unconditionally, since tag refs pass it by construction. Blocks `HEAD:main`, `feature:main`, `+HEAD:main`, `HEAD:refs/heads/main`, and `:main` (deleting the remote protected branch). Covered by `.ai-policy/scripts/test-push-refs.sh`, auto-discovered by `project-validation.sh` and run in every repo since neither layer is tool-specific ([#195]).
+
+### Changed
+
+- `.ai-policy/hooks/block-protected-branch-bash.sh` now parses a `git push` refspec and blocks when its target names a protected branch, independent of the current branch. This fires before the command runs, so the agent gets a better error than a rejected push, but it works from a command string and can be defeated by shell constructs it cannot parse (a flag taking a separate value shifts the positional count); `check-push-refs.sh` is the backstop. Tag pushes, plain `git push`, and pushes to non-protected branches are unaffected ([#195]).
+- Corrected the comment at `.ai-policy/hooks/block-protected-branch-bash.sh:22-24`, which stated that "the authoritative safety net is the pre-push git hook, which inspects the actual refs being pushed". The pre-push hook read the refs only to classify the push as tag-only, then delegated to a check that ignored them, so the layer described as authoritative did not perform the check attributed to it and a reader would reasonably conclude the route was already protected. The comment now names `check-push-refs.sh`, which does perform it, and states which layer wins when the two disagree ([#195]).
+
+### Fixed
+
+- Fixed a fail-open in `check-push-refs.sh` where a final input line with no trailing newline was silently skipped, allowing the very ref under inspection. Git's pre-push always terminates its lines, so this was not reachable through the hook, but a guard should not depend on its caller's formatting. Caught by a test written before the behaviour was checked ([#195]).
+
 ## 3.13.0 - 2026-08-04
 
 ### Added
@@ -460,3 +475,5 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#189]: https://github.com/philippe-ths/ai-coding-workflow/issues/189
 [#191]: https://github.com/philippe-ths/ai-coding-workflow/issues/191
 [#193]: https://github.com/philippe-ths/ai-coding-workflow/issues/193
+[#194]: https://github.com/philippe-ths/ai-coding-workflow/pull/194
+[#195]: https://github.com/philippe-ths/ai-coding-workflow/issues/195

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.13.0
+Version: 3.14.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.13.0
+Version: 3.14.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.17.0
+Version: 1.18.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -85,7 +85,8 @@ Version: 1.17.0
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), and `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools).
-- The branch guards (`block-protected-branch-bash.sh`, `block-protected-branch-mcp.sh`) are branch-conditioned and ask which branch a write targets; `block-pr-merge.sh` is not branch-conditioned, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
+- `.ai-policy/scripts/check-push-refs.sh` is the authoritative protected-branch check for pushes; `.githooks/pre-push` pipes git's resolved refs to it, and it blocks when any pushed ref targets a protected branch.
+- Guards answer one of two questions. `check-push-refs.sh` and the refspec check in `block-protected-branch-bash.sh` ask what a write targets; `check-protected-branch.sh` and the current-branch check ask where the agent is standing; `block-pr-merge.sh` asks neither and blocks the action outright, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.
@@ -116,7 +117,7 @@ Version: 1.17.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, and `test-pr-merge-hook.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, and `test-push-refs.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.


### PR DESCRIPTION
Closes #195.

## Problem

Every protected-branch guard asked *where am I standing?* rather than *what am I writing to*. From a feature branch, a push whose refspec targeted a protected branch was allowed by all of them.

Same design flaw as #193, on a route #194 did not close. The difference is that a pull request merge names no branch, so a branch-shaped guard genuinely cannot see it, whereas `git push origin HEAD:main` names the target explicitly and it was simply never read.

`.githooks/pre-push` already received git's resolved refs, but used them only to classify the push as tag-only before delegating to `check-protected-branch.sh`, which checks `current-branch.sh` and ignores the refs entirely.

## A comment made this harder to notice

`block-protected-branch-bash.sh:22-24` stated that "the authoritative safety net is the pre-push git hook, which inspects the actual refs being pushed". The layer described as authoritative did not perform the check attributed to it, so a reader would reasonably conclude the route was already protected. Corrected, and now true.

## Approach

Two layers, explicitly ranked.

**`check-push-refs.sh`** is authoritative. Invoked by `.githooks/pre-push`, it reads git's resolved refs and blocks when any targets a protected branch. It runs first and unconditionally; tag refs pass by construction, so it needs no tag guard of its own. This is the only layer that sees what git is actually about to write rather than inferring it from a command string.

**The refspec parser in `block-protected-branch-bash.sh`** is a usability layer. It fires before the command runs, giving a better error than a rejected push, but it works from a string and can be defeated by constructs it cannot read.

Blocked forms: `HEAD:main`, `main`, `feature:main`, `+HEAD:main`, `HEAD:refs/heads/main`, and `:main`, the last of which deletes the remote protected branch outright.

## Verification

End-to-end against a real remote with the real hooks installed, not stubs.

Pre-fix policy layer taken from `origin/main`:

```
git push origin HEAD:main -> ALLOWED (exit 0)
remote main before: 3c6ebf1
remote main after:  36f0c19
VERDICT: remote main MOVED to the feature commit.
```

This branch, same scenario:

```
  ok    git push origin HEAD:main                      -> block
  ok    git push --force origin HEAD:refs/heads/main   -> block
  ok    git push origin :main (delete remote main)     -> block
  ok    git push origin HEAD:feature/x                 -> allow
  ok    git push origin --tags                         -> allow
  VERDICT: remote main still at the seed commit.
```

Also blocked live by the agent hook. Full validation exits 0. `test-push-refs.sh` adds 28 cases; `test-pre-push-hook.sh` gains three that prove the wiring and that the refs actually arrive on stdin, rather than assuming either.

## A fail-open the tests caught

`check-push-refs.sh` initially skipped a final input line with no trailing newline, which would have allowed the very ref under inspection. Not reachable through git, which always terminates its lines, but a guard should not depend on its caller's formatting. Fixed and asserted.

## Measured limits of the heuristic layer

Probed adversarially rather than assumed:

```
  caught git push -o ci.skip origin HEAD:main
  caught git push --receive-pack=/x origin HEAD:main
  caught git push --force-with-lease origin HEAD:main
  caught git push origin HEAD:refs/heads/main
  MISS   git push origin $TARGET
  MISS   git push origin "HEAD:$(echo main)"
  MISS   git push origin HEAD:mai"n"
  MISS   cd /tmp && git push origin HEAD:main
```

The first three misses are inherent: a target behind expansion cannot be read from a string. All four are backstopped by `check-push-refs.sh`.

## Out of scope, found while working

The fourth miss has a different cause. The filter in `block-protected-branch-bash.sh` anchors on `git push*` at the *start* of the command, so no compound command reaches any policy in that file. This predates both this change and #194, and applies equally to `git commit`. Both are backstopped by `.githooks/pre-commit` and `.githooks/pre-push`, which run however the command was invoked, so the cost is a worse error message rather than a hole. Not addressed here: fixing it means changing the top-level filter and `is_tag_push` together, a wider blast radius than this issue warrants.
