### PR TITLE
Add three session-preflight checks and correct the telemetry residue record

### DIFF
--- a/project-checks.md
+++ b/project-checks.md
@@ -33,15 +33,11 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 - Normal: empty.
 - Matters: post-merge cleanup was skipped, and the leftover branch will be mistaken for live work.
 
-### Pushed branch with no pull request
-- Check: for each branch in `git ls-remote --heads origin` other than `main`, `gh pr list --head <branch> --state all`
-- Normal: every pushed branch has a pull request.
-- Matters: a branch pushed without a pull request is finished work that nothing will ever merge. The open-pull-request check above cannot see it, because an absent pull request reads there as nothing waiting on you.
-
-### Remote branches not merged into main
-- Check: `git ls-remote --heads origin`, then for each branch compare against `gh pr list --head <branch> --state all`
-- Normal: only `main` and branches with an open pull request.
-- Matters: a remote branch outlives the machine it was pushed from, so post-merge cleanup done locally leaves it behind. Resolving whether one is merged needs its objects, which a read-only run does not have; report the branch and say its merge status is unresolved rather than fetching.
+### Remote branch without an open pull request
+- Check: `git ls-remote --heads origin`, then for each branch other than `main`, `gh pr list --head <branch> --state all --json number,state`
+- Normal: every remote branch other than `main` has an open pull request.
+- Matters: two different things fail this, and they need different answers, so report which one each branch is rather than only that it has no open pull request. A branch with no pull request at all is finished work that nothing will ever merge, and the open-pull-request check above cannot see it, because an absent pull request reads there as nothing waiting on you. A branch whose pull request already merged is post-merge cleanup that happened locally and never reached the remote, and a remote branch outlives the machine it was pushed from.
+- Read the result, not the exit status: `gh pr list` prints nothing for a branch with no pull request, so a command that fails prints nothing too. If the lookup is wrapped in anything that substitutes a default on error, every branch reads as having no pull request. Resolving whether an unmerged branch's commits already sit in `main` needs its objects, which a read-only run does not have; say the merge status is unresolved rather than fetching.
 
 ## Repository Integrity
 
@@ -91,13 +87,14 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 - Matters: the dashboard is the only view of how workflow changes are landing across sessions, and a stale one invites conclusions drawn from old data.
 
 ### Recurring unverified surface
-- Check: `gh pr list --state merged --limit 20 --json number,body`, then group the bodies' unverified-surface sections by the surface named and count repeats; for any surface named in three or more, `gh issue list --state all --search "<surface>"`.
+- Check: `gh pr list --state merged --limit 20 --json number,body`, then read each body's unverified-surface section, group by the surface named, and count repeats; for any surface named in three or more, search the issues for that surface.
 - Normal: no surface named in three or more of the last twenty merged pull requests without an issue tracking it.
 - Matters: a gap declared once is a task's limitation, and a gap declared across many tasks is the repository's. Left untracked it is re-declared indefinitely, which reads as honesty while nothing moves.
+- This one is read, not grepped. The section has no fixed heading: recent bodies write it as "What was not checked", as "**Not verified:**", and as "**Also not verified:**" partway through a paragraph, and `aiw-verification` names it only as part 3. Locating it is a judgement, and so is deciding that two differently-worded gaps are the same surface. Treat the count as a prompt to look rather than as a measurement. Put the real surface into the issue search; the literal placeholder matches everything and returns the whole issue list, which reads as though all of it is already tracked.
 
 ## Not Covered Here
 
-- **Application logs and error tracking.** No runtime application exists to produce them. The `telemetry/` residue that used to sit here, left by the removed eval stack, was deleted in #204 and then recreated: the same issue left two launchd agents registered, and a failing agent recreates the log paths its plist declares. Both agents were unregistered and the residue removed on 2026-08-21, so nothing recreates it now. A deletion is not finished while something outside the repository still points at what was deleted.
+- **Application logs and error tracking.** No runtime application exists to produce them. The `telemetry/` residue that used to sit here, left by the removed eval stack, was deleted in #204 and then recreated: the same issue left two launchd agents registered, and a failing agent recreates the log paths its plist declares. Both agents were unregistered and the residue removed on 2026-08-21. That last part is a reading from one machine and nothing in the repository can confirm it for another, so if the residue reappears, check `launchctl list` before assuming this line still holds. A deletion is not finished while something outside the repository still points at what was deleted.
 - **Dependent services.** Nothing is called at runtime. `bash`, `git`, `jq`, and `python3` are developer tools, checked by their absence breaking validation rather than by a health probe.
 - **Deployment and CI.** `.github/` holds no workflows, so there is no remote build whose status could be red. The nearest equivalent is the local validation state above.
 - **Certificate and secret expiry.** No secrets are held; the only credential is the `gh` token, checked under Expiry and Limits.

