### PR TITLE
Allow deleting an unprotected branch from a protected one

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-bash.sh
+++ b/.ai-policy/hooks/block-protected-branch-bash.sh
@@ -131,6 +131,60 @@ if targets_protected_branch "$COMMAND"; then
   exit 2
 fi
 
+# Does the command only delete refs? A deletion writes to no branch's contents,
+# so the current-branch rule below does not apply to it. A delete naming a
+# protected branch was already rejected above, so what reaches here removes
+# unprotected refs only. Post-merge cleanup deletes the merged branch from the
+# protected branch it just switched back to; without this it is always blocked.
+# Like every heuristic in this file it reads a command string, so a flag taking
+# a separate value can shift the positional count; check-push-refs.sh, which
+# rejects deletions of protected refs from the resolved refs, is the backstop.
+is_delete_push() {
+  local cmd="$1"
+  case "$cmd" in
+    git\ push*) ;;
+    *) return 1 ;;
+  esac
+
+  local args
+  args="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]*git[[:space:]]+push[[:space:]]*//')"
+
+  local delete_flag=false seen_remote=false refspecs=0 colon_forms=0
+  for token in $args; do
+    case "$token" in
+      --delete|-d) delete_flag=true; continue ;;
+      -*) continue ;;
+    esac
+
+    # The first positional is the remote, not a refspec.
+    if [ "$seen_remote" = false ]; then
+      seen_remote=true
+      continue
+    fi
+
+    refspecs=$((refspecs + 1))
+    # `:<dst>` with an empty source is the refspec form of a deletion.
+    case "$token" in
+      :?*) colon_forms=$((colon_forms + 1)) ;;
+    esac
+  done
+
+  # `git push --delete` with no ref names nothing; leave it to the rules below.
+  [ "$refspecs" -eq 0 ] && return 1
+
+  # With --delete, every listed ref is deleted.
+  [ "$delete_flag" = true ] && return 0
+
+  # Without it, only a push whose every refspec is a `:<dst>` deletion qualifies.
+  [ "$colon_forms" -eq "$refspecs" ] && return 0
+
+  return 1
+}
+
+if is_delete_push "$COMMAND"; then
+  exit 0
+fi
+
 CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"
 
 for protected in $PROTECTED_BRANCHES; do

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -211,6 +211,34 @@ printf '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD:main"}
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_blocked "git push origin HEAD:main on main" "$rc"
 
+# ── Branch-deletion cases (simulated main branch still active) ──
+#
+# Post-merge cleanup deletes the merged branch while standing on main, so the
+# deletion must be allowed from there. The exemption is for deletions only: an
+# ordinary push of the same branch from main stays blocked.
+
+echo "Branch-deletion cases on simulated main:"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin --delete feature/x"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin --delete feature/x on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin :feature/x"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin :feature/x on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin --delete main"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin --delete main on main" "$rc"
+
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/x"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin feature/x on main (not a deletion)" "$rc"
+
 # ── Summary ──
 
 echo ""

--- a/.ai-policy/scripts/test-pre-push-hook.sh
+++ b/.ai-policy/scripts/test-pre-push-hook.sh
@@ -124,7 +124,40 @@ rc=0
 printf '' | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
 assert_exit "empty stdin invokes branch check" 2 "$rc"
 
-# 8. The ref-target check is actually wired in, and runs even for a tag-only
+# 8. Deleting a branch remotely (local_sha all zeros) — writes to no branch, so
+# the current-branch check must be skipped. This is post-merge cleanup: the
+# developer is standing on main when they delete the merged feature branch.
+rc=0
+printf '(delete) 0000000000000000000000000000000000000000 refs/heads/feature/x abc\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "branch deletion skips branch check" 0 "$rc"
+
+# 9. Several branch deletions at once — still delete-only.
+rc=0
+{
+  printf '(delete) 0000000000000000000000000000000000000000 refs/heads/feature/x abc\n'
+  printf '(delete) 0000000000000000000000000000000000000000 refs/heads/feature/y def\n'
+} | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "multiple branch deletions skip branch check" 0 "$rc"
+
+# 10. A deletion combined with a branch update is not delete-only: the update
+# writes to a branch, so the current-branch check applies → exit 2.
+rc=0
+{
+  printf '(delete) 0000000000000000000000000000000000000000 refs/heads/feature/x abc\n'
+  printf 'refs/heads/feature/y abc refs/heads/feature/y def\n'
+} | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "deletion plus branch update invokes branch check" 2 "$rc"
+
+# 11. A branch deletion alongside a tag deletion — both exempt → exit 0.
+rc=0
+{
+  printf '(delete) 0000000000000000000000000000000000000000 refs/heads/feature/x abc\n'
+  printf '(delete) 0000000000000000000000000000000000000000 refs/tags/v1.0.0 def\n'
+} | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "branch and tag deletion skip branch check" 0 "$rc"
+
+# 12. The ref-target check is actually wired in, and runs even for a tag-only
 # push (it needs no tag guard of its own, so it must not be skipped). Swap the
 # stub for one with a distinctive exit code and confirm pre-push propagates it.
 cat > .ai-policy/scripts/check-push-refs.sh <<'STUB'
