### PR TITLE
Answer both push questions from one parse

### DIFF
--- a/.ai-policy/hooks/block-protected-branch-bash.sh
+++ b/.ai-policy/hooks/block-protected-branch-bash.sh
@@ -80,11 +80,28 @@ if is_tag_push "$COMMAND"; then
   exit 0
 fi
 
-# Does an explicit refspec name a protected branch as its target?
-# `git push origin HEAD:main` writes to a protected branch while the current
-# branch is unprotected, so the current-branch check below cannot see it.
-targets_protected_branch() {
+# One parse, two questions: what does this command write to, and is it only
+# deleting? Both are read from the same tokens so they cannot drift apart or
+# reach different conclusions about the same command.
+#
+# The parse works from a command string, so it is approximate: a flag taking a
+# separate value shifts the positional count, and the remote and every target
+# are then read one token out. The limitation belongs to the parse rather than
+# to either question, which is why it is stated here once. check-push-refs.sh
+# reads the refs git actually resolved and is unaffected by it; when the two
+# disagree, it is correct.
+#
+# Sets, for a `git push` command:
+#   PUSH_TARGETS    destination branch name per refspec, space-separated
+#   PUSH_REFSPECS   how many refspecs were given
+#   PUSH_DELETIONS  how many of those are deletions
+# Anything that is not a push leaves the counts at zero and returns 1.
+parse_push_command() {
   local cmd="$1"
+  PUSH_TARGETS=""
+  PUSH_REFSPECS=0
+  PUSH_DELETIONS=0
+
   case "$cmd" in
     git\ push*) ;;
     *) return 1 ;;
@@ -93,63 +110,7 @@ targets_protected_branch() {
   local args
   args="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]*git[[:space:]]+push[[:space:]]*//')"
 
-  local seen_remote=false target
-  for token in $args; do
-    # Skip flags. A flag taking a separate value can shift the positional
-    # count and cause a miss; check-push-refs.sh is the backstop for that.
-    case "$token" in
-      -*) continue ;;
-    esac
-
-    # The first positional is the remote, not a refspec.
-    if [ "$seen_remote" = false ]; then
-      seen_remote=true
-      continue
-    fi
-
-    # Refspec forms: <dst>, <src>:<dst>, :<dst> (delete), +<src>:<dst> (force).
-    target="${token#+}"
-    case "$target" in
-      *:*) target="${target##*:}" ;;
-    esac
-    target="${target#refs/heads/}"
-
-    for protected in $PROTECTED_BRANCHES; do
-      if [ "$target" = "$protected" ]; then
-        return 0
-      fi
-    done
-  done
-
-  return 1
-}
-
-if targets_protected_branch "$COMMAND"; then
-  echo "Blocked: '$COMMAND' targets protected branch." >&2
-  echo "The refspec writes to a protected branch even though the current branch is not one." >&2
-  echo "Open a pull request instead; merging it is the human's decision." >&2
-  exit 2
-fi
-
-# Does the command only delete refs? A deletion writes to no branch's contents,
-# so the current-branch rule below does not apply to it. A delete naming a
-# protected branch was already rejected above, so what reaches here removes
-# unprotected refs only. Post-merge cleanup deletes the merged branch from the
-# protected branch it just switched back to; without this it is always blocked.
-# Like every heuristic in this file it reads a command string, so a flag taking
-# a separate value can shift the positional count; check-push-refs.sh, which
-# rejects deletions of protected refs from the resolved refs, is the backstop.
-is_delete_push() {
-  local cmd="$1"
-  case "$cmd" in
-    git\ push*) ;;
-    *) return 1 ;;
-  esac
-
-  local args
-  args="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]*git[[:space:]]+push[[:space:]]*//')"
-
-  local delete_flag=false seen_remote=false refspecs=0 colon_forms=0
+  local delete_flag=false seen_remote=false target
   for token in $args; do
     case "$token" in
       --delete|-d) delete_flag=true; continue ;;