--- a/project-checks.md
+++ b/project-checks.md
@@ -97,7 +97,7 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 
 ## Not Covered Here
 
-- **Application logs and error tracking.** No runtime application exists to produce them. The `telemetry/` residue that used to sit here — four zero-byte `.log` files and five empty directories left by the removed eval stack — was deleted in #204.
+- **Application logs and error tracking.** No runtime application exists to produce them. The `telemetry/` residue that used to sit here, left by the removed eval stack, was deleted in #204 and then recreated: the same issue left two launchd agents registered, and a failing agent recreates the log paths its plist declares. Both agents were unregistered and the residue removed on 2026-08-21, so nothing recreates it now. A deletion is not finished while something outside the repository still points at what was deleted.
 - **Dependent services.** Nothing is called at runtime. `bash`, `git`, `jq`, and `python3` are developer tools, checked by their absence breaking validation rather than by a health probe.
 - **Deployment and CI.** `.github/` holds no workflows, so there is no remote build whose status could be red. The nearest equivalent is the local validation state above.
 - **Certificate and secret expiry.** No secrets are held; the only credential is the `gh` token, checked under Expiry and Limits.

--- a/project-checks.md
+++ b/project-checks.md
@@ -33,6 +33,16 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 - Normal: empty.
 - Matters: post-merge cleanup was skipped, and the leftover branch will be mistaken for live work.
 
+### Pushed branch with no pull request
+- Check: for each branch in `git ls-remote --heads origin` other than `main`, `gh pr list --head <branch> --state all`
+- Normal: every pushed branch has a pull request.
+- Matters: a branch pushed without a pull request is finished work that nothing will ever merge. The open-pull-request check above cannot see it, because an absent pull request reads there as nothing waiting on you.
+
+### Remote branches not merged into main
+- Check: `git ls-remote --heads origin`, then for each branch compare against `gh pr list --head <branch> --state all`
+- Normal: only `main` and branches with an open pull request.
+- Matters: a remote branch outlives the machine it was pushed from, so post-merge cleanup done locally leaves it behind. Resolving whether one is merged needs its objects, which a read-only run does not have; report the branch and say its merge status is unresolved rather than fetching.
+
 ## Repository Integrity
 
 ### Local main matches remote
@@ -79,6 +89,11 @@ Surfaces this repository has no instance of are recorded under "Not Covered Here
 - Check: `python3 -c "import os,time;p=os.path.expanduser('~/.claude/aiw-observation/dashboard.html');print(int((time.time()-os.path.getmtime(p))/86400))"`
 - Normal: 30 or fewer days since the last `make observe`.
 - Matters: the dashboard is the only view of how workflow changes are landing across sessions, and a stale one invites conclusions drawn from old data.
+
+### Recurring unverified surface
+- Check: `gh pr list --state merged --limit 20 --json number,body`, then group the bodies' unverified-surface sections by the surface named and count repeats; for any surface named in three or more, `gh issue list --state all --search "<surface>"`.
+- Normal: no surface named in three or more of the last twenty merged pull requests without an issue tracking it.
+- Matters: a gap declared once is a task's limitation, and a gap declared across many tasks is the repository's. Left untracked it is re-declared indefinitely, which reads as honesty while nothing moves.
 
 ## Not Covered Here
 


### PR DESCRIPTION
## What this changes

Two additions and one correction to `project-checks.md`, this repository's record of what is worth checking at session start.

- **Remote branch without an open pull request.** One check that classifies each remote branch: no pull request at all is finished work nothing will merge, and a merged pull request whose branch survives is post-merge cleanup that never reached the remote. The existing open-pull-request check sees neither, because an absent pull request reads there as nothing waiting on you.
- **Recurring unverified surface.** Groups the unverified-surface sections of recent merged pull requests and escalates any surface named three or more times without a tracking issue.
- **Telemetry residue correction.** The previous entry said the residue was deleted in #204 and left it there. It was recreated: #204 left two launchd agents registered, and a failing agent recreates the log paths its plist declares.

