### PR TITLE
Tie a validation pass to the tree it was computed against

### DIFF
--- a/.ai-policy/scripts/check-validation.sh
+++ b/.ai-policy/scripts/check-validation.sh
@@ -13,10 +13,41 @@ if [ ! -f "$STATE_FILE" ]; then
   exit 2
 fi
 
-STATUS="$(cat "$STATE_FILE")"
+# A passing result is recorded as "passed <fingerprint>", where the fingerprint
+# identifies the working tree the result was computed against. The other states
+# imply no tree and stay bare.
+STATE_LINE="$(head -n 1 "$STATE_FILE")"
+STATUS="${STATE_LINE%% *}"
+RECORDED_FINGERPRINT=""
+case "$STATE_LINE" in
+  *' '*) RECORDED_FINGERPRINT="${STATE_LINE#* }" ;;
+esac
 
 if [ "$STATUS" = "passed" ]; then
-  exit 0
+  # A bare "passed" was written by a policy layer that predated fingerprinting.
+  # It cannot be tied to any tree, so it is not evidence that what is about to
+  # be committed was validated.
+  if [ -z "$RECORDED_FINGERPRINT" ]; then
+    echo "Blocked: validation status records no working-tree fingerprint."
+    echo "It was written before the gate started tying results to a tree, so"
+    echo "there is no way to tell what content it passed against."
+    echo "Run ./.ai-policy/scripts/run-validation.sh to record a current result."
+    exit 2
+  fi
+
+  CURRENT_FINGERPRINT="$("$ROOT_DIR/.ai-policy/scripts/tree-fingerprint.sh")"
+
+  if [ "$RECORDED_FINGERPRINT" = "$CURRENT_FINGERPRINT" ]; then
+    exit 0
+  fi
+
+  echo "Blocked: the working tree has changed since validation passed."
+  echo "The recorded pass was computed against different content, so it does not"
+  echo "cover what is being committed or pushed."
+  echo "  validated tree: $RECORDED_FINGERPRINT"
+  echo "  current tree:   $CURRENT_FINGERPRINT"
+  echo "Run ./.ai-policy/scripts/run-validation.sh and only continue once it passes."
+  exit 2
 fi
 
 if [ "$STATUS" = "running" ]; then

--- a/.ai-policy/scripts/mark-validation-pass.sh
+++ b/.ai-policy/scripts/mark-validation-pass.sh
@@ -6,6 +6,12 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 . "$ROOT_DIR/.ai-policy/policy.env"
 
 mkdir -p "$(dirname "$ROOT_DIR/$VALIDATION_STATE_FILE")"
-printf "passed" > "$ROOT_DIR/$VALIDATION_STATE_FILE"
 
-echo "Validation status set to passed."
+# The override still records the tree it was set on. It remains an escape hatch
+# from running validation, not from the requirement that the result belong to the
+# content being committed.
+printf 'passed %s\n' "$("$ROOT_DIR/.ai-policy/scripts/tree-fingerprint.sh")" \
+  > "$ROOT_DIR/$VALIDATION_STATE_FILE"
+
+echo "Validation status set to passed for the current working tree."
+echo "Editing any file after this point will block the gate until validation is re-run."

--- a/.ai-policy/scripts/run-validation.sh
+++ b/.ai-policy/scripts/run-validation.sh
@@ -19,7 +19,12 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if sh -c "$VALIDATION_COMMAND"; then
-  printf "passed" > "$STATE_FILE"
+  # Record which tree this result covers. Taken after the command returns, so it
+  # describes the content the gate will compare against. If the fingerprint
+  # cannot be computed, set -e aborts here with the state still "running" and the
+  # trap turns it into "failed" — the gate blocks rather than trusting an
+  # unattributed pass.
+  printf 'passed %s\n' "$("$ROOT_DIR/.ai-policy/scripts/tree-fingerprint.sh")" > "$STATE_FILE"
   trap - EXIT INT TERM
   echo "Validation passed."
   exit 0