@@ -162,26 +123,71 @@ is_delete_push() {
       continue
     fi
 
-    refspecs=$((refspecs + 1))
+    PUSH_REFSPECS=$((PUSH_REFSPECS + 1))
+
+    # Refspec forms: <dst>, <src>:<dst>, :<dst> (delete), +<src>:<dst> (force).
+    target="${token#+}"
+    case "$target" in
+      *:*) target="${target##*:}" ;;
+    esac
+    PUSH_TARGETS="$PUSH_TARGETS ${target#refs/heads/}"
+
     # `:<dst>` with an empty source is the refspec form of a deletion.
     case "$token" in
-      :?*) colon_forms=$((colon_forms + 1)) ;;
+      :?*) PUSH_DELETIONS=$((PUSH_DELETIONS + 1)) ;;
     esac
   done
 
-  # `git push --delete` with no ref names nothing; leave it to the rules below.
-  [ "$refspecs" -eq 0 ] && return 1
+  # --delete applies to the whole command, wherever in it the flag appears, so
+  # it is settled after the loop rather than per token.
+  if [ "$delete_flag" = true ]; then
+    PUSH_DELETIONS="$PUSH_REFSPECS"
+  fi
 
-  # With --delete, every listed ref is deleted.
-  [ "$delete_flag" = true ] && return 0
+  return 0
+}
 
-  # Without it, only a push whose every refspec is a `:<dst>` deletion qualifies.
-  [ "$colon_forms" -eq "$refspecs" ] && return 0
+# Non-push commands leave the counts at zero, so both questions below answer no
+# and the command falls through to the current-branch rule, as it should.
+parse_push_command "$COMMAND" || :
+
+# Does an explicit refspec name a protected branch as its target?
+# `git push origin HEAD:main` writes to a protected branch while the current
+# branch is unprotected, so the current-branch check below cannot see it.
+targets_protected_branch() {
+  local target protected
+  for target in $PUSH_TARGETS; do
+    for protected in $PROTECTED_BRANCHES; do
+      if [ "$target" = "$protected" ]; then
+        return 0
+      fi
+    done
+  done
 
   return 1
 }
 
-if is_delete_push "$COMMAND"; then
+if targets_protected_branch; then
+  echo "Blocked: '$COMMAND' targets protected branch." >&2
+  echo "The refspec writes to a protected branch even though the current branch is not one." >&2
+  echo "Open a pull request instead; merging it is the human's decision." >&2
+  exit 2
+fi
+
+# Does the command only delete refs? A deletion writes to no branch's contents,
+# so the current-branch rule below does not apply to it. A deletion naming a
+# protected branch was already rejected above, so what reaches here removes
+# unprotected refs only. Post-merge cleanup deletes the merged branch from the
+# protected branch it just switched back to; without this it is always blocked.
+#
+# A command naming no refspec at all is not a deletion: `git push --delete` on
+# its own names nothing, and plain `git push` implies its target from the
+# current branch, which is exactly what the rule below is for.
+is_delete_only_push() {
+  [ "$PUSH_REFSPECS" -gt 0 ] && [ "$PUSH_DELETIONS" -eq "$PUSH_REFSPECS" ]
+}
+
+if is_delete_only_push; then
   exit 0
 fi
 

--- a/.ai-policy/scripts/test-claude-code-enforcement.sh
+++ b/.ai-policy/scripts/test-claude-code-enforcement.sh
@@ -239,6 +239,20 @@ printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/x"}
   | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
 assert_blocked "git push origin feature/x on main (not a deletion)" "$rc"
 
+# A refspec list mixing a deletion with an ordinary push is not delete-only:
+# the second refspec writes to a branch, so the current-branch rule applies.
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin :feature/x feature/y"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_blocked "git push origin :feature/x feature/y on main (mixed)" "$rc"
+
+# --delete applies to the whole command wherever the flag sits, so a trailing
+# flag must read the same as a leading one.
+rc=0
+printf '{"tool_name":"Bash","tool_input":{"command":"git push origin feature/x --delete"}}' \
+  | "$BASH_HOOK" >/dev/null 2>&1 || rc=$?
+assert_allowed "git push origin feature/x --delete on main (trailing flag)" "$rc"
+
 # ── Summary ──
 
 echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.15.2 - 2026-08-06