@@ -144,7 +177,7 @@ printf 'refs/tags/v1.0.0 abc refs/tags/v1.0.0 0000000000000000000000000000000000
   | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
 assert_exit "tag-only push also reaches check-push-refs" 3 "$rc"
 
-# 9. The refs reach the check on stdin rather than arriving empty.
+# 13. The refs reach the check on stdin rather than arriving empty.
 cat > .ai-policy/scripts/check-push-refs.sh <<'STUB'
 #!/usr/bin/env bash
 input="$(cat)"
@@ -159,6 +192,13 @@ rc=0
 printf 'HEAD abc refs/heads/main def\n' \
   | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
 assert_exit "push refs are piped to check-push-refs" 4 "$rc"
+
+# 14. The delete-only exemption skips the current-branch check, not the ref-target
+# check. Deleting a protected branch must still reach check-push-refs.
+rc=0
+printf '(delete) 0000000000000000000000000000000000000000 refs/heads/main abc\n' \
+  | "$HOOK" origin git@example:foo.git >/dev/null 2>&1 || rc=$?
+assert_exit "deleting a protected branch still reaches check-push-refs" 4 "$rc"
 
 # ── Summary ──
 

--- a/.ai-policy/scripts/test-push-refs.sh
+++ b/.ai-policy/scripts/test-push-refs.sh
@@ -99,6 +99,29 @@ judge "git push origin HEAD:master" 2 "$(cmd_exit 'git push origin HEAD:master')
 judge "git push origin main:refs/heads/main" 2 \
   "$(cmd_exit 'git push origin main:refs/heads/main')"
 
+# Deleting an unprotected branch writes to no branch, so it is allowed from any
+# branch including a protected one — post-merge cleanup runs from exactly there.
+# Asserted unconditionally: "regardless of the current branch" is the point.
+echo "block-protected-branch-bash — unprotected deletion allowed from any branch:"
+
+judge "git push origin --delete feature/x" 0 \
+  "$(cmd_exit 'git push origin --delete feature/x')"
+judge "git push origin -d feature/x" 0 "$(cmd_exit 'git push origin -d feature/x')"
+judge "git push --delete origin feature/x" 0 \
+  "$(cmd_exit 'git push --delete origin feature/x')"
+judge "git push origin :feature/x (refspec delete)" 0 \
+  "$(cmd_exit 'git push origin :feature/x')"
+judge "git push origin --delete feature/x feature/y" 0 \
+  "$(cmd_exit 'git push origin --delete feature/x feature/y')"
+
+echo "block-protected-branch-bash — protected deletion blocked from any branch:"
+
+judge "git push origin --delete main" 2 "$(cmd_exit 'git push origin --delete main')"
+judge "git push --delete origin main" 2 "$(cmd_exit 'git push --delete origin main')"
+judge "git push origin -d master" 2 "$(cmd_exit 'git push origin -d master')"
+judge "git push origin --delete feature/x main" 2 \
+  "$(cmd_exit 'git push origin --delete feature/x main')"
+
 CURRENT_BRANCH="$("$ROOT_DIR/.ai-policy/scripts/current-branch.sh")"
 IS_PROTECTED=false
 # shellcheck disable=SC1091

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,19 +5,26 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 # Pre-push receives one line per ref being pushed on stdin:
 #   <local_ref> <local_sha> <remote_ref> <remote_sha>
-# If every remote_ref is under refs/tags/, this is a tag-only push and
-# the protected-branch check does not apply (no branch is being modified).
+# Two shapes of push modify no branch's contents and so do not need the
+# current-branch check:
+#   tag-only   — every remote_ref is under refs/tags/
+#   delete-only — every local_sha is all zeros, git's marker for a deletion
 # Otherwise run the protected-branch check.
 PUSH_REFS="$(cat || true)"
 TAG_ONLY=true
+DELETE_ONLY=true
 HAS_ANY_REF=false
 