## Correction after adversarial review

**An earlier version of this pull request claimed three pushed branches had no pull request. That was wrong, and so was the evidence behind it.**

The command I ran wrapped the per-branch lookup in `... --jq '...' || echo "NO PR"`, and the jq expression had a syntax error (`if ... then ... else ... else end`). jq failed on every branch, the fallback fired every time, and I read a string my own error handler had printed as the lookup's answer.

Ground truth, re-run with the failure path no longer swallowed:

```
claude/ai-workflow-setup-SCOYl           <no pull request>
claude/ai-workflow-setup-xaoRX           <no pull request>
claude/open-issues-review-nqEam          157 MERGED
```

**Two** branches have no pull request. `claude/open-issues-review-nqEam` has merged pull request #157 from June with its branch left behind, which is the other half of the same check and a real instance of it.

The check itself now carries that warning, because a lookup that prints nothing for a branch with no pull request looks identical to a lookup that failed.

## Decisions taken after review

**The two branch checks became one.** As first written they overlapped: a branch with no pull request necessarily has no open one, so the first check's trigger set was a strict subset of the second's and added no detection, only a different narrative. One check that reports which of the two each branch is keeps both narratives and runs the lookup once.

**The recurring-unverified-surface check now says it is read rather than grepped.** The section has no fixed heading. Across the last twenty merged bodies it appears as "What was not checked", as "**Not verified:**", and as "**Also not verified:**" partway through a paragraph, and `aiw-verification` names it only as part 3. Locating it is a judgement before the grouping is one, and the check now says so rather than implying a mechanical count. It also warns that leaving the literal `<surface>` placeholder in the issue search returns the entire issue list, which reads as though everything is already tracked.

**The telemetry entry no longer states the launchd cleanup as settled fact.** What is checkable from here is that no `telemetry/` path exists and `launchctl list` shows nothing matching. That the agents were unregistered on a particular date is a reading from one machine, and the entry now says so instead of presenting it as repository truth.

## Verification

**What could plausibly have broken.** This file is read by `aiw-init` and by a human at session start. The risk is a check that cannot be run as written, or a "Normal" that misdescribes this repository, either of which turns preflight into a source of false readings. The realised risk was narrower and worse than that: a check that runs, prints something plausible, and is believed.

**Evidence.** Each check was executed against this repository and its **output was inspected**, with the lookup's exit status tested separately from its output so a failure cannot masquerade as an empty result:

- The remote-heads listing returns 8 branches besides `main`.
- The per-branch lookup returns an open pull request for six of them, no pull request for two, and a merged pull request for one. Those three outcomes are exactly the three the merged check distinguishes, so the check fires on real state in all its branches.
- The merged-pull-request query returns 20 bodies. Of the last 25 merged, 12 declare an unverified surface, and all 12 do it under a heading or a bold lead-in rather than inline, which is what the "read, not grepped" note now records.

Evidence level: end-to-end execution against the real repository and the real `gh` account, which is the system these checks address.

## What was not checked

- **The grouping step of the recurring-unverified-surface check was not run to completion.** Only that its input query returns the bodies it needs, and that the sections it must find are formatted inconsistently. Grouping is a judgement, so running it here would verify my reading rather than the check. A miscount understates recurrence and delays an escalation; it cannot invent one.
- **The launchd claim rests on this machine on 2026-08-21.** Nothing in the repository can confirm it, which is now stated in the entry itself rather than only here.
- **No mechanism executes the commands this file documents.** They are prose, and a wrong one is found by a human running it. That is what happened here, one review too late. The prose checker in #230 would not catch it either: it checks structure, not whether a documented command does what its text claims.

## Finding surfaced by this change

Two branches with no pull request (`claude/ai-workflow-setup-SCOYl`, `claude/ai-workflow-setup-xaoRX`) and one merged branch never deleted (`claude/open-issues-review-nqEam`, pull request #157). Deciding what becomes of them is yours.

## Issue

No issue. Discovered by the `aiw-init` preflight while running this repository's own declared checks; the change is to the check list itself.