+
+### Changed
+
+- `.ai-policy/hooks/block-protected-branch-bash.sh` derives both of its questions about a `git push` — what branch it targets, and whether it is only deleting — from a single parse of the command, replacing two separate tokenisations of the same string. Both copies carried the same documented limitation, that a flag taking a separate value shifts the positional count, so anyone tightening it had to find both sites and a fix applied to one would leave the two disagreeing about the same command. A guard whose halves can disagree is the shape of problem [#193] and [#195] both turned out to be. The limitation is now stated once, on the parse it belongs to. `is_tag_push` keeps its own scan: it answers a different question and keys off the last positional including the remote, so folding it in would change behaviour rather than preserve it. No behaviour change, verified by running 47 push and non-push commands through the pre-refactor and refactored hooks under both a protected and an unprotected current branch, 94 combinations with no difference in verdict. Two cases pinning the parse semantics added to `.ai-policy/scripts/test-claude-code-enforcement.sh`: a refspec list mixing a deletion with an ordinary push is not delete-only, and `--delete` reads the same trailing as leading ([#200]).
+
 ## 3.15.1 - 2026-08-06
 
 ### Fixed
@@ -496,3 +502,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#195]: https://github.com/philippe-ths/ai-coding-workflow/issues/195
 [#197]: https://github.com/philippe-ths/ai-coding-workflow/issues/197
 [#177]: https://github.com/philippe-ths/ai-coding-workflow/issues/177
+[#200]: https://github.com/philippe-ths/ai-coding-workflow/issues/200

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.15.1
+Version: 3.15.2
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.15.1
+Version: 3.15.2
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.


### PR DESCRIPTION
Closes #200.

## Problem

`block-protected-branch-bash.sh` decided two things about a `git push` — what branch it targets, and whether it is only deleting — by separately re-tokenising the same command string. Both copies carried the same documented limitation, that a flag taking a separate value shifts the positional count and the wrong token is read as the target.

The live consequence was nil: `check-push-refs.sh` catches that case at the git layer, so the outcome was a worse error message rather than an allowed write. The cost was future divergence. Anyone tightening the limitation had to find both sites, and a fix applied to one would leave the two halves disagreeing about the same command. A guard whose halves can disagree is the shape of problem #193 and #195 both turned out to be.

## Approach

One parse yields the destination branch per refspec, the refspec count, and the deletion count. `targets_protected_branch` and `is_delete_only_push` read those rather than re-deriving them. The limitation is stated once, on the parse it belongs to, instead of at each caller.

`--delete` is settled after the loop rather than per token, because the flag applies to the whole command wherever it appears.

### Deliberately left alone

`is_tag_push` keeps its own scan. It answers a different question and keys off the *last* positional including the remote, so folding it into the shared parse would change behaviour on commands like `git push origin` where a tag named `origin` exists. That is a behaviour change, not a refactor.

So the file still has two token scans. The issue's "single parse" criterion is met for the two questions it names, not for tag detection.

## Verification

This is a refactor, so equivalence is shown rather than asserted. 47 command shapes were run through the pre-refactor hook (from `origin/main`) and this one, under both a protected and an unprotected current branch.

```
── current branch: feature/x ──
── current branch: main ──

94 command/branch combinations compared, 0 differences.
```

The matrix discriminates rather than passing trivially: 29 allowed / 18 blocked on `feature/x`, 14 / 33 on `main`. It covers plain pushes, protected targets, deletions in four syntaxes, mixed delete-plus-push refspec lists, tags, non-push commands, and the known flag-with-value case, which degrades identically in both versions.

Suites: `test-push-refs.sh` 37/37, `test-claude-code-enforcement.sh` 25/25, `test-pre-push-hook.sh` 15/15, full validation exit 0.

Two cases added permanently, pinning semantics the shared parse now owns:

- a refspec list mixing a deletion with an ordinary push is not delete-only
- `--delete` reads the same trailing as leading

## Not covered

The differential harness compares against `origin/main`, which moves, so it cannot survive as a checked-in test. The two cases above are pinned; the other 45 shapes rest on the one-off run recorded here.

New cases went into the Claude enforcement suite only. Codex, Gemini, and Copilot share the identical script, so the logic is covered, but their suites have no case of their own.
