### PR TITLE
Deny agent pull-request approvals

### DIFF
--- a/.ai-policy/hooks/block-pr-approve.sh
+++ b/.ai-policy/hooks/block-pr-approve.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -eu
+
+# PreToolUse hook for Claude Code, Codex, Gemini CLI, and VS Code Copilot.
+# Blocks the agent from approving a pull request by any route.
+# Reads tool_input from JSON on stdin.
+# Exit 2 = block, exit 0 = allow.
+#
+# Approving review is a human judgement in the same category as merging, so
+# this hook is shaped like block-pr-merge.sh: it asks "is this an approval?"
+# and blocks unconditionally, rather than conditioning on any repository state.
+#
+# The failure this prevents is self-approval: an agent that opens a pull
+# request and approves it has satisfied a human-shaped review requirement
+# using only its own judgement. block-pr-merge.sh stops the loop completing,
+# but the approval is a false signal recorded against a human process.
+#
+# Leaving a review comment and requesting changes are not approvals and are
+# not blocked here. Neither is auto-approved in the permission defaults, so
+# both still prompt.
+
+INPUT="$(cat)"
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')"
+
+deny() {
+  echo "Blocked: $1" >&2
+  echo "Approving a pull request is the human's decision, not the agent's." >&2
+  echo "An agent approving its own work is not review." >&2
+  echo "Report what you changed and what you verified, and let the human review it." >&2
+  exit 2
+}
+
+# ── MCP route ──
+# Review creation and submission tools, under any server prefix.
+case "$TOOL_NAME" in
+  *create_pull_request_review|*submit_pending_pull_request_review|*create_and_submit_pull_request_review)
+    EVENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.event // empty' | tr '[:lower:]' '[:upper:]')"
+    # Fail closed: block unless the payload positively identifies itself as a
+    # non-approving review. An absent or unrecognised event is treated as an
+    # approval, because guessing the other way is how merge_pull_request got
+    # through the branch guards.
+    case "$EVENT" in
+      COMMENT|REQUEST_CHANGES) exit 0 ;;
+      *) deny "MCP tool '$TOOL_NAME' (event: ${EVENT:-unspecified})" ;;
+    esac
+    ;;
+esac
+
+# ── Shell route ──
+[ -n "$COMMAND" ] || exit 0
+
+# `gh pr review` anywhere in the command, in any spacing.
+if printf '%s' "$COMMAND" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+review([^[:alnum:]_-]|$)'; then
+  # An explicit non-approving review type is allowed through.
+  if printf '%s' "$COMMAND" | grep -Eq '(^|[[:space:]])--(comment|request-changes)([[:space:]=]|$)'; then
+    exit 0
+  fi
+  # --approve, or no review type at all. The latter is interactive and offers
+  # approval as an option, so it is blocked rather than gambled on.
+  deny "'$COMMAND'"
+fi
+
+# `gh api` against the reviews endpoint. The event lives in the request body,
+# which cannot be read reliably from a command string, so this blocks the
+# endpoint rather than trying to parse intent out of it.
+if printf '%s' "$COMMAND" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+api([^[:alnum:]_-]|$)'; then
+  if printf '%s' "$COMMAND" | grep -Eq '/pulls/[0-9]+/reviews'; then
+    deny "'$COMMAND'"
+  fi
+fi
+
+exit 0