--- a/.ai-policy/scripts/test-validation-state.sh
+++ b/.ai-policy/scripts/test-validation-state.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+set -eu
+
+# Tests for the validation gate: check-validation.sh, run-validation.sh,
+# mark-validation-pass.sh, and tree-fingerprint.sh.
+#
+# The case this suite exists for is the stale pass: a result computed against an
+# earlier working tree must not satisfy the gate for a later one. The gate fails
+# in the reporting-green direction when it does, so the negative paths matter
+# more here than the happy one.
+#
+# Runs in a sandbox repository so the real repository's state file is never
+# touched.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SRC="$ROOT_DIR/.ai-policy"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit $expected, got $actual)"
+  fi
+}
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_ne() {
+  local label="$1"
+  local a="$2"
+  local b="$3"
+  if [ "$a" != "$b" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (both values were '$a')"
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      PASS=$((PASS + 1))
+      echo "  PASS: $label"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      echo "  FAIL: $label (output did not mention '$needle')"
+      ;;
+  esac
+}
+
+SANDBOX="$(mktemp -d)"
+# Kept outside SANDBOX: a nested repository inside it would break `git add -A`.
+EMPTY_REPO="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX" "$EMPTY_REPO"' EXIT
+
+cd "$SANDBOX"
+git init -q -b feature/work .
+git config user.email "test@example.com"
+git config user.name "Test"
+
+mkdir -p .ai-policy/scripts .ai-policy/hooks .githooks
+
+for s in check-validation.sh run-validation.sh mark-validation-pass.sh \
+  mark-validation-fail.sh tree-fingerprint.sh check-protected-branch.sh \
+  current-branch.sh; do
+  cp "$SRC/scripts/$s" ".ai-policy/scripts/$s"
+  chmod +x ".ai-policy/scripts/$s"
+done
+
+cp "$ROOT_DIR/.githooks/pre-commit" .githooks/pre-commit
+chmod +x .githooks/pre-commit
+
+cat > .ai-policy/policy.env <<'ENV'
+PROTECTED_BRANCHES="main master"
+REQUIRE_VALIDATION_BEFORE_COMMIT="true"
+REQUIRE_VALIDATION_BEFORE_PUSH="true"
+VALIDATION_STATE_FILE=".ai-policy/state/validation.status"
+VALIDATION_COMMAND="true"
+ENV
+
+cat > .gitignore <<'IGN'
+.ai-policy/state/validation.status
+build-output.txt
+IGN
+
+echo "original" > source.txt
+git add -A
+git commit -qm "initial"
+
+STATE=".ai-policy/state/validation.status"
+CHECK=".ai-policy/scripts/check-validation.sh"
+RUN=".ai-policy/scripts/run-validation.sh"
+MARK_PASS=".ai-policy/scripts/mark-validation-pass.sh"
+MARK_FAIL=".ai-policy/scripts/mark-validation-fail.sh"
+FINGERPRINT=".ai-policy/scripts/tree-fingerprint.sh"
+
+echo "Validation gate tests:"
+
+# ── Fingerprint properties ──
+# An unstable fingerprint would block every commit in every repository that
+# installs this, so stability is checked before anything that depends on it.
+
+fp1="$("$FINGERPRINT")"
+fp2="$("$FINGERPRINT")"
+assert_eq "fingerprint is stable across runs on an unchanged tree" "$fp1" "$fp2"
+
+echo "changed" > source.txt
+fp_modified="$("$FINGERPRINT")"
+assert_ne "modifying a tracked file changes the fingerprint" "$fp1" "$fp_modified"
+
+echo "original" > source.txt
+assert_eq "reverting a modification restores the fingerprint" "$fp1" "$("$FINGERPRINT")"
+
+echo "new" > untracked.txt
+assert_ne "adding an untracked file changes the fingerprint" "$fp1" "$("$FINGERPRINT")"
+rm untracked.txt
+
+rm source.txt
+assert_ne "deleting a tracked file changes the fingerprint" "$fp1" "$("$FINGERPRINT")"
+git checkout -q -- source.txt
+
+echo "noise" > build-output.txt
+assert_eq "changing a gitignored file leaves the fingerprint alone" "$fp1" "$("$FINGERPRINT")"
+rm build-output.txt
+
+git mv source.txt renamed.txt
+assert_ne "renaming a file changes the fingerprint" "$fp1" "$("$FINGERPRINT")"
+git mv renamed.txt source.txt
+git add -A
+
+# ── Fingerprint boundaries ──
+
+printf 'one' > "spaced name.txt"
+fp_spaced="$("$FINGERPRINT")"
+assert_ne "a filename with a space is covered" "$fp1" "$fp_spaced"
+printf 'two' > "spaced name.txt"
+assert_ne "editing a spaced filename moves the fingerprint" "$fp_spaced" "$("$FINGERPRINT")"
+rm "spaced name.txt"
+
+# git reports a path containing a control character in quoted form, which cannot
+# be hashed. Producing a fingerprint anyway would silently omit that file's
+# contents, so the script must refuse rather than understate the tree.
+printf 'hostile' > "$(printf 'weird\nname.txt')"
+rc=0
+out="$("$FINGERPRINT" 2>&1)" || rc=$?
+assert_ne "an unhashable filename fails closed rather than being skipped" "0" "$rc"
+assert_contains "the refusal names the offending path" "weird" "$out"
+rm "$(printf 'weird\nname.txt')"
+assert_eq "removing it restores the fingerprint" "$fp1" "$("$FINGERPRINT")"
+
+# A repository with no commits, and so nothing in the index.
+mkdir -p "$EMPTY_REPO/.ai-policy/scripts"
+git init -q "$EMPTY_REPO"
+cp .ai-policy/policy.env "$EMPTY_REPO/.ai-policy/policy.env"
+cp "$FINGERPRINT" "$EMPTY_REPO/.ai-policy/scripts/tree-fingerprint.sh"
+chmod +x "$EMPTY_REPO/.ai-policy/scripts/tree-fingerprint.sh"
+rc=0
+(cd "$EMPTY_REPO" && ./.ai-policy/scripts/tree-fingerprint.sh >/dev/null 2>&1) || rc=$?
+assert_exit "a repository with no commits still fingerprints" 0 "$rc"
+
+# ── Gate: states that carry no tree ──
+
+rm -f "$STATE"
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "absent state file blocks" 2 "$rc"
+
+mkdir -p "$(dirname "$STATE")"
+"$MARK_FAIL" >/dev/null
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "failed state blocks" 2 "$rc"
+
+: > "$STATE"
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "empty state file blocks" 2 "$rc"
+
+printf 'passed' > "$STATE"
+printf 'passed extra-token %s\n' "$("$FINGERPRINT")" > "$STATE"
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "a malformed passed line blocks" 2 "$rc"
+
+printf 'running' > "$STATE"
+rc=0
+out="$("$CHECK" 2>&1)" || rc=$?
+assert_exit "running state blocks" 2 "$rc"
+assert_contains "running state keeps its own message" "still running" "$out"
+
+# A state file written by a version of this policy layer that predated
+# fingerprinting carries a bare word. It cannot be tied to any tree, so it must
+# fail closed rather than being trusted.
+printf 'passed' > "$STATE"
+rc=0
+out="$("$CHECK" 2>&1)" || rc=$?
+assert_exit "legacy bare 'passed' blocks" 2 "$rc"
+assert_contains "legacy state explains itself" "run-validation.sh" "$out"
+
+# ── Gate: the stale pass ──
+
+rc=0
+"$RUN" >/dev/null 2>&1 || rc=$?
+assert_exit "run-validation succeeds when the command passes" 0 "$rc"
+
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "fresh pass on an unchanged tree allows" 0 "$rc"
+
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "reading the gate twice does not invalidate it" 0 "$rc"
+
+echo "edited after validation ran" > source.txt
+rc=0
+out="$("$CHECK" 2>&1)" || rc=$?
+assert_exit "pass computed against an earlier tree blocks" 2 "$rc"
+assert_contains "stale block names the cause" "changed since validation" "$out"
+assert_contains "stale block names the remedy" "run-validation.sh" "$out"
+
+echo "original" > source.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "restoring the validated content allows again" 0 "$rc"
+
+echo "appeared after validation ran" > added-later.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "a new untracked file blocks" 2 "$rc"
+rm added-later.txt
+
+echo "noise" > build-output.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "a changed gitignored file does not block" 0 "$rc"
+rm build-output.txt
+
+# The ordinary sequence is edit, validate, stage, commit, push. Neither staging
+# nor committing changes what any file contains, so neither may invalidate a
+# fresh pass. A gate that fires on the normal path gets routed around.
+echo "ready to be committed" > source.txt
+"$RUN" >/dev/null 2>&1
+
+git add source.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "staging a validated change does not block" 0 "$rc"
+
+git -c core.hooksPath=/dev/null commit -qm "committed mid-suite"
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "committing does not block the push that follows" 0 "$rc"
+
+git -c core.hooksPath=/dev/null commit -q --amend -m "amended" --allow-empty
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "rewriting history without touching files does not block" 0 "$rc"
+
+git rm -q source.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "a staged deletion still blocks" 2 "$rc"
+git checkout -q HEAD -- source.txt || printf 'original' > source.txt
+git add -A
+"$RUN" >/dev/null 2>&1
+
+# ── Gate: the manual override ──
+
+echo "override this" > source.txt
+"$MARK_PASS" >/dev/null
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "manual override allows for the tree it was set on" 0 "$rc"
+
+echo "moved on again" > source.txt
+rc=0
+"$CHECK" >/dev/null 2>&1 || rc=$?
+assert_exit "manual override does not survive a later edit" 2 "$rc"
+
+# ── Runtime: a real commit through the real hook ──
+# Exit codes from the check script alone would not show that the gate actually
+# stops a commit, so this drives git itself.
+
+git config core.hooksPath .githooks
+
+before="$(git rev-parse HEAD)"
+
+echo "staged while state is stale" > source.txt
+git add source.txt
+rc=0
+out="$(git commit -m "should be blocked" 2>&1)" || rc=$?
+assert_ne "git commit is blocked by a stale pass" "0" "$rc"
+assert_contains "the blocked commit explains why" "changed since validation" "$out"
+assert_eq "no commit object was created" "$before" "$(git rev-parse HEAD)"
+
+"$RUN" >/dev/null 2>&1
+rc=0
+git commit -qm "allowed after revalidating" 2>&1 || rc=$?
+assert_exit "git commit succeeds once validation matches the tree" 0 "$rc"
+assert_ne "the commit landed" "$before" "$(git rev-parse HEAD)"
+
+# ── Summary ──
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests."
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.ai-policy/scripts/tree-fingerprint.sh
+++ b/.ai-policy/scripts/tree-fingerprint.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Prints a fingerprint of the current working tree's content.
+#
+# The validation gate records this alongside a passing result so that the pass
+# can be tied to the content it was computed against. Two runs over an identical
+# tree must print the same value, and any change to a file the project would
+# validate must change it — an unstable fingerprint blocks every commit, and one
+# that misses a change lets a stale pass through.
+#
+# Covers tracked files plus untracked files git would not ignore. Ignored files
+# are excluded deliberately: validation does not read them, so changing one is
+# not a reason to revalidate.
+set -eu
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+# shellcheck disable=SC1091
+. "$ROOT_DIR/.ai-policy/policy.env"
+cd "$ROOT_DIR"
+
+STATE_REL="$VALIDATION_STATE_FILE"
+
+# The state file is excluded from every part of the stream below. The fingerprint
+# is written into it, so including it would make each recorded result invalidate
+# itself on the next read. It is gitignored in this repository, but an adopting
+# project may not have ignored it, so the exclusion is explicit rather than
+# relying on the ignore rules.
+ALL_PATHS="$(
+  git -c core.quotePath=false ls-files --cached --others --exclude-standard |
+    LC_ALL=C sort -u |
+    while IFS= read -r p; do
+      if [ -n "$p" ] && [ "$p" != "$STATE_REL" ]; then
+        printf '%s\n' "$p"
+      fi
+    done
+)"
+
+# git emits a path containing a quote, a backslash, or a control character in
+# quoted form ("weird\nname.txt"), which no longer names a file on disk. Such a
+# path would drop out of the content hashing below while still appearing in the
+# path list, so edits to that file would not move the fingerprint — the same
+# fail-open shape this script exists to close. Refuse to produce a fingerprint at
+# all rather than produce one that silently covers less than it appears to.
+# Paths containing spaces are not quoted and are handled normally.
+QUOTED_PATHS="$(
+  printf '%s\n' "$ALL_PATHS" |
+    while IFS= read -r p; do
+      case "$p" in
+        '"'*) printf '%s\n' "$p" ;;
+      esac
+    done
+)"
+
+if [ -n "$QUOTED_PATHS" ]; then
+  echo "tree-fingerprint: cannot fingerprint a tree containing these paths:" >&2
+  printf '%s\n' "$QUOTED_PATHS" >&2
+  echo "Their names contain a quote, backslash, or control character, so their" >&2
+  echo "contents cannot be hashed reliably and a fingerprint would understate" >&2
+  echo "what changed. Rename or remove them." >&2
+  exit 1
+fi
+
+# Only existing regular files can be hashed. A tracked file deleted from the
+# working tree is carried by the porcelain status line instead, so a deletion
+# still moves the fingerprint rather than aborting the run.
+EXISTING_PATHS="$(
+  printf '%s\n' "$ALL_PATHS" |
+    while IFS= read -r p; do
+      if [ -n "$p" ] && [ -f "$p" ]; then
+        printf '%s\n' "$p"
+      fi
+    done
+)"
+
+# What the fingerprint covers is the content validation actually read: the paths
+# on disk and their contents. It deliberately excludes two things that move
+# during an ordinary commit without changing that content.
+#
+# Index state is excluded: `git add` changes whether a modification is staged,
+# not what any file contains. Including it blocked the commit that immediately
+# followed a passing validation run.
+#
+# HEAD is excluded: committing moves it while leaving every file on disk
+# identical. Including it blocked the push that followed a commit, so every
+# commit would have demanded a second validation run before it could be pushed.
+# A gate that fires on the normal path trains people to route around it.
+{
+  # Path names, so a rename that preserves content still moves the fingerprint.
+  printf '%s\n' "$ALL_PATHS"
+
+  # Tracked files missing from the working tree. These carry no content hash
+  # below, and naming them keeps a deletion unambiguous rather than inferred
+  # from the hash list being one line shorter.
+  git -c core.quotePath=false ls-files --deleted | LC_ALL=C sort -u
+
+  # Content, hashed by git itself so the format needs no external checksum tool.
+  if [ -n "$EXISTING_PATHS" ]; then
+    printf '%s\n' "$EXISTING_PATHS" | git hash-object --stdin-paths
+  fi
+} | git hash-object --stdin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.17.0 - 2026-08-06
+
+### Fixed
+
+- `.ai-policy/scripts/check-validation.sh` rejects a passing validation result that was computed against a different working tree, closing a gate that failed open. The state file recorded a bare `passed` with nothing tying it to the content that produced it, so an hour-old result satisfied the commit and push gates for a tree that had moved on since; the defect was observed with ten files edited after the recorded pass. The gate exists so that what is being committed has been validated, and a stale pass satisfied the mechanism while defeating its purpose. It also failed in the dangerous direction, reporting green, and the only workaround put the guarantee back on remembering to re-run validation immediately before every commit, which is what the gate was meant to remove. A new `.ai-policy/scripts/tree-fingerprint.sh` hashes the tracked and untracked-not-ignored content with git's own object hashing, so no external checksum tool is needed, and `run-validation.sh` records it alongside the result. Ignored files are excluded because validation does not read them; the state file is excluded explicitly rather than by ignore rules, since a target that has not ignored it would otherwise have each recorded result invalidate itself on the next read. `mark-validation-pass.sh` stamps the same fingerprint, so the manual override remains an escape hatch from running validation and not from the result belonging to the content being committed. The fingerprint covers path names and file contents only. Index state and HEAD are excluded deliberately: `git add` changes whether a modification is staged rather than what any file contains, and committing moves HEAD while leaving every file on disk identical. Including either was tried and both broke the ordinary edit-validate-stage-commit-push sequence, invalidating a pass that had just been recorded and demanding a second validation run before every push, with no change in what validation had read. A gate that fires on the normal path gets routed around. A path git reports in quoted form — one containing a quote, backslash, or control character — aborts the fingerprint with the path named, because such a file would drop out of content hashing while still appearing in the path list, reintroducing the same fail-open shape in a corner. Covered by `.ai-policy/scripts/test-validation-state.sh`, which drives a real `git commit` through the real hook rather than asserting on exit codes alone, and pins fingerprint stability first: a fingerprint that differed between two runs over an identical tree would block every commit in every repository that installs this ([#205]).
+
+### Changed
+
+- A validation result recorded before this version carries no fingerprint and no longer satisfies the gate. The first commit or push after updating blocks with a message naming the cause and the remedy, and `./.ai-policy/scripts/run-validation.sh` clears it. Failing closed is deliberate: a bare `passed` cannot be tied to any tree, so it is not evidence that what is about to be committed was validated ([#205]).
+
 ## 3.16.0 - 2026-08-06
 
 ### Added
@@ -511,3 +521,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#177]: https://github.com/philippe-ths/ai-coding-workflow/issues/177
 [#200]: https://github.com/philippe-ths/ai-coding-workflow/issues/200
 [#202]: https://github.com/philippe-ths/ai-coding-workflow/issues/202
+[#205]: https://github.com/philippe-ths/ai-coding-workflow/issues/205

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.16.0
+Version: 3.17.0
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/design/decisions/enforcement-layers.md
+++ b/design/decisions/enforcement-layers.md
@@ -37,17 +37,53 @@ Nothing is lost by the exemption: a deletion naming a protected branch has alrea
 
 ### Validation state tracking
 
-The validation system uses a simple state file (`validation.status`) with three states: `running`, `passed`, `failed`.
+The validation system uses a state file (`validation.status`) with three states: `running`, `passed`, `failed`.
+A pass is recorded as `passed <fingerprint>`; the other two imply no particular tree and stay bare.
 
 `run-validation.sh` orchestrates the flow: it sets the state to `running`, runs the configured validation command, and sets the state to `passed` or `failed` based on the result.
-The `running` state plus a trap on exit ensures that if the script is interrupted or crashes, the state reverts to `failed` rather than remaining `passed` from a stale run.
+The `running` state plus a trap on exit ensures that if the script is interrupted or crashes, the state reverts to `failed` rather than remaining `passed` from an abandoned run.
 
-`check-validation.sh` reads the state file and blocks the Git action unless the state is `passed`.
-This enforces the workflow rule that validation must pass before commit or push.
+`check-validation.sh` reads the state file and blocks the Git action unless the state is `passed` **and** the recorded fingerprint matches the current working tree.
+
+### Why a pass is tied to a tree
+
+A bare result records that validation passed, not what it passed against.
+The gate then answers a weaker question than the one it exists to ask: it confirms that some validation run succeeded at some point, when what matters is whether the content being committed is the content that was validated.
+The two diverge the moment a file is edited after the run, and the gap is invisible because the state still reads `passed`.
+This failed in the direction that costs most — it reported green — and the only workaround was to remember to re-run validation immediately before every commit, putting the guarantee back on human memory, which is what the deterministic layer exists to remove.
+
+`tree-fingerprint.sh` produces the fingerprint, hashing tracked and untracked-not-ignored paths and their content through `git hash-object`.
+Using git's own hashing rather than `shasum` or `sha256sum` avoids a portability split between platforms, and git is already a hard dependency of every hook here.
+
+Three exclusions are deliberate.
+Ignored files are out because validation does not read them, so changing one is not a reason to revalidate.
+The state file itself is excluded by explicit path rather than by relying on the ignore rules, because the fingerprint is written into that file: in a target repository that had not ignored it, every recorded result would invalidate itself on the next read, bricking the gate.
+Deleted-but-tracked files are named by `git ls-files --deleted` rather than hashed, since hashing a missing path would abort the run on any ordinary deletion.
+
+Two further exclusions are what make the gate usable rather than merely correct.
+Index state is excluded, because `git add` changes whether a modification is staged and not what any file contains.
+HEAD is excluded, because committing moves it while leaving every file on disk identical.
+Including either was tried and both broke the ordinary sequence: staging invalidated the pass that had just been recorded, and committing invalidated it again so that every push demanded a second validation run.
+Neither block corresponded to any change in what validation had read.
+This matters more than the precision it gives up — a fingerprint keyed to history would distinguish the same edit before and after a rebase — because a gate that fires on the normal path gets routed around, and a bypassed gate enforces nothing.
+
+One case refuses outright.
+git reports a path containing a quote, a backslash, or a control character in quoted form, and that quoted string no longer names a file on disk.
+Such a file would drop out of the content hashing while still appearing in the path list, so edits to it would not move the fingerprint — the same fail-open shape this change exists to close, reintroduced in a corner.
+The script therefore aborts with the offending paths named rather than producing a fingerprint that covers less than it appears to.
+Paths containing spaces are not quoted and need no special handling.
+
+The fingerprint's stability is the load-bearing property, and the risk runs opposite to the defect it fixes.
+A fingerprint that differs between two runs over an identical tree would block every commit in every repository that installs this layer, so `test-validation-state.sh` pins stability before it tests anything that depends on it.
+
+Two limits are known and accepted.
+The fingerprint is taken after the validation command returns, so a validation run that mutated a tracked file would fold that mutation into the recorded result.
+The pre-commit gate fingerprints the working tree rather than the index, so committing a subset of a validated tree passes; this matches what validation actually ran against, which is the whole tree.
 
 `mark-validation-pass.sh` and `mark-validation-fail.sh` exist as manual overrides.
 They allow the human to set validation state directly when the automated flow is not appropriate (e.g. the project has no tests yet, or a known-failing test needs to be bypassed for a specific commit).
 These are escape hatches, not normal workflow paths.
+`mark-validation-pass.sh` still stamps the current fingerprint: the override exists to skip running validation, not to exempt the result from belonging to the content being committed.
 
 ### project-validation.sh
 

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.16.0
+Version: 3.17.0
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/project-checks.md
+++ b/project-checks.md
@@ -41,9 +41,9 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 - Matters: a branch cut from a stale `main` rebases onto surprises later. Uses `ls-remote` rather than `git fetch`, which writes remote-tracking refs.
 
 ### Validation state
-- Check: `cat .ai-policy/state/validation.status`, then compare its modification time against the newest file in `git status --porcelain`.
-- Normal: `passed`, written after the most recent working-tree edit.
-- Matters: commits and pushes are blocked until validation passes, so a failed state left from last session stops the first commit of this one. A `passed` older than the tree is worse than a failure: it is last session's result being read as this session's green.
+- Check: `./.ai-policy/scripts/check-validation.sh; echo "exit $?"`
+- Normal: `exit 0`.
+- Matters: commits and pushes are blocked until validation passes, so a failed state left from last session stops the first commit of this one. The gate itself compares the recorded pass against a fingerprint of the current tree, so running it reports staleness exactly rather than inferring it from modification times; a non-zero exit names which of the two cases applies. Read-only: the check reads the state file and hashes the tree without writing either.
 
 ## Policy Layer
 

--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.20.0
+Version: 1.21.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -13,7 +13,8 @@ Version: 1.20.0
 - **Project context**: a factual reference document (`project-context.md`) describing the target repository's current implementation state, authored using the `aiw-project-context-management` skill.
 - **Project checks**: a per-repository document (`project-checks.md`) recording what is worth checking at session start and what normal looks like for each check, maintained by the `aiw-init` skill.
 - **Session preflight**: a read-only run of the declared checks that reports project state the human may not be aware of and starts no work.
-- **Validation state**: a local runtime artifact (`.ai-policy/state/validation.status`) tracking whether the current validation run has passed.
+- **Validation state**: a local runtime artifact (`.ai-policy/state/validation.status`) recording whether validation passed and, for a pass, a fingerprint of the working tree it was computed against.
+- **Tree fingerprint**: a hash of tracked and untracked-not-ignored content, produced by `.ai-policy/scripts/tree-fingerprint.sh`, which ties a validation result to the content that produced it so a pass from an earlier tree cannot satisfy the gate.
 - **Policy layer**: the set of shell scripts in `.ai-policy/` that enforce protected-branch and validation-state rules.
 - **Skill**: a domain-specific instruction file loaded on demand by the agent when a workflow step requires it.
 - **Checkpoint**: a required human-review pause defined in the workflow before a consequential action.
@@ -85,7 +86,7 @@ Version: 1.20.0
 - `CLAUDE.md`: Claude Code agent instructions; structure mirrors `.github/copilot-instructions.md`.
 - `GEMINI.md`: Gemini CLI agent instructions; structure mirrors `AGENTS.md`.
 - `.ai-policy/policy.env`: declares protected branches, validation state file path, and validation command.
-- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
+- `.ai-policy/scripts/`: shell scripts for running validation, marking pass/fail state, and testing enforcement; `check-validation.sh` is the commit and push gate and blocks unless the recorded pass matches the fingerprint `tree-fingerprint.sh` computes for the current tree; `project-validation.sh` is the portable policy-layer check (shell-script syntax plus enforcement tests gated on the agent entry points installed) and invokes `scripts/repo-validation.sh` afterwards when present, warning loudly when it is absent.
 - `.ai-policy/hooks/`: hook logic scripts invoked by `.githooks/`, `.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`, and `.github/hooks/`, including `check-changelog.sh` (pre-push, rejects `ai-workflow.md` version bumps without a matching `CHANGELOG.md` entry), `check-context-drift.sh` (SessionStart, advisory reminder when `project-context.md` is `CONTEXT_DRIFT_THRESHOLD`+ commits behind HEAD; wired for Claude Code and Codex only), `block-pr-merge.sh` (PreToolUse, blocks agent pull-request merges on the shell and MCP routes unconditionally; wired for all four tools), and `block-pr-approve.sh` (PreToolUse, blocks agent pull-request approvals on both routes, failing closed on an unreadable MCP review event; review comments and change requests pass).
 - `.ai-policy/scripts/check-push-refs.sh` is the authoritative protected-branch check for pushes; `.githooks/pre-push` pipes git's resolved refs to it, and it blocks when any pushed ref targets a protected branch.
 - Guards answer one of two questions. `check-push-refs.sh` and the refspec check in `block-protected-branch-bash.sh` ask what a write targets; `check-protected-branch.sh` and the current-branch check ask where the agent is standing; `block-pr-merge.sh` asks neither and blocks the action outright, because a pull-request merge names no branch and reaches a protected branch without writing to one locally.
@@ -120,7 +121,7 @@ Version: 1.20.0
 
 ## Testing Overview
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
-- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, `test-push-refs.sh`, and `test-pr-approve-hook.sh` always run.
+- Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, `test-push-refs.sh`, `test-pr-approve-hook.sh`, and `test-validation-state.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, and changelog-removals sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.


### PR DESCRIPTION
Closes #205.

## The defect

`.ai-policy/state/validation.status` recorded a bare `passed` with nothing tying it to the content that produced it. The commit and push gates read the word and allowed the action, so a result computed against an earlier working tree satisfied the gate for a later one. It was observed with ten files edited after the recorded pass.

The gate exists so that what is being committed has been validated. A stale pass satisfies the mechanism while defeating its purpose, and it fails in the dangerous direction: it reports green. The only workaround was to remember to re-run validation immediately before every commit, which puts the guarantee back on human memory — exactly what the deterministic layer exists to remove.

## The change

`tree-fingerprint.sh` hashes path names and file contents through `git hash-object`, so no external checksum tool is needed and no portability split appears between platforms. `run-validation.sh` records the result as `passed <fingerprint>`; `check-validation.sh` blocks unless it matches the current tree. `mark-validation-pass.sh` stamps the same fingerprint, so the manual override remains an escape hatch from running validation and not from the result belonging to the content being committed.

## What the fingerprint covers, and what it does not

Index state and HEAD are excluded deliberately. `git add` changes whether a modification is staged rather than what any file contains, and committing moves HEAD while leaving every file on disk identical.

Both were included in a first cut, and both broke the ordinary edit-validate-stage-commit-push sequence: staging invalidated the pass that had just been recorded, and committing invalidated it again so every push demanded a second validation run. Neither block corresponded to any change in what validation had read. This gives up real precision — a fingerprint keyed to history would distinguish the same edit before and after a rebase — but a gate that fires on the normal path gets routed around, and a bypassed gate enforces nothing. Both flows are now pinned by tests.

Ignored files are excluded because validation does not read them. The state file is excluded by explicit path rather than by ignore rules: in a target that had not ignored it, every recorded result would invalidate itself on the next read.

A path git reports in quoted form — one containing a quote, backslash, or control character — aborts the fingerprint with the path named. Such a file would drop out of content hashing while still appearing in the path list, so edits to it would not move the fingerprint, reintroducing the same fail-open shape in a corner. Paths containing spaces are unaffected.

## Behaviour change on update

A result recorded before this version carries no fingerprint and no longer satisfies the gate. The first commit or push after updating blocks with a message naming the cause and the remedy; `run-validation.sh` clears it. A bare `passed` cannot be tied to any tree, so failing closed is the honest reading.

## Verification

`check-validation.sh` had no test at all, which is why this shipped: the enforcement suite covered protected-branch logic, push refs, and hook wiring, but never the validation gate.

`test-validation-state.sh` now covers the whole script — 41 assertions, picked up automatically by `project-validation.sh`. It ran against the unmodified scripts first and failed 11 of 29 before the change. It drives a real `git commit` through the real `pre-commit` hook rather than asserting on exit codes alone, and pins fingerprint stability as its first assertion: a fingerprint differing between two runs over an identical tree would block every commit in every repository that installs this layer.

Negative paths covered: absent state file, empty state file, malformed `passed` line, legacy bare `passed`, stale after edit, stale after a new untracked file, staged deletion, and the manual override failing to survive a later edit.

Full validation is green, and the pre-commit and pre-push hooks on this branch were themselves gated by the new code.

## Known limits

- The fingerprint is taken after the validation command returns, so a validation run that mutated a tracked file would fold that mutation into the recorded result.
- The pre-commit gate fingerprints the working tree rather than the index, so committing a subset of a validated tree passes. This matches what validation actually ran against.
- The gate now hashes the tree on every commit and push: 0.10s over 123 files here, 3.60s over 20,002 files in a synthetic repo. Adopting projects at that scale pay it twice per commit-and-push cycle.

## Not verified

- The `pre-push` path was not driven end to end. It calls the same `check-validation.sh`, but a defect specific to that hook's invocation would not be caught by what ran.
- No installed target was driven through the upgrade to observe the bare-`passed` block in place.
- macOS and one git version only.