-while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
+while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
   [ -z "${remote_ref:-}" ] && continue
   HAS_ANY_REF=true
   case "$remote_ref" in
     refs/tags/*) ;;
     *) TAG_ONLY=false ;;
+  esac
+  # An absent or non-zero local sha means something is being written, not deleted.
+  case "${local_sha:-}" in
+    ""|*[!0]*) DELETE_ONLY=false ;;
   esac
 done <<EOF
 $PUSH_REFS
@@ -31,7 +38,14 @@ printf '%s\n' "$PUSH_REFS" | "$ROOT_DIR/.ai-policy/scripts/check-push-refs.sh"
 # Usability check: are we standing on a protected branch? Narrower than the
 # check above and kept for the plain `git push` case, where no refspec is
 # given and the target is implied by the current branch.
-if [ "$HAS_ANY_REF" = "false" ] || [ "$TAG_ONLY" = "false" ]; then
+#
+# Skipped for tag-only and delete-only pushes. A delete-only push writes to no
+# branch, and the check above has already rejected it if any deleted ref were
+# protected, so what reaches here removes unprotected refs only. Post-merge
+# cleanup runs from the protected branch by nature: you switch back to it,
+# then delete the merged branch. Asking where the pusher stands rejects that.
+if [ "$HAS_ANY_REF" = "false" ] ||
+  { [ "$TAG_ONLY" = "false" ] && [ "$DELETE_ONLY" = "false" ]; }; then
   "$ROOT_DIR/.ai-policy/scripts/check-protected-branch.sh"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.15.1 - 2026-08-06
+
+### Fixed
+
+- `.githooks/pre-push` no longer runs the current-branch check on a delete-only push, so deleting a merged feature branch from `main` is allowed. Post-merge cleanup runs from the protected branch by nature: you switch back to it, then delete the branch you just merged. Asking "where am I standing?" rejects that, which made CLI branch cleanup structurally impossible; it went unnoticed only because GitHub's auto-delete-on-merge had been removing branches server-side. A deletion writes to no branch, and `check-push-refs.sh` runs first and unconditionally, so a delete naming a protected branch is already rejected before the exemption is reached. Delete-only is read from git's own pre-push input, where a deleted ref carries an all-zero local sha; a deletion combined with any branch update is not delete-only and still gets the check ([#177]).
+- `.ai-policy/hooks/block-protected-branch-bash.sh` allows `git push --delete`, `-d`, and `:<ref>` deletions of non-protected branches from a protected branch, matching the pre-push hook. Fixing only the git hook would have left the symptom in place on the route that produced it, since post-merge cleanup is run by the agent and this hook blocks the command before git sees it. The exemption is applied after the refspec check, so `git push origin --delete main` still blocks, and it covers deletions only: `git push origin feature/x` from `main` is still rejected ([#177]).
+
 ## 3.15.0 - 2026-08-05
 
 ### Added
@@ -488,3 +495,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#194]: https://github.com/philippe-ths/ai-coding-workflow/pull/194
 [#195]: https://github.com/philippe-ths/ai-coding-workflow/issues/195
 [#197]: https://github.com/philippe-ths/ai-coding-workflow/issues/197
+[#177]: https://github.com/philippe-ths/ai-coding-workflow/issues/177

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.15.0
+Version: 3.15.1
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/design/decisions/enforcement-layers.md
+++ b/design/decisions/enforcement-layers.md
@@ -30,6 +30,11 @@ Scripts source this file rather than hardcoding values.
 This enforces the workflow rule "Do not work directly on `main`" at the Git level.
 The agent may forget or rationalise working on main; the hook will not.
 
+It answers "where am I standing?", which is the right question at commit time, when the ref being written is the current branch.
+At push time the target is explicit, so `.githooks/pre-push` runs `check-push-refs.sh` first and skips this check for pushes that write to no branch: tag-only pushes and delete-only pushes.
+The delete exemption exists because post-merge cleanup runs from the protected branch by nature — you switch back to it, then delete the branch you just merged — so a current-branch rule rejects the normal cleanup path.
+Nothing is lost by the exemption: a deletion naming a protected branch has already been rejected by `check-push-refs.sh`, which reads the resolved refs.
+
 ### Validation state tracking
 
 The validation system uses a simple state file (`validation.status`) with three states: `running`, `passed`, `failed`.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.15.0
+Version: 3.15.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.19.0
+Version: 1.19.1
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -87,6 +87,7 @@ Version: 1.19.0
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools), and `block-pr-approve.sh` (PreToolUse, blocks agent pull-request approvals on both routes, failing closed on an unreadable MCP review event; review comments and change requests pass).
 - `.ai-policy/scripts/check-push-refs.sh` is the authoritative protected-branch check for pushes; `.githooks/pre-push` pipes git's resolved refs to it, and it blocks when any pushed ref targets a protected branch.
 - Guards answer one of two questions. `check-push-refs.sh` and the refspec check in `block-protected-branch-bash.sh` ask what a write targets; `check-protected-branch.sh` and the current-branch check ask where the agent is standing; `block-pr-merge.sh` asks neither and blocks the action outright, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
+- The where-am-I-standing guards are skipped for pushes that write to no branch: tag-only and delete-only. `.githooks/pre-push` reads delete-only from the all-zero local sha in git's pre-push input; `block-protected-branch-bash.sh` reads it from the command string (`--delete`, `-d`, `:<ref>`). Both apply the exemption after the target check, so deleting a protected branch stays blocked.
 - `.githooks/pre-commit`, `.githooks/pre-push`: git hooks that call `.ai-policy/` scripts to enforce policy.
 - `.github/hooks/block-protected-branch.json`: VS Code Copilot PreToolUse hook configuration for protected branch enforcement.
 - `.gemini/settings.json`: Gemini CLI settings including BeforeTool hook configuration and tool permission defaults.


### PR DESCRIPTION
Closes #177.

## Problem

Post-merge cleanup runs from the protected branch by nature: you switch back to it, then delete the branch you just merged. Both protected-branch guards asked *where am I standing?*, so they rejected that push even though it writes to no branch. CLI branch cleanup was structurally impossible from `main`, and it went unnoticed only because GitHub's auto-delete-on-merge had been removing branches server-side.

This is the residue of the same design flaw as #193 and #195, seen from the other side. Those were cases where a branch-shaped guard was too *weak* to see the real target. This is one where it is too *blunt*: it blocks on position when nothing is being written at all.

## Approach

Two layers, both already ranked by #196, both given the same exemption.

**`.githooks/pre-push`** skips the current-branch check for delete-only pushes, alongside the tag-only exemption it already had. Delete-only is read from git's own pre-push input, where a deleted ref carries an all-zero local sha, so it is exact rather than inferred. A deletion combined with any branch update is not delete-only and still gets the check.

**`.ai-policy/hooks/block-protected-branch-bash.sh`** gets the same exemption for `--delete`, `-d`, and `:<ref>` forms. Fixing only the git hook would have left the symptom in place on the route that produced it, since post-merge cleanup is run by the agent and this hook blocks the command before git ever sees it.

Nothing is lost either way. `check-push-refs.sh` runs first and unconditionally, so a deletion naming a protected branch is rejected before the exemption is reached. The exemption covers deletions only: `git push origin feature/x` from `main` is still blocked.

### Considered and rejected

The broader form: stop asking "where am I standing" for *any* push with an explicit non-protected refspec, since `check-push-refs.sh` is authoritative anyway. Coherent, but it widens the hole past what was reported, and the recent history here is a run of guards found too weak. One case at a time.

## Verification

End-to-end against a real bare remote with the real hooks installed, run twice: once with the pre-push hook taken from `origin/main`, once with this branch's.

```
=== PRE-FIX hook (origin/main) ===
  FAIL: delete merged feature branch from main (expected allow, exit 1)
  PASS: push commits to main from main (expected block, exit 1)
  PASS: push commits to main via refspec (expected block, exit 1)
  PASS: delete remote main (expected block, exit 1)

=== POST-FIX hook (this branch) ===
  PASS: delete merged feature branch from main (expected allow, exit 0)
  PASS: push commits to main from main (expected block, exit 1)
  PASS: push commits to main via refspec (expected block, exit 1)
  PASS: delete remote main (expected block, exit 1)
  remote main still at: ebd5150
  local main at:        b25d7ff
```

Remote `main` holds its seeded sha while the local branch moves three commits ahead, so nothing leaked through the widened path.

Test coverage added:

- `test-pre-push-hook.sh` (15 cases): delete-only, multiple deletes, delete-plus-update still checked, branch-and-tag deletion, and a delete of a protected ref still reaching `check-push-refs.sh`.
- `test-push-refs.sh` (37 cases): `--delete` / `-d` / `:ref` allowed unconditionally, protected counterparts blocked.
- `test-claude-code-enforcement.sh` (23 cases): on a simulated `main`, the deletion is allowed and `git push origin feature/x` is still blocked — the check that the exemption did not widen past deletions.

Full validation gate passes.

## Coverage gap that let this ship

`test-pre-push-hook.sh` had a tag-deletion case (`(delete)` plus all-zero sha) but never a branch deletion, and the enforcement suites simulated standing on `main` only for pushes. The missing case sat directly beside one that existed.

## Known residual, pre-existing

`is_delete_push` reads a command string, so a flag taking a separate value (`git push -o ci.skip origin --delete main`) shifts its positional count and can misread the target. `targets_protected_branch` already had this limitation and documents it; `check-push-refs.sh` catches it at the git layer regardless, so the outcome is a worse error message, not an allowed write.

## Follow-up, not in this PR

`block-protected-branch-bash.sh` now parses a push refspec twice, in `targets_protected_branch` and `is_delete_push`, carrying the same limitation in both. Worth one shared parser.