--- a/.ai-policy/scripts/test-pr-approve-hook.sh
+++ b/.ai-policy/scripts/test-pr-approve-hook.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for block-pr-approve.sh.
+# Runs in every repo; the hook is wired into all four entry points and is not
+# tool-specific.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HOOK="$ROOT_DIR/.ai-policy/hooks/block-pr-approve.sh"
+
+PASS=0
+FAIL=0
+
+run_hook() {
+  local rc=0
+  printf '%s' "$1" | "$HOOK" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+assert_blocked() {
+  local rc; rc="$(run_hook "$2")"
+  if [ "$rc" -eq 2 ]; then PASS=$((PASS + 1)); echo "  PASS: $1"
+  else FAIL=$((FAIL + 1)); echo "  FAIL: $1 (expected exit 2, got $rc)"; fi
+}
+
+assert_allowed() {
+  local rc; rc="$(run_hook "$2")"
+  if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: $1"
+  else FAIL=$((FAIL + 1)); echo "  FAIL: $1 (expected exit 0, got $rc)"; fi
+}
+
+bash_payload() {
+  printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"
+}
+
+# ── Shell route: blocked ──
+
+echo "Shell route — approvals blocked:"
+
+assert_blocked "gh pr review --approve" "$(bash_payload 'gh pr review --approve')"
+assert_blocked "gh pr review 12 --approve" "$(bash_payload 'gh pr review 12 --approve')"
+assert_blocked "approve with a body" \
+  "$(bash_payload 'gh pr review 12 --approve --body "lgtm"')"
+assert_blocked "bare gh pr review (interactive)" "$(bash_payload 'gh pr review')"
+assert_blocked "bare review with a PR number" "$(bash_payload 'gh pr review 12')"
+assert_blocked "irregular spacing" "$(bash_payload 'gh   pr    review  --approve')"
+assert_blocked "compound command" \
+  "$(bash_payload 'gh pr checks 12 && gh pr review 12 --approve')"
+assert_blocked "absolute path to gh" \
+  "$(bash_payload '/opt/homebrew/bin/gh pr review 4 --approve')"
+assert_blocked "quoted wrapper" \
+  "$(bash_payload 'bash -c "gh pr review 1 --approve"')"
+assert_blocked "gh api POST to reviews endpoint" \
+  "$(bash_payload 'gh api --method POST repos/o/n/pulls/12/reviews -f event=APPROVE')"
+
+# ── Shell route: allowed ──
+#
+# Non-approving review types are not this hook's business. Neither is
+# auto-approved in the permission defaults, so both still prompt.
+
+echo "Shell route — non-approving review types allowed:"
+
+assert_allowed "gh pr review --comment" \
+  "$(bash_payload 'gh pr review 12 --comment --body "a note"')"
+assert_allowed "gh pr review --request-changes" \
+  "$(bash_payload 'gh pr review 12 --request-changes --body "please fix"')"
+
+echo "Shell route — unrelated commands allowed:"
+
+assert_allowed "gh pr view" "$(bash_payload 'gh pr view 12')"
+assert_allowed "gh pr list" "$(bash_payload 'gh pr list')"
+assert_allowed "gh pr create" "$(bash_payload 'gh pr create --title t --body b')"
+assert_allowed "gh pr checks" "$(bash_payload 'gh pr checks 12')"
+assert_allowed "gh api on a non-review endpoint" \
+  "$(bash_payload 'gh api repos/o/n/pulls/12')"
+assert_allowed "word ending in gh" "$(bash_payload 'highgh pr review --approve')"
+assert_allowed "git commit" "$(bash_payload 'git commit -m test')"
+assert_allowed "empty command" '{"tool_name":"Bash","tool_input":{}}'
+
+# ── MCP route ──
+#
+# Fails closed: an absent or unrecognised event is treated as an approval.
+# Guessing the other way is exactly how merge_pull_request passed the branch
+# guards before it was gated.
+
+echo "MCP route — approvals and unreadable events blocked:"
+
+assert_blocked "create_pull_request_review event=APPROVE" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"APPROVE"}}'
+
+assert_blocked "lowercase event" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"approve"}}'
+
+assert_blocked "event absent (fails closed)" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1}}'
+
+assert_blocked "unrecognised event (fails closed)" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"SIGN_OFF"}}'
+
+assert_blocked "submit_pending_pull_request_review APPROVE" \
+  '{"tool_name":"mcp__github__submit_pending_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"APPROVE"}}'
+
+assert_blocked "Gemini single-underscore naming" \
+  '{"tool_name":"mcp_github_create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"APPROVE"}}'
+
+assert_blocked "third-party server prefix" \
+  '{"tool_name":"mcp__acme_forge__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"APPROVE"}}'
+
+echo "MCP route — non-approving reviews and other tools allowed:"
+
+assert_allowed "create_pull_request_review event=COMMENT" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"COMMENT"}}'
+
+assert_allowed "create_pull_request_review event=REQUEST_CHANGES" \
+  '{"tool_name":"mcp__github__create_pull_request_review","tool_input":{"owner":"x","repo":"y","pullNumber":1,"event":"REQUEST_CHANGES"}}'
+
+assert_allowed "create_pull_request" \
+  '{"tool_name":"mcp__github__create_pull_request","tool_input":{"owner":"x","repo":"y","title":"t"}}'
+
+assert_allowed "get_pull_request" \
+  '{"tool_name":"mcp__github__get_pull_request","tool_input":{"owner":"x","repo":"y","pullNumber":1}}'
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -85,7 +85,8 @@
       "mcp__github__list_pull_requests"
     ],
     "deny": [
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr review:*)"
     ]
   },
   "hooks": {
@@ -109,6 +110,10 @@
           },
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
           }
         ]
