### PR TITLE
Preserve every tool's vendored paths in the target .gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The canonical version is the `Version:` header in `ai-workflow.md`. Every bump o
 
 Every `### Removed` bullet must lead with the removed path as a backticked token (`` - `path/to/thing` — explanation``), one removed path per bullet. The update path reads these to know which installed files to delete from a target repo, so the format must stay machine-extractable. `scripts/check-changelog-removals.sh` enforces this (factory-only validation; it is not shipped to target repos).
 
+## 3.25.1 - 2026-08-21
+
+### Fixed
+
+- Installing a second agent tool into the same target no longer strips the first tool's vendored paths from the target's `.gitignore`. The installer-managed block was rebuilt from only the current run's paths, so the documented multi-tool procedure — one installer run per tool, which `scripts/update.sh` requires by refusing to auto-detect an ambiguous target — left each run undoing the one before it. In a repository running this workflow with four tools installed, the result was `.claude/`, `.codex/`, `.gemini/`, `CLAUDE.md` and `AGENTS.md` all untracked, one `git add -A` away from being committed into a history that is supposed to vendor them. The block is now a union: entries already in it are kept in order and the current run's paths appended if absent. This is the opposite symptom of [#166], and [#166]'s fix is its cause — to stop duplicate entries the installer began deleting matching lines from anywhere in the file, and combined with each run knowing only one tool's paths, removal outran replacement. That file-wide deletion is now confined to the first install, the only run with no managed block to date the file against; once a block exists, a matching line outside it is hand-maintained and is left alone, so a section a human labelled as needing to survive updates does. `scripts/update.sh` prunes paths named in `### Removed` changelog bullets from the block, since a union would otherwise keep a path that had left the product forever, and never prunes one the current product still ships. The gap that let this run for two months was that both sandbox tests only ever installed a single tool; they now install three in sequence and assert on `git status --porcelain`, which is the hazard the issue actually describes rather than a proxy for it ([#216]).
+
 ## 3.25.0 - 2026-08-21
 
 ### Added
@@ -561,6 +567,7 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#155]: https://github.com/philippe-ths/ai-coding-workflow/issues/155
 [#99]: https://github.com/philippe-ths/ai-coding-workflow/issues/99
 [#165]: https://github.com/philippe-ths/ai-coding-workflow/issues/165
+[#166]: https://github.com/philippe-ths/ai-coding-workflow/issues/166
 [#114]: https://github.com/philippe-ths/ai-coding-workflow/issues/114
 [#170]: https://github.com/philippe-ths/ai-coding-workflow/issues/170
 [#173]: https://github.com/philippe-ths/ai-coding-workflow/issues/173
@@ -590,3 +597,4 @@ Major redesign of the workflow structure. The 14-step numbered workflow plus ref
 [#208]: https://github.com/philippe-ths/ai-coding-workflow/issues/208
 [#209]: https://github.com/philippe-ths/ai-coding-workflow/issues/209
 [#224]: https://github.com/philippe-ths/ai-coding-workflow/issues/224
+[#216]: https://github.com/philippe-ths/ai-coding-workflow/issues/216

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.25.0
+Version: 3.25.1
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/lite-monolithic/ai-workflow.md
+++ b/lite-monolithic/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.25.0
+Version: 3.25.1
 
 This file defines the workflow for AI-assisted coding on this project.
 It is written for the AI coding agent.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,71 +89,76 @@ copy_tracked() {
 # The block is a UNION across installs: entries already in it are kept in order
 # and this run's paths are appended if absent, so installing a second tool does
 # not un-ignore the first tool's paths (#216).
+#
+# A target's .gitignore is arbitrary bytes written by humans and other tools, so
+# this function assumes nothing about its content (#229):
+#   * the whole new file is built in one awk pass into $gi.tmp and moved into
+#     place only on success, so a failure cannot leave the file truncated;
+#   * text processing runs under LC_ALL=C, because a line that is not valid
+#     UTF-8 makes BSD awk/grep/sed fail with "illegal byte sequence" under a
+#     UTF-8 locale;
+#   * this run's paths reach awk through a file, never a delimited string, so a
+#     literal delimiter in a path or an existing line cannot mis-split;
+#   * entries are compared AND re-emitted normalised, so an indented "  .claude/"
+#     cannot shadow the real ".claude/" while git ignores nothing.
 write_gitignore_block() {
   local gi="$TARGET/.gitignore"
   local begin="# >>> ai-workflow (vendored, managed by installer) >>>"
   local end="# <<< ai-workflow <<<"
   touch "$gi"
-  # Entries currently inside the managed block, in order.
-  local existing
-  existing="$(awk -v b="$begin" -v e="$end" '
-    $0==b {inblock=1; next}
-    $0==e {inblock=0; next}
-    inblock==1 {print}
-  ' "$gi")"
-  local had_block=0
-  grep -qxF "$begin" "$gi" 2>/dev/null && had_block=1
-  # Drop our previous managed block. On a FIRST install only (no managed block
-  # yet), also drop pre-existing unmarked lines that exactly match a vendored
-  # path, folding an earlier manual copy into the managed block instead of
-  # leaving the same path listed twice (#166). Once a managed block exists, a
-  # matching line outside it is hand-maintained and is left untouched (#216).
-  local joined; joined="$(printf '%s|' "$@")"
-  [ "$had_block" -eq 1 ] && joined=""
-  awk -v b="$begin" -v e="$end" -v paths="$joined" '
-    BEGIN {
-      n = split(paths, parr, "|")
-      for (i = 1; i <= n; i++) { k = parr[i]; sub(/\/+$/, "", k); if (k != "") drop[k] = 1 }
-    }
-    $0==b {skip=1}
-    skip==0 {
-      key = $0
-      sub(/^[ \t]+/, "", key); sub(/[ \t]+$/, "", key); sub(/\/+$/, "", key)
-      if (!(key in drop)) print
-    }
-    $0==e {skip=0}
-  ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
-  # New block contents: kept entries first, then this run's unseen paths.
-  local keys="|" out="" line k
-  while IFS= read -r line; do
-    k="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's#/*$##')"
-    [ -z "$k" ] && continue
-    case "$keys" in *"|$k|"*) continue ;; esac
-    keys="$keys$k|"
-    out="$out$line
-"
-  done <<EXISTING
-$existing
-EXISTING
-  local p
-  for p in "$@"; do
-    k="$(printf '%s' "$p" | sed -e 's#/*$##')"
-    [ -z "$k" ] && continue
-    case "$keys" in *"|$k|"*) continue ;; esac
-    keys="$keys$k|"
-    out="$out$p
-"
-  done
-  if [ -s "$gi" ] && [ -n "$(tail -c1 "$gi" 2>/dev/null)" ]; then
-    printf '\n' >> "$gi"
-  fi
-  {
-    printf '%s\n' "$begin"
-    printf '%s' "$out"
-    printf '%s\n' "$end"
-  } >> "$gi"
-}
 
+  local paths_file p
+  paths_file="$(mktemp)" || { echo "error: could not create a temp file" >&2; return 1; }
+  for p in "$@"; do
+    [ -n "$p" ] && printf '%s\n' "$p"
+  done > "$paths_file"
+
+  # Existing block entries are kept in order and deduplicated by normalised key;
+  # this run's unseen paths are appended verbatim, exactly as the manifest gives
+  # them. Pre-existing unmarked lines matching a vendored path are folded into
+  # the block on a FIRST install only (#166); once a managed block exists such a
+  # line is hand-maintained and is left alone (#216). Exactly one marker pair is
+  # emitted however many the input held.
+  if LC_ALL=C LANG=C awk -v b="$begin" -v e="$end" -v pf="$paths_file" '
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    function norm(s) { s = trim(s); sub(/\/+$/, "", s); return s }
+    FILENAME == pf { raw[++np] = $0; runkey[norm($0)] = 1; next }
+    { lines[++nl] = $0; if ($0 == b) hadblock = 1 }
+    END {
+      fold = (hadblock ? 0 : 1)
+      skip = 0
+      for (i = 1; i <= nl; i++) {
+        line = lines[i]
+        if (line == b) skip = 1
+        if (skip == 0) {
+          k = norm(line)
+          if (!(fold && k != "" && (k in runkey))) out[++no] = line
+        } else if (line != b && line != e) {
+          k = norm(line)
+          if (k != "" && !(k in seen)) { seen[k] = 1; keep[++nk] = trim(line) }
+        }
+        if (line == e) skip = 0
+      }
+      for (i = 1; i <= no; i++) print out[i]
+      print b
+      for (i = 1; i <= nk; i++) print keep[i]
+      for (i = 1; i <= np; i++) {
+        k = norm(raw[i])
+        if (k == "" || (k in seen)) continue
+        seen[k] = 1
+        print raw[i]
+      }
+      print e
+    }
+  ' "$paths_file" "$gi" > "$gi.tmp"; then
+    rm -f "$paths_file"
+    mv "$gi.tmp" "$gi"
+  else
+    rm -f "$paths_file" "$gi.tmp"
+    echo "error: could not rewrite $gi; it was left unchanged" >&2
+    return 1
+  fi
+}
 ignore_paths=()
 
 if [ "$PROFILE" = "full" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,16 +86,30 @@ copy_tracked() {
 }
 
 # Rewrite the installer-managed block in the target .gitignore (idempotent).
+# The block is a UNION across installs: entries already in it are kept in order
+# and this run's paths are appended if absent, so installing a second tool does
+# not un-ignore the first tool's paths (#216).
 write_gitignore_block() {
   local gi="$TARGET/.gitignore"
   local begin="# >>> ai-workflow (vendored, managed by installer) >>>"
   local end="# <<< ai-workflow <<<"
   touch "$gi"
-  # Drop our previous managed block, and also any pre-existing unmarked lines
-  # that exactly match a vendored path (ignoring trailing slashes). The latter
-  # folds entries from an earlier manual install into the managed block instead
-  # of leaving the same path listed twice.
+  # Entries currently inside the managed block, in order.
+  local existing
+  existing="$(awk -v b="$begin" -v e="$end" '
+    $0==b {inblock=1; next}
+    $0==e {inblock=0; next}
+    inblock==1 {print}
+  ' "$gi")"
+  local had_block=0
+  grep -qxF "$begin" "$gi" 2>/dev/null && had_block=1
+  # Drop our previous managed block. On a FIRST install only (no managed block
+  # yet), also drop pre-existing unmarked lines that exactly match a vendored
+  # path, folding an earlier manual copy into the managed block instead of
+  # leaving the same path listed twice (#166). Once a managed block exists, a
+  # matching line outside it is hand-maintained and is left untouched (#216).
   local joined; joined="$(printf '%s|' "$@")"
+  [ "$had_block" -eq 1 ] && joined=""
   awk -v b="$begin" -v e="$end" -v paths="$joined" '
     BEGIN {
       n = split(paths, parr, "|")
@@ -109,13 +123,33 @@ write_gitignore_block() {
     }
     $0==e {skip=0}
   ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
+  # New block contents: kept entries first, then this run's unseen paths.
+  local keys="|" out="" line k
+  while IFS= read -r line; do
+    k="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's#/*$##')"
+    [ -z "$k" ] && continue
+    case "$keys" in *"|$k|"*) continue ;; esac
+    keys="$keys$k|"
+    out="$out$line
+"
+  done <<EXISTING
+$existing
+EXISTING
+  local p
+  for p in "$@"; do
+    k="$(printf '%s' "$p" | sed -e 's#/*$##')"
+    [ -z "$k" ] && continue
+    case "$keys" in *"|$k|"*) continue ;; esac
+    keys="$keys$k|"
+    out="$out$p
+"
+  done
   if [ -s "$gi" ] && [ -n "$(tail -c1 "$gi" 2>/dev/null)" ]; then
     printf '\n' >> "$gi"
   fi
   {
     printf '%s\n' "$begin"
-    local p
-    for p in "$@"; do printf '%s\n' "$p"; done
+    printf '%s' "$out"
     printf '%s\n' "$end"
   } >> "$gi"
 }

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -109,6 +109,107 @@ present "$T" .agents/skills
 absent  "$T" CLAUDE.md
 absent  "$T" GEMINI.md
 
+# --- multi-tool helpers ---------------------------------------------------
+manifest_paths() { # tool -> full-profile vendored paths, one per line
+  jq -r --arg t "$1" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$ROOT_DIR/install-manifest.json"
+}
+tool_paths() { # tools... -> deduplicated union of their vendored paths
+  local tool
+  for tool in "$@"; do manifest_paths "$tool"; done | sort -u
+}
+block_count() { grep -cF "# >>> ai-workflow (vendored, managed by installer) >>>" "$1/.gitignore" 2>/dev/null || echo 0; }
+outside_block() { # lines of .gitignore that are NOT inside the managed block
+  awk -v b="# >>> ai-workflow (vendored, managed by installer) >>>" \
+      -v e="# <<< ai-workflow <<<" \
+      '$0==b {skip=1} skip==0 {print} $0==e {skip=0}' "$1/.gitignore" 2>/dev/null
+}
+has_outside() { if outside_block "$1" | grep -qxF "$2"; then ok "kept outside block: $2"; else bad "lost outside block: $2"; fi; }
+one_block() { local n; n="$(block_count "$1")"; if [ "$n" -eq 1 ]; then ok "single managed block"; else bad "managed block count = $n"; fi; }
+no_untracked_vendored() { # target, then tools... : git status must not report vendored paths
+  local t="$1"; shift
+  local paths untracked p u pn un offenders=""
+  paths="$(tool_paths "$@")"
+  untracked="$(git -C "$t" status --porcelain 2>/dev/null | awk '/^\?\? /{print substr($0, 4)}')"
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    pn="${p%/}"
+    while IFS= read -r u; do
+      [ -z "$u" ] && continue
+      un="${u%/}"
+      case "$pn" in "$un"|"$un"/*) offenders="$offenders $p" ; continue ;; esac
+      case "$un" in "$pn"|"$pn"/*) offenders="$offenders $p" ;; esac
+    done <<UNTRACKED
+$untracked
+UNTRACKED
+  done <<PATHS
+$paths
+PATHS
+  if [ -z "$offenders" ]; then
+    ok "git status reports no vendored paths as untracked"
+  else
+    bad "git status reports vendored paths as untracked:$offenders"
+  fi
+}
+
+echo "multi-tool install (gemini then claude, same target):"
+T="$(new_target multi-gemini-claude)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "claude install exited non-zero"
+while IFS= read -r p; do has_line "$T" "$p"; done <<EOF
+$(tool_paths gemini claude)
+EOF
+exactly_once "$T" ".agents/skills/"
+exactly_once "$T" ".ai-policy/"
+exactly_once "$T" "ai-workflow.md"
+one_block "$T"
+no_untracked_vendored "$T" gemini claude
+
+echo "multi-tool install (third tool: codex on top):"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool codex --profile full >/dev/null 2>&1 || bad "codex install exited non-zero"
+while IFS= read -r p; do has_line "$T" "$p"; done <<EOF
+$(tool_paths gemini claude codex)
+EOF
+exactly_once "$T" ".agents/skills/"
+one_block "$T"
+no_untracked_vendored "$T" gemini claude codex
+
+echo "hand-maintained entries outside the managed block survive a later install:"
+T="$(new_target hand-maintained)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+cat >> "$T/.gitignore" <<'GI'
+
+# keep these - hand maintained
+.agents/skills/
+build-output/
+GI
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool codex --profile full >/dev/null 2>&1 || bad "codex install exited non-zero"
+has_outside "$T" "# keep these - hand maintained"
+has_outside "$T" ".agents/skills/"
+has_outside "$T" "build-output/"
+one_block "$T"
+
+# The one moment the installer cannot tell a deliberate hand-maintained entry
+# from the residue of an earlier manual install is the first one, because there
+# is no managed block yet to date the file against. It folds on that run only
+# (#166's normalisation), and never again (#216). Pinned so the boundary is a
+# chosen behaviour rather than an accident.
+echo "a first install folds a pre-existing vendored path, and only that path:"
+T="$(new_target fold-on-first)"
+cat > "$T/.gitignore" <<'GI'
+# keep these - hand maintained
+.agents/skills/
+build-output/
+GI
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+exactly_once "$T" ".agents/skills/"
+has_outside  "$T" "build-output/"
+has_outside  "$T" "# keep these - hand maintained"
+if git -C "$T" status --porcelain 2>/dev/null | grep -qE '\.agents/|\.gemini/|GEMINI\.md'; then
+  bad "a vendored path is untracked after the fold"
+else
+  ok "no vendored path is untracked after the fold"
+fi
+
 echo "lite / claude:"
 T="$(new_target lite-claude)"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile lite >/dev/null 2>&1

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -16,8 +16,8 @@ bad()  { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
 
 present() { if [ -e "$1/$2" ]; then ok "present: $2"; else bad "missing: $2"; fi; }
 absent()  { if [ -e "$1/$2" ]; then bad "should be absent: $2"; else ok "absent: $2"; fi; }
-has_line() { if grep -qF "$2" "$1/.gitignore" 2>/dev/null; then ok ".gitignore has $2"; else bad ".gitignore missing $2"; fi; }
-exactly_once() { local c; c="$(grep -cxF "$2" "$1/.gitignore" 2>/dev/null || true)"; if [ "${c:-0}" -eq 1 ]; then ok ".gitignore has exactly one '$2'"; else bad ".gitignore has $c '$2' (expected 1)"; fi; }
+has_line() { if LC_ALL=C grep -qF "$2" "$1/.gitignore" 2>/dev/null; then ok ".gitignore has $2"; else bad ".gitignore missing $2"; fi; }
+exactly_once() { local c; c="$(LC_ALL=C grep -cxF "$2" "$1/.gitignore" 2>/dev/null || true)"; if [ "${c:-0}" -eq 1 ]; then ok ".gitignore has exactly one '$2'"; else bad ".gitignore has $c '$2' (expected 1)"; fi; }
 
 SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t aiw-install)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -117,13 +117,13 @@ tool_paths() { # tools... -> deduplicated union of their vendored paths
   local tool
   for tool in "$@"; do manifest_paths "$tool"; done | sort -u
 }
-block_count() { grep -cF "# >>> ai-workflow (vendored, managed by installer) >>>" "$1/.gitignore" 2>/dev/null || echo 0; }
+block_count() { local n; n="$(LC_ALL=C grep -cF "# >>> ai-workflow (vendored, managed by installer) >>>" "$1/.gitignore" 2>/dev/null || true)"; echo "${n:-0}"; }
 outside_block() { # lines of .gitignore that are NOT inside the managed block
-  awk -v b="# >>> ai-workflow (vendored, managed by installer) >>>" \
+  LC_ALL=C awk -v b="# >>> ai-workflow (vendored, managed by installer) >>>" \
       -v e="# <<< ai-workflow <<<" \
       '$0==b {skip=1} skip==0 {print} $0==e {skip=0}' "$1/.gitignore" 2>/dev/null
 }
-has_outside() { if outside_block "$1" | grep -qxF "$2"; then ok "kept outside block: $2"; else bad "lost outside block: $2"; fi; }
+has_outside() { if outside_block "$1" | LC_ALL=C grep -qxF "$2"; then ok "kept outside block: $2"; else bad "lost outside block: $2"; fi; }
 one_block() { local n; n="$(block_count "$1")"; if [ "$n" -eq 1 ]; then ok "single managed block"; else bad "managed block count = $n"; fi; }
 no_untracked_vendored() { # target, then tools... : git status must not report vendored paths
   local t="$1"; shift
@@ -209,6 +209,65 @@ if git -C "$T" status --porcelain 2>/dev/null | grep -qE '\.agents/|\.gemini/|GE
 else
   ok "no vendored path is untracked after the fold"
 fi
+
+# --- byte- and shape-hostile .gitignore content (#229) --------------------
+# A target's .gitignore is arbitrary bytes written by humans and other tools.
+# Each case below is a real .gitignore that silently un-ignored vendored paths,
+# truncated the file, or grew a block per install.
+
+insert_in_block() { # target, line : add a line just inside the managed block
+  local t="$1" l="$2"
+  LC_ALL=C awk -v e="# <<< ai-workflow <<<" -v l="$l" '$0==e {print l} {print}' \
+    "$t/.gitignore" > "$t/.gitignore.ins" && mv "$t/.gitignore.ins" "$t/.gitignore"
+}
+
+echo "a non-UTF-8 byte inside the managed block does not truncate .gitignore:"
+T="$(new_target invalid-utf8-in-block)"
+printf 'node_modules/\n# >>> ai-workflow (vendored, managed by installer) >>>\nL\xf6sungen/\n.claude/\n# <<< ai-workflow <<<\n' > "$T/.gitignore"
+before_bytes="$(wc -c < "$T/.gitignore" | tr -d ' ')"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "install exited non-zero on an invalid-UTF-8 .gitignore"
+after_bytes="$(wc -c < "$T/.gitignore" | tr -d ' ')"
+if [ "${after_bytes:-0}" -ge "${before_bytes:-0}" ]; then
+  ok ".gitignore not truncated ($before_bytes -> $after_bytes bytes)"
+else
+  bad ".gitignore truncated ($before_bytes -> $after_bytes bytes)"
+fi
+has_line "$T" "node_modules/"
+has_line "$T" "$(printf 'L\xf6sungen/')"
+exactly_once "$T" ".claude/"
+one_block "$T"
+no_untracked_vendored "$T" claude
+
+echo "a non-UTF-8 byte outside the block does not append a second block per install:"
+T="$(new_target invalid-utf8-outside-block)"
+printf 'node_modules/\nL\xf6sungen/\n' > "$T/.gitignore"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "first install exited non-zero"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "second install exited non-zero"
+one_block "$T"
+exactly_once "$T" ".claude/"
+has_line "$T" "node_modules/"
+absent "$T" .gitignore.tmp
+no_untracked_vendored "$T" claude
+
+echo "a block entry containing a literal '|' does not un-ignore a vendored path:"
+T="$(new_target pipe-in-block)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+insert_in_block "$T" 'a|.claude|b'
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "claude install exited non-zero"
+exactly_once "$T" ".claude/"
+has_line "$T" 'a|.claude|b'
+if git -C "$T" check-ignore -q .claude/settings.json; then ok "git still ignores .claude/settings.json"; else bad "git no longer ignores .claude/settings.json"; fi
+one_block "$T"
+
+echo "a leading-whitespace block entry does not shadow the real vendored path:"
+T="$(new_target leading-space-in-block)"
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+insert_in_block "$T" '  .claude/'
+"$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "claude install exited non-zero"
+exactly_once "$T" ".claude/"
+if git -C "$T" check-ignore -q .claude/settings.json; then ok "git ignores .claude/settings.json"; else bad "git does not ignore .claude/settings.json"; fi
+one_block "$T"
+no_untracked_vendored "$T" gemini claude
 
 echo "lite / claude:"
 T="$(new_target lite-claude)"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -111,6 +111,46 @@ for p in "ai-workflow.md" ".ai-policy/" ".githooks/" "CLAUDE.md" ".claude/"; do
   if grep -qxF "$p" "$T/.gitignore"; then ok "still ignored: $p"; else bad "wrongly pruned: $p"; fi
 done
 
+# A removal bullet names a path by name, not by tool. When several tools are
+# installed side by side, a path one tool dropped may still be shipped by
+# another, and pruning it un-ignores that tool's vendored files (#229).
+echo "a removal does not un-ignore a path another installed tool still ships:"
+FAKE_SRC2="$SANDBOX/fake-src-2"
+mkdir -p "$FAKE_SRC2"
+git -C "$ROOT_DIR" archive HEAD | tar -x -C "$FAKE_SRC2"
+mkdir -p "$FAKE_SRC2/legacy-thing"
+echo legacy > "$FAKE_SRC2/legacy-thing/note.md"
+tmp_manifest="$(mktemp)"
+jq '.profiles.full.tools.claude += ["legacy-thing/"]' "$FAKE_SRC2/install-manifest.json" > "$tmp_manifest" \
+  && mv "$tmp_manifest" "$FAKE_SRC2/install-manifest.json"
+set_version "$FAKE_SRC2/ai-workflow.md" 90.0.0
+( cd "$FAKE_SRC2" && git init -q && git config user.email t@t && git config user.name t \
+    && git add -A && git commit -qm init ) >/dev/null 2>&1
+
+T="$(new_target multi-tool-prune)"
+"$INSTALL" --source "$FAKE_SRC2" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "claude install exited non-zero"
+"$INSTALL" --source "$FAKE_SRC2" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "gemini install exited non-zero"
+if grep -qxF "legacy-thing/" "$T/.gitignore"; then ok "legacy-thing/ recorded before update"; else bad "legacy-thing/ not recorded before update"; fi
+
+# The source names the path as removed; the claude tool set still ships it.
+set_version "$FAKE_SRC2/ai-workflow.md" 90.1.0
+tmp_changelog="$(mktemp)"
+{
+  printf '## 90.1.0\n\n### Removed\n\n- `legacy-thing/` no longer shipped for gemini.\n\n'
+  cat "$FAKE_SRC2/CHANGELOG.md"
+} > "$tmp_changelog" && mv "$tmp_changelog" "$FAKE_SRC2/CHANGELOG.md"
+( cd "$FAKE_SRC2" && git add -A && git commit -qm drop ) >/dev/null 2>&1
+
+"$UPDATE" --source "$FAKE_SRC2" --target "$T" --tool gemini --profile full >/dev/null 2>&1 || bad "multi-tool prune update exited non-zero"
+if grep -qxF "legacy-thing/" "$T/.gitignore"; then
+  ok "legacy-thing/ still ignored (the claude set still ships it)"
+else
+  bad "legacy-thing/ pruned from .gitignore though the claude set still ships it"
+fi
+for p in "ai-workflow.md" ".ai-policy/" ".githooks/" "CLAUDE.md" ".claude/" "GEMINI.md" ".gemini/"; do
+  if grep -qxF "$p" "$T/.gitignore"; then ok "still ignored: $p"; else bad "wrongly pruned: $p"; fi
+done
+
 echo "already up-to-date (no-op):"
 T="$(new_target current)"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -72,6 +72,45 @@ done
 present "$T" .claude/skills/my-local-skill/SKILL.md
 present "$T" .claude/skills/aiw-planning/SKILL.md
 
+echo "removed path is pruned from the managed .gitignore block:"
+# Fabricate a source repo carrying an extra top-level product path, install it,
+# then drop that path from the source and name it in a `### Removed` bullet.
+FAKE_SRC="$SANDBOX/fake-src"
+mkdir -p "$FAKE_SRC"
+git -C "$ROOT_DIR" archive HEAD | tar -x -C "$FAKE_SRC"
+mkdir -p "$FAKE_SRC/legacy-thing"
+echo legacy > "$FAKE_SRC/legacy-thing/note.md"
+tmp_manifest="$(mktemp)"
+jq '.profiles.full.shared += ["legacy-thing/"]' "$FAKE_SRC/install-manifest.json" > "$tmp_manifest" \
+  && mv "$tmp_manifest" "$FAKE_SRC/install-manifest.json"
+set_version "$FAKE_SRC/ai-workflow.md" 90.0.0
+( cd "$FAKE_SRC" && git init -q && git config user.email t@t && git config user.name t \
+    && git add -A && git commit -qm init ) >/dev/null 2>&1
+
+T="$(new_target pruned)"
+"$INSTALL" --source "$FAKE_SRC" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "fake-source install exited non-zero"
+if grep -qxF "legacy-thing/" "$T/.gitignore"; then ok "legacy-thing/ recorded in .gitignore before update"; else bad "legacy-thing/ not recorded before update"; fi
+
+# The source drops the path and declares the removal.
+rm -rf "$FAKE_SRC/legacy-thing"
+tmp_manifest="$(mktemp)"
+jq '.profiles.full.shared -= ["legacy-thing/"]' "$FAKE_SRC/install-manifest.json" > "$tmp_manifest" \
+  && mv "$tmp_manifest" "$FAKE_SRC/install-manifest.json"
+set_version "$FAKE_SRC/ai-workflow.md" 90.1.0
+tmp_changelog="$(mktemp)"
+{
+  printf '## 90.1.0\n\n### Removed\n\n- `legacy-thing/` no longer shipped.\n\n'
+  cat "$FAKE_SRC/CHANGELOG.md"
+} > "$tmp_changelog" && mv "$tmp_changelog" "$FAKE_SRC/CHANGELOG.md"
+( cd "$FAKE_SRC" && git add -A && git commit -qm drop ) >/dev/null 2>&1
+
+"$UPDATE" --source "$FAKE_SRC" --target "$T" --tool claude --profile full >/dev/null 2>&1 || bad "prune update exited non-zero"
+absent "$T" legacy-thing
+if grep -qxF "legacy-thing/" "$T/.gitignore"; then bad "legacy-thing/ still in .gitignore after update"; else ok "legacy-thing/ pruned from .gitignore"; fi
+for p in "ai-workflow.md" ".ai-policy/" ".githooks/" "CLAUDE.md" ".claude/"; do
+  if grep -qxF "$p" "$T/.gitignore"; then ok "still ignored: $p"; else bad "wrongly pruned: $p"; fi
+done
+
 echo "already up-to-date (no-op):"
 T="$(new_target current)"
 "$INSTALL" --source "$ROOT_DIR" --target "$T" --tool claude --profile full >/dev/null 2>&1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -94,8 +94,34 @@ fi
 "$SCRIPT_DIR/install.sh" --source "$SOURCE" --target "$TARGET" --tool "$TOOL" --profile "$PROFILE" >/dev/null \
   || { echo "error: re-copy step failed" >&2; exit 1; }
 
+# Drop paths from the installer-managed .gitignore block (the block is a union,
+# so a path that left the product would otherwise linger forever). Nothing
+# outside the managed block is touched.
+prune_gitignore_block() {
+  local gi="$TARGET/.gitignore" joined="$1"
+  [ -f "$gi" ] || return 0
+  [ -n "$joined" ] || return 0
+  local begin="# >>> ai-workflow (vendored, managed by installer) >>>"
+  local end="# <<< ai-workflow <<<"
+  awk -v b="$begin" -v e="$end" -v paths="$joined" '
+    BEGIN {
+      n = split(paths, parr, "|")
+      for (i = 1; i <= n; i++) { k = parr[i]; sub(/\/+$/, "", k); if (k != "") drop[k] = 1 }
+    }
+    $0==b { inblock=1; print; next }
+    $0==e { inblock=0; print; next }
+    inblock==1 {
+      key = $0
+      sub(/^[ \t]+/, "", key); sub(/[ \t]+$/, "", key); sub(/\/+$/, "", key)
+      if (key in drop) next
+    }
+    { print }
+  ' "$gi" > "$gi.tmp" && mv "$gi.tmp" "$gi"
+}
+
 # --- removal reconciliation (full profile; lite is a single file with nothing to reconcile) ---
 removed_count=0
+prune_keys=""
 if [ "$PROFILE" = "full" ]; then
   current_product="$(mktemp)"
   trap 'rm -f "$current_product"' EXIT
@@ -124,6 +150,7 @@ if [ "$PROFILE" = "full" ]; then
     [ -z "${ver:-}" ] && continue
     in_range "$ver" "$installed_version" "$source_version" || continue
     rp_stripped="${rp%/}"
+    prune_keys="$prune_keys$rp_stripped|"
     case "$rp" in
       */)  # directory removal: delete target files under it that are not current product
         if [ -d "$TARGET/$rp_stripped" ]; then
@@ -145,6 +172,23 @@ if [ "$PROFILE" = "full" ]; then
   done <<EOF
 $removed_paths
 EOF
+
+  # Prune the removed paths from the managed .gitignore block, but never a path
+  # the current product still ships.
+  keep_keys="|"
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    keep_keys="$keep_keys${p%/}|"
+  done < <(jq -r --arg t "$TOOL" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$MANIFEST")
+  drop_keys=""
+  while IFS= read -r k; do
+    [ -z "$k" ] && continue
+    case "$keep_keys" in *"|$k|"*) continue ;; esac
+    drop_keys="$drop_keys$k|"
+  done <<EOF
+$(printf '%s' "$prune_keys" | tr '|' '\n')
+EOF
+  prune_gitignore_block "$drop_keys"
 fi
 
 echo "Update complete: target now at $source_version (profile: $PROFILE, tool: $TOOL); $removed_count file(s) removed."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -128,7 +128,10 @@ if [ "$PROFILE" = "full" ]; then
   while IFS= read -r p; do
     [ -z "$p" ] && continue
     git -C "$SOURCE" ls-files -- "${p%/}" >> "$current_product"
-  done < <(jq -r --arg t "$TOOL" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$MANIFEST")
+    # Spans EVERY tool, not just the one being updated. A removal bullet names a
+    # path, not a tool, so scoping this to $TOOL deletes from disk a file another
+    # installed tool still ships (#229).
+  done < <(jq -r '[.profiles.full.shared[], (.profiles.full.tools[] | .[])] | unique | .[]' "$MANIFEST")
 
   in_range() { # version, installed, source : installed < version <= source
     ver_lt "$2" "$1" && ver_le "$1" "$3"
@@ -174,20 +177,22 @@ $removed_paths
 EOF
 
   # Prune the removed paths from the managed .gitignore block, but never a path
-  # the current product still ships.
-  keep_keys="|"
-  while IFS= read -r p; do
-    [ -z "$p" ] && continue
-    keep_keys="$keep_keys${p%/}|"
-  done < <(jq -r --arg t "$TOOL" '[.profiles.full.shared[], .profiles.full.tools[$t][]] | .[]' "$MANIFEST")
+  # the current product still ships. The keep set spans EVERY tool, not just the
+  # one being updated: a removal bullet names a path, not a tool, and several
+  # tools can be installed in one repo, so pruning a path another installed tool
+  # still ships would un-ignore that tool's vendored files (#229).
+  keep_file="$(mktemp)"
+  jq -r '[.profiles.full.shared[], (.profiles.full.tools[] | .[])] | unique | .[]' "$MANIFEST" \
+    | sed 's#/*$##' > "$keep_file"
   drop_keys=""
   while IFS= read -r k; do
     [ -z "$k" ] && continue
-    case "$keep_keys" in *"|$k|"*) continue ;; esac
+    LC_ALL=C grep -Fxq -- "$k" "$keep_file" && continue
     drop_keys="$drop_keys$k|"
   done <<EOF
 $(printf '%s' "$prune_keys" | tr '|' '\n')
 EOF
+  rm -f "$keep_file"
   prune_gitignore_block "$drop_keys"
 fi
 


### PR DESCRIPTION
Closes #216.

## The change

`write_gitignore_block()` rebuilt the installer-managed block from only the current run's paths. Because the documented multi-tool procedure is one installer run per tool, which `scripts/update.sh` requires by refusing to auto-detect an ambiguous target, so each run undid the one before it. The block is now a **union**: entries already in it are kept in order, and this run's paths are appended if absent.

`scripts/update.sh` gains a prune step for paths named in `### Removed` changelog bullets, because a union would otherwise keep a departed path ignored forever. It never prunes a path the current product still ships.

## Decisions taken

**The file-wide deletion from #166 is confined to the first install rather than removed.** #166 and #216 pull in opposite directions on the same line of code: #166 wants a pre-existing manual copy of a vendored path folded into the managed block so it is not listed twice, and #216 wants entries a human maintains outside the block left alone. The first install is the only run with no managed block to date the file against, so it is the only moment the installer genuinely cannot tell a deliberate hand-maintained entry from the residue of an earlier manual install. It folds there and never again. `scripts/test-install.sh` pins both sides, so this is a chosen boundary rather than an accident.

The alternative, never touching lines outside the block, reopens #166, and would break its regression test, which asserts that a human's `.ai-policy` (no trailing slash) is normalised to the canonical `.ai-policy/`. That is a real part of what #166 bought.

**Version bumped to 3.25.1** even though `scripts/` is factory-only and is not in `design/decisions/maintenance.md`'s list of files requiring a bump. The installer decides which governance files exist and which are ignored in a target, so its behaviour reaches agent behaviour there, and there is precedent: the `scripts/update.sh` reconciliation change was changelogged under [#165].

## Verification

**What could plausibly have broken.** The block-rewriting function is the only writer of the target's `.gitignore`, so everything downstream of it is at risk: idempotency (a re-run duplicating lines or the marker pair), the #166 normalisation, hand-maintained content elsewhere in the file, the lite profile which passes a different and much shorter path list, and `update.sh`, which calls the installer before reconciling removals and could now leave a departed path ignored forever.

**Fix modality requires a check that failed before and passes after.** The new multi-tool tests were written first and run against unfixed `HEAD`: **11 failed**. They were exactly the reported bug: `GEMINI.md`, `.gemini/` and `.agents/skills/` missing after the second install, `git status` reporting them untracked, and the hand-maintained `.agents/skills/` deleted. After the fix: **0 failed, 89 assertions passing** in `test-install.sh` and 37 in `test-update.sh`.

The tests assert on `git status --porcelain` directly rather than on a proxy, because the hazard the issue names is `git add -A`, not the file's text.

**Independent clean-context verification.** A sub-agent that did not write the change, and was told to assume it was wrong, ran the installer against throwaway repositories: three-tool and four-tool sequences, reversed install order, repeat installs, lite/full mixes, and an adversarial pass over CRLF line endings, a missing trailing newline, an absent `.gitignore`, whitespace-indented entries, trailing-slash mismatches, and a begin marker with no end marker. **All seven scenarios passed**, `.vscode/` and `GEMINI.md` included, and no case produced an untracked vendored path or lost unrelated content.

That verifier independently rediscovered the first-install fold described above, having never been told about it, which is the corroboration that it is a real boundary rather than a rationalisation.

Evidence level: end-to-end runs of the real installer against real git repositories, which is the system the issue is about.

**Coverage gap that let this ship.** Both sandbox tests only ever installed a single tool, so the multi-tool path, the only path where the bug exists, had no coverage for two months. That is now the first thing `test-install.sh` exercises.

## What was not checked

- **`update.sh` on a multi-tool target still errors** and demands `--tool`, and updating with one tool's name refreshes only that tool's files. Installing several tools is now safe; updating them together is not. Untouched here, and the natural follow-up to this issue. Tracked by #233.
- **The managed block moves to the end of the file** on every install, so a hand-maintained section that sat after it ends up before it. Content is preserved and ignore behaviour is unchanged; only the order differs. Not fixed, because rewriting the block in place would mean tracking its original offset for no functional gain.
- **`update.sh`'s `keep_keys` guard is built from the current tool's manifest paths only.** A path still shipped for a *different* tool but named in a `### Removed` bullet would be pruned from the block. Not reachable today, since a `### Removed` bullet means the path left the product entirely. It becomes reachable if a bullet is ever used to mean "removed for this tool only", which the changelog convention does not currently allow.
- **The four tools' hook wiring is asserted as configuration present, never as interception observed** for Codex, Gemini and Copilot. Pre-existing, shared with every other hook here, and untouched by this change.

## Follow-up filed, not acted on

`scripts/update.sh` refuses to run against a multi-tool target. Now that a multi-tool target is a supported end state rather than a broken one, that refusal is the remaining half of the problem. Filed as #233.


---

# After adversarial review

A hostile reviewer was asked to refute this, and was told the earlier clean-context pass had probably missed something. **It had.** Four defects, three of them breaking the claim.

## What it found

**1. Destructive: a non-UTF-8 byte in a block line destroyed `.gitignore`.** The `sed` normalising keys failed with "illegal byte sequence"; because the result was a bare assignment under `set -eu`, the installer aborted. The abort window opened *after* the first awk pass had already stripped the old block, so the file was left truncated (181 bytes to 25, and 0 bytes when it held only the block) with every vendored path untracked and the target half-installed. Reachable without hand-editing: a Latin-1 path such as `Lösungen/` is ordinary in a real repository.

**2. Silent un-ignore: a literal `|` in any block line.** Membership used a `|`-delimited string, so a line reading `a|.claude|b` made the test report `.claude` as already present. `.claude/` was never emitted and stopped being ignored. Exit code 0, no warning.

**3. Silent un-ignore plus unbounded growth: a non-UTF-8 byte anywhere in the file.** BSD `grep -qxF` returns 1 on a file containing an invalid byte even when the marker line is present, so `had_block` was 0, the first-install branch was taken, and a second managed block was appended. One more per install, forever.

**4. Leading whitespace.** The key was built with whitespace stripped but the line re-emitted verbatim, so a block line `  .claude/` (leading spaces are significant in `.gitignore`) suppressed the real `.claude/` while git ignored nothing.

Plus the `update.sh` tool-scoping limitation this pull request had disclosed as "not reachable today". The reviewer reached it: a path shipped for two tools and named in a `### Removed` bullet is pruned while another installed tool still ships it.

## What changed

**The union is now a single `awk` pass under `LC_ALL=C`, writing the whole file to a temp and moving it only on success.** That is three fixes in one shape rather than three patches:

- Atomicity removes the truncation window entirely. If awk fails, `mv` never runs and the original file is untouched.
- `LC_ALL=C` makes bytes bytes, so an invalid sequence is no longer an error in `sed` or a false negative in `grep`.
- **The run's paths reach awk through a file, not a delimited string.** There is no bash string-membership test left in the function, which removes the delimiter class of defect rather than escaping one character. `had_block` is computed inside the same pass, so the separate `grep` that defect 3 exploited is gone.
- Kept block entries are emitted trimmed, closing defect 4. Trailing slashes are deliberately *not* stripped on emit, because that would rewrite an existing `.claude/` entry to `.claude` and regress #166's normalisation.

**`update.sh` gains the same fix twice more.** Beyond the `.gitignore` prune the reviewer reported, the *current-product* set had the identical bug, and its consequence was worse: a file still shipped for another installed tool but named in a removal bullet was **deleted from disk**. Both sets now span every tool, because a removal bullet names a path and not a tool. The remaining `|`-delimited membership is gone too; those keys come from CHANGELOG text, which carries no guarantee about the delimiter.

## Evidence

| | before | after |
|---|---|---|
| `test-install.sh` | 89 pass | **108 pass, 0 fail** |
| `test-update.sh` | 37 pass | **46 pass, 0 fail** |

Every new test was confirmed red first: **14 failures** in `test-install.sh` and **1** in `test-update.sh` against the unfixed code, with the D1 case showing the exact reported truncation. All 89 and 37 pre-existing assertions still pass, including #166's first-install fold, hand-maintained lines surviving, idempotency, lite, and the three-tool union.

I re-ran the reviewer's own four reproductions independently against the fixed code rather than taking the report on trust:

```
D1 non-UTF-8 inside block : rc=0, 156 -> 175 bytes (not truncated), 0 untracked
D2 literal | in block     : .claude/ present exactly once, 0 untracked
D3 non-UTF-8 outside block: exactly 1 managed block, 0 untracked
D5 leading whitespace     : 0 untracked
```

## Still not checked

- **`update.sh` on a multi-tool target still errors** and demands `--tool`. Tracked by #233.
- **The managed block still moves to the end of the file** on every install. Content and ignore behaviour preserved; only order changes.
- **Non-UTF-8 handling was tested on macOS with BSD tools only.** `LC_ALL=C` is the portable fix and the tests now assert it, but GNU coreutils were not exercised; there is no CI here to do it.
- **The four tools' hook wiring** remains asserted as configuration present rather than interception observed for Codex, Gemini and Copilot. Pre-existing.