@@ -119,6 +124,10 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\""
           },
           {
             "type": "command",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -27,6 +27,11 @@
           },
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-bash.sh\"",
             "timeout": 10
           }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -16,6 +16,12 @@
             "timeout": 10000
           },
           {
+            "name": "block-pr-approve",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\"",
+            "timeout": 10000
+          },
+          {
             "name": "block-protected-branch-mcp",
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\"",
@@ -30,6 +36,12 @@
             "name": "block-pr-merge",
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-merge.sh\"",
+            "timeout": 10000
+          },
+          {
+            "name": "block-pr-approve",
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\"",
             "timeout": 10000
           },
           {

--- a/.github/hooks/block-protected-branch.json
+++ b/.github/hooks/block-protected-branch.json
@@ -7,6 +7,10 @@
       },
       {
         "type": "command",
+        "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-pr-approve.sh\""
+      },
+      {
+        "type": "command",
         "command": "bash \"$(git rev-parse --show-toplevel)/.ai-policy/hooks/block-protected-branch-mcp.sh\""
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.15.0 - 2026-08-05
+
+### Added
+
+- Added `.ai-policy/hooks/block-pr-approve.sh`, which blocks the agent from approving a pull request on the shell route (`gh pr review --approve`, bare `gh pr review`, and `gh api` POSTs to a `/pulls/N/reviews` endpoint) and the MCP route (review-creation and review-submission tools under any server prefix). [#194] narrowed the allow-list so approval prompted rather than running unattended, but a prompt is the wrong gate: approving review is a human judgement in the same category as merging. The failure this prevents is self-approval, where an agent opens a pull request and approves it, satisfying a human-shaped review requirement using only its own judgement; [#194] stops that loop completing at the merge step, but the approval is still a false signal recorded against a human process. Bare `gh pr review` is blocked because it is interactive and offers approval as an option. The MCP branch fails closed: an absent or unrecognised `event` is treated as an approval, since guessing the other way is precisely how `merge_pull_request` passed the branch guards before [#193]. Wired into all four agent entry points, and `Bash(gh pr review:*)` added to the Claude Code `deny` list. Covered by `.ai-policy/scripts/test-pr-approve-hook.sh` ([#197]).
+
+### Changed
+
+- Review comments and change requests are explicitly not blocked. `gh pr review --comment` and `--request-changes` pass this hook, as do the MCP equivalents with `event` set to `COMMENT` or `REQUEST_CHANGES`. Neither is auto-approved in the permission defaults, so both still prompt ([#197]).
+
 ## 3.14.0 - 2026-08-05
 
 ### Added
@@ -477,3 +487,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#193]: https://github.com/philippe-ths/ai-coding-workflow/issues/193
 [#194]: https://github.com/philippe-ths/ai-coding-workflow/pull/194
 [#195]: https://github.com/philippe-ths/ai-coding-workflow/issues/195
+[#197]: https://github.com/philippe-ths/ai-coding-workflow/issues/197

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.14.0
+Version: 3.15.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.14.0
+Version: 3.15.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.18.0
+Version: 1.19.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -84,7 +84,7 @@ Version: 1.18.0
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
 - `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
-- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), and `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools).
+- `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools), and `block-pr-approve.sh` (PreToolUse, blocks agent pull-request approvals on both routes, failing closed on an unreadable MCP review event; review comments and change requests pass).
 - `.ai-policy/scripts/check-push-refs.sh` is the authoritative protected-branch check for pushes; `.githooks/pre-push` pipes git's resolved refs to it, and it blocks when any pushed ref targets a protected branch.
 - Guards answer one of two questions. `check-push-refs.sh` and the refspec check in `block-protected-branch-bash.sh` ask what a write targets; `check-protected-branch.sh` and the current-branch check ask where the agent is standing; `block-pr-merge.sh` asks neither and blocks the action outright, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
@@ -117,7 +117,7 @@ Version: 1.18.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, and `test-push-refs.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, `test-push-refs.sh`, and `test-pr-approve-hook.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.


### PR DESCRIPTION
Closes #197.

## Problem

#194 narrowed the `gh pr` allow-list, which moved approval from auto-approved to prompted. A prompt is the wrong gate. Approving review is a human judgement in the same category as merging, not a routine action worth interrupting for.

The concrete failure is self-approval: an agent that opens a pull request and approves it has satisfied a human-shaped review requirement using only its own judgement. #194 stops that loop completing at the merge step, so it is not exploitable end-to-end today, but the approval is still a false signal recorded against a process built to carry human sign-off.

## Approach

`block-pr-approve.sh`, shaped like `block-pr-merge.sh`: it asks "is this an approval?" and blocks unconditionally.

Blocked:

- `gh pr review --approve`
- bare `gh pr review` — interactive, and approval is one of the options it offers, so it is blocked rather than gambled on
- `gh api` POSTs to a `/pulls/N/reviews` endpoint — the event lives in the request body, which cannot be read reliably from a command string, so the endpoint is blocked rather than intent guessed out of it
- MCP review-creation and review-submission tools, under any server prefix

Not blocked, and deliberately so:

- `gh pr review --comment` and `--request-changes`, plus the MCP equivalents with `event` set to `COMMENT` or `REQUEST_CHANGES`. Neither is auto-approved in the permission defaults, so both still prompt.

## The MCP branch fails closed

An absent or unrecognised `event` is treated as an approval rather than waved through.

This is the specific lesson of #193. `block-protected-branch-mcp.sh` allowed `merge_pull_request` because the payload named no branch, and the reasoning "we cannot judge this, so allow it" is what put eight merges into production. A hook written to correct that mistake should not contain it, so the unreadable case is blocked and the caller can be explicit if it wants through.

## Verification

31 test cases in `.ai-policy/scripts/test-pr-approve-hook.sh`, auto-discovered and run in every repo. Full validation exits 0.

Verified live rather than only by piping payloads: an approval attempt in a running session was blocked by the harness.

```
Blocked: 'gh pr review --help ...'
Approving a pull request is the human's decision, not the agent's.
An agent approving its own work is not review.
```

That example also shows the conservatism: `--help` is blocked, because it carries no explicit non-approving review type. Same trade-off as `block-pr-merge.sh`, where the cost of a false positive is a permission prompt and the cost of a false negative is a false review signal.

## Observation, not addressed here

This is the third hook wired into four entry points, so twelve wiring points now exist for three guards that all answer variants of "is the agent taking an action reserved to the human?". A single hook dispatching on the action would be one wiring point per config, but consolidating means renaming files shipped in 3.13.0 and 3.15.0 and reconciling those through the `### Removed` update path. Worth doing before a fourth guard, not during this one.
