### PR TITLE
Check the agent-facing prose for what a script can judge

### DIFF
--- a/project-context.md
+++ b/project-context.md
@@ -1,6 +1,6 @@
 # Project Context
 
-Version: 1.22.0
+Version: 1.23.0
 
 ## Product Summary
 - This repository provides project-agnostic governance files for AI-assisted coding, enabling a human to maintain consistent guardrails for an AI coding agent across repositories.
@@ -34,6 +34,7 @@ Version: 1.22.0
 - Provides agent skills for session preflight, code-aware planning, ground-truth sourcing, failure analysis, GitHub handoff, issue creation, test construction, verification, performance profiling, security testing, and project-context management, located in two directories: `.agents/skills/` (cross-platform, for VS Code Copilot, Gemini CLI, Codex) and `.claude/skills/` (Claude Code).
 - Both skill directories contain the same skills.
 - Provides agent instruction entry points for VS Code Copilot (`.github/copilot-instructions.md`), Claude Code (`CLAUDE.md`), Codex (`AGENTS.md`), and Gemini CLI (`GEMINI.md`).
+- Checks the agent-facing prose for structural coherence (`scripts/check-prose-integrity.sh`), wired into validation so it runs without a human choosing to run it.
 - Provides an agent-driven installer (`scripts/install.sh`) and updater (`scripts/update.sh`) that copy the product file set for a chosen tool and profile into a target repository, vendor them in the target's `.gitignore`, and reconcile removals on update from `CHANGELOG.md`.
 - Declares the product/factory boundary in `install-manifest.json`, validated by `scripts/check-manifest.sh` and printed by `make classify`.
 - Records observed AI agent failure patterns (`observations/observed-ai-failings.md`) to inform workflow rule changes.
@@ -118,6 +119,7 @@ Version: 1.22.0
 - `scripts/classify.sh`: prints the product/factory classification read from `install-manifest.json`.
 - `scripts/check-manifest.sh`: validates that the manifest classifies every git-tracked file exactly once.
 - `scripts/check-changelog-removals.sh`: enforces the leading-path convention on `### Removed` bullets (factory-only).
+- `scripts/check-prose-integrity.sh`: checks the invariants of the agent-facing prose that a script can judge without an editorial call (skill-tree parity, frontmatter, reference resolution, version headers, size budget, entry-point parity), and prints what it cannot cover; `scripts/test-prose-integrity.sh` asserts each check fires.
 - `scripts/test-install.sh`, `scripts/test-update.sh`, `scripts/test-changelog-removals.sh`: sandbox tests for the installer, updater, and changelog convention.
 - `scripts/repo-validation.sh`: this repo's repo-specific validation; runs shell and Python checks on `observation/`, the parser regression test, JSONL fixture validity, the manifest integrity check, and the install, update, and changelog-removals sandbox tests.
 
@@ -125,6 +127,7 @@ Version: 1.22.0
 - Policy-layer validation (`./.ai-policy/scripts/project-validation.sh`, portable across repos) runs `bash -n` on `.ai-policy/scripts/`, `.ai-policy/hooks/`, and `.githooks/`, then the enforcement test scripts whose matching agent entry point is installed.
 - Enforcement test scripts are gated as follows: `test-claude-code-enforcement.sh` requires `.claude/`; `test-codex-enforcement.sh` requires `.codex/`; `test-gemini-enforcement.sh` requires `.gemini/`; `test-vscode-copilot-enforcement.sh` requires `.github/hooks/`; `test-changelog-hook.sh`, `test-pre-push-hook.sh`, `test-project-validation.sh`, `test-context-drift-hook.sh`, `test-pr-merge-hook.sh`, `test-push-refs.sh`, `test-pr-approve-hook.sh`, `test-pr-verification-hook.sh`, and `test-validation-state.sh` always run.
 - When `scripts/repo-validation.sh` is absent, `project-validation.sh` warns loudly that only the policy layer ran rather than skipping silently, so a fresh install cannot present a green-but-empty gate; `test-project-validation.sh` regression-tests both the absent (warns, still passes) and present (runs it, no warning) branches.
+- Prose integrity (`scripts/check-prose-integrity.sh`) runs inside repo-specific validation, so a change to the agent-facing rules is checked by something other than its author's reading. It is structural only: it cannot tell whether two passages contradict each other.
 - Repo-specific validation in `scripts/repo-validation.sh` runs `bash -n` on `observation/*.sh`, `py_compile` on `observation/*.py`, the `observation/test_parse.py` parser regression test, a JSONL validity check on the fixture, the manifest integrity check, and the installer, updater, changelog-removals, and observation install/uninstall sandbox tests.
 - No unit test framework exists; there are no automated tests for documentation content or for the generated dashboard's rendering.
 - Manual verification is the primary check for documentation changes and for the dashboard's visual behaviour.

--- a/project-context.md
+++ b/project-context.md
@@ -119,7 +119,7 @@ Version: 1.23.0
 - `scripts/classify.sh`: prints the product/factory classification read from `install-manifest.json`.
 - `scripts/check-manifest.sh`: validates that the manifest classifies every git-tracked file exactly once.
 - `scripts/check-changelog-removals.sh`: enforces the leading-path convention on `### Removed` bullets (factory-only).
-- `scripts/check-prose-integrity.sh`: checks the invariants of the agent-facing prose that a script can judge without an editorial call (skill-tree parity, frontmatter, reference resolution, version headers, size budget, entry-point parity), and prints what it cannot cover; `scripts/test-prose-integrity.sh` asserts each check fires.
+- `scripts/check-prose-integrity.sh`: checks the invariants of the agent-facing prose that a script can judge without an editorial call (skill-tree parity, frontmatter, the documented skill set, version headers, size budget, entry-point parity), reports a single summary line unless something fails or `--verbose` is passed, and prints what it cannot cover; `scripts/test-prose-integrity.sh` asserts each check fires.
 - `scripts/test-install.sh`, `scripts/test-update.sh`, `scripts/test-changelog-removals.sh`: sandbox tests for the installer, updater, and changelog convention.
 - `scripts/repo-validation.sh`: this repo's repo-specific validation; runs shell and Python checks on `observation/`, the parser regression test, JSONL fixture validity, the manifest integrity check, and the install, update, and changelog-removals sandbox tests.
 

--- a/scripts/check-prose-integrity.sh
+++ b/scripts/check-prose-integrity.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Checks the invariants of this repository's agent-facing prose that a script can
+# judge without making an editorial call. It does not read for meaning: see the
+# "cannot check" block it prints, and issue #227 for why that boundary is drawn
+# where it is. A gate that fires on the normal path gets routed around, so every
+# check here is one whose failure is unambiguously a defect.
+set -uo pipefail
+
+ROOT="${PROSE_CHECK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$ROOT"
+
+fails=0
+ok()   { echo "  PASS: $1"; }
+bad()  { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+
+AGENT_DIR=".agents/skills"
+CLAUDE_DIR=".claude/skills"
+ENTRY_POINTS=("CLAUDE.md" "AGENTS.md" "GEMINI.md" ".github/copilot-instructions.md")
+PROSE=("ai-workflow.md" "project-context.md" "${ENTRY_POINTS[@]}")
+
+echo "Skill mirror parity:"
+a_list="$(ls "$AGENT_DIR" 2>/dev/null | sort)"
+c_list="$(ls "$CLAUDE_DIR" 2>/dev/null | sort)"
+if [ "$a_list" = "$c_list" ]; then
+  ok "both skill trees define the same skills"
+else
+  bad "skill trees differ: $(diff <(echo "$a_list") <(echo "$c_list") | tr '\n' ' ')"
+fi
+
+for s in $c_list; do
+  [ -d "$AGENT_DIR/$s" ] || continue
+  if diff -q "$AGENT_DIR/$s/SKILL.md" "$CLAUDE_DIR/$s/SKILL.md" >/dev/null 2>&1; then
+    ok "$s identical across both trees"
+  else
+    bad "$s differs between $AGENT_DIR and $CLAUDE_DIR (agents on different tools would read different rules)"
+  fi
+done
+
+echo "Skill frontmatter:"
+for s in $c_list; do
+  f="$CLAUDE_DIR/$s/SKILL.md"
+  head -1 "$f" | grep -qx -- '---' || { bad "$s: no YAML frontmatter opening"; continue; }
+  name="$(awk '/^---$/{n++; next} n==1 && /^name:/{sub(/^name:[[:space:]]*/,""); print; exit}' "$f")"
+  desc="$(awk '/^---$/{n++; next} n==1 && /^description:/{sub(/^description:[[:space:]]*/,""); print; exit}' "$f")"
+  [ "$name" = "$s" ] || bad "$s: frontmatter name '$name' does not match its directory"
+  [ -n "$desc" ] || bad "$s: frontmatter description is empty (nothing would load this skill)"
+  [ "$name" = "$s" ] && [ -n "$desc" ] && ok "$s: name matches directory, description present"
+done
+
+echo "Skill references resolve:"
+# A token is a reference only when it is not a path segment: `aiw-observation`
+# inside ~/.claude/aiw-observation/sessions.jsonl names a directory, not a skill.
+ref_fails=0
+for f in "${PROSE[@]}" "$CLAUDE_DIR"/*/SKILL.md; do
+  [ -f "$f" ] || continue
+  while read -r ref; do
+    [ -z "$ref" ] && continue
+    [ -d "$CLAUDE_DIR/$ref" ] || { bad "$f references '$ref', which is not a skill in $CLAUDE_DIR"; ref_fails=$((ref_fails + 1)); }
+  done < <(
+    grep -oE '[^[:space:]]*aiw-[a-z]+(-[a-z]+)*[^[:space:]]*' "$f" \
+      | grep -v '/' \
+      | grep -oE 'aiw-[a-z]+(-[a-z]+)*' \
+      | sort -u
+  )
+done
+[ "$ref_fails" -eq 0 ] && ok "every aiw-* reference in prose and skills resolves to a real skill"
+
+echo "Documented skill set matches the tree:"
+doc_fails=0
+for s in $c_list; do
+  grep -qF "$s" project-context.md || { bad "skill '$s' exists but project-context.md never names it"; doc_fails=$((doc_fails + 1)); }
+done
+[ "$doc_fails" -eq 0 ] && ok "project-context.md names every skill in the tree"
+
+echo "Version headers:"
+# Equality between the lite condensation and the canonical version is enforced
+# in scripts/repo-validation.sh, which runs before this and exits on drift.
+for f in ai-workflow.md project-context.md lite-monolithic/ai-workflow.md; do
+  if grep -qE '^Version:[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+' "$f"; then
+    ok "$f carries a Version header"
+  else
+    bad "$f has no Version header, so no session can be tied to a file state"
+  fi
+done
+
+echo "Declared size budget:"
+pc_lines="$(wc -l < project-context.md | tr -d ' ')"
+if [ "$pc_lines" -le 300 ]; then
+  ok "project-context.md is $pc_lines lines (budget 300)"
+else
+  bad "project-context.md is $pc_lines lines, over its declared 300-line budget"
+fi
+
+echo "Entry-point parity:"
+for e in "${ENTRY_POINTS[@]}"; do
+  [ -f "$e" ] || { bad "$e is missing"; continue; }
+  miss=""
+  grep -qF 'ai-workflow.md' "$e"     || miss="$miss ai-workflow.md"
+  grep -qF 'project-context.md' "$e" || miss="$miss project-context.md"
+  [ -z "$miss" ] && ok "$e points at the governance files" || bad "$e does not reference:$miss"
+done
+
+cat <<'LIMITS'
+
+What this cannot check:
+  - Whether two passages contradict each other. Meaning is not mechanically
+    decidable, and the contradiction that prompted this check (#225, two
+    adjacent paragraphs of aiw-verification) would still pass here.
+  - Whether a skill's description matches what its body actually covers.
+  - Whether a rule is good, needed, or reachable by the agent that must follow it.
+  A pass means the prose is structurally coherent, never that it is correct.
+LIMITS
+
+if [ "$fails" -gt 0 ]; then
+  echo "prose integrity: $fails check(s) failed" >&2
+  exit 1
+fi
+echo "prose integrity: all checks passed"

--- a/scripts/check-prose-integrity.sh
+++ b/scripts/check-prose-integrity.sh
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
 # Checks the invariants of this repository's agent-facing prose that a script can
 # judge without making an editorial call. It does not read for meaning: see the
-# "cannot check" block it prints, and issue #227 for why that boundary is drawn
-# where it is. A gate that fires on the normal path gets routed around, so every
-# check here is one whose failure is unambiguously a defect.
+# "cannot check" block it prints on failure, and issue #227 for why that boundary
+# is drawn where it is. A gate that fires on the normal path gets routed around,
+# so every check here is one whose failure is unambiguously a defect.
+#
+# It runs on every commit and every push, so a clean tree prints one summary line
+# and nothing else. Pass --verbose (or set PROSE_CHECK_VERBOSE=1) for the
+# per-check detail and the limits block.
 set -uo pipefail
+
+VERBOSE="${PROSE_CHECK_VERBOSE:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    -v|--verbose) VERBOSE=1 ;;
+  esac
+done
 
 ROOT="${PROSE_CHECK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT"
 
 fails=0
-ok()   { echo "  PASS: $1"; }
+passes=0
+ok()   { passes=$((passes + 1)); [ "$VERBOSE" = 1 ] && echo "  PASS: $1"; return 0; }
 bad()  { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+head_() { [ "$VERBOSE" = 1 ] && echo "$1"; return 0; }
 
 AGENT_DIR=".agents/skills"
 CLAUDE_DIR=".claude/skills"
 ENTRY_POINTS=("CLAUDE.md" "AGENTS.md" "GEMINI.md" ".github/copilot-instructions.md")
-PROSE=("ai-workflow.md" "project-context.md" "${ENTRY_POINTS[@]}")
 
-echo "Skill mirror parity:"
+head_ "Skill mirror parity:"
 a_list="$(ls "$AGENT_DIR" 2>/dev/null | sort)"
 c_list="$(ls "$CLAUDE_DIR" 2>/dev/null | sort)"
 if [ "$a_list" = "$c_list" ]; then
@@ -36,43 +48,59 @@ for s in $c_list; do
   fi
 done
 
-echo "Skill frontmatter:"
+head_ "Skill frontmatter:"
+# One awk per skill, not four processes: this runs on every commit, and the
+# per-skill loops are where the wall clock goes.
 for s in $c_list; do
   f="$CLAUDE_DIR/$s/SKILL.md"
-  head -1 "$f" | grep -qx -- '---' || { bad "$s: no YAML frontmatter opening"; continue; }
-  name="$(awk '/^---$/{n++; next} n==1 && /^name:/{sub(/^name:[[:space:]]*/,""); print; exit}' "$f")"
-  desc="$(awk '/^---$/{n++; next} n==1 && /^description:/{sub(/^description:[[:space:]]*/,""); print; exit}' "$f")"
+  info="$(awk '
+    NR==1 && $0 != "---" { print "!"; exit }
+    /^---$/ { n++; if (n==2) exit; next }
+    n==1 && /^name:/ && !gotn { sub(/^name:[[:space:]]*/,""); print "N" $0; gotn=1; next }
+    n==1 && /^description:/ && !gotd { sub(/^description:[[:space:]]*/,""); print "D" $0; gotd=1; next }
+  ' "$f")"
+  name=""; desc=""; nofm=0
+  while IFS= read -r line; do
+    case "$line" in
+      "!") nofm=1 ;;
+      N*)  name="${line#N}" ;;
+      D*)  desc="${line#D}" ;;
+    esac
+  done <<< "$info"
+  [ "$nofm" -eq 1 ] && { bad "$s: no YAML frontmatter opening"; continue; }
+  # A description of whitespace, or of quotes wrapping whitespace, loads nothing.
+  # Trim outside-in: space, then one matching quote pair, then space again.
+  desc="${desc#"${desc%%[![:space:]]*}"}"; desc="${desc%"${desc##*[![:space:]]}"}"
+  case "$desc" in
+    \"*\") desc="${desc#\"}"; desc="${desc%\"}" ;;
+    \'*\') desc="${desc#\'}"; desc="${desc%\'}" ;;
+  esac
+  desc="${desc#"${desc%%[![:space:]]*}"}"; desc="${desc%"${desc##*[![:space:]]}"}"
   [ "$name" = "$s" ] || bad "$s: frontmatter name '$name' does not match its directory"
   [ -n "$desc" ] || bad "$s: frontmatter description is empty (nothing would load this skill)"
   [ "$name" = "$s" ] && [ -n "$desc" ] && ok "$s: name matches directory, description present"
 done
 
-echo "Skill references resolve:"
-# A token is a reference only when it is not a path segment: `aiw-observation`
-# inside ~/.claude/aiw-observation/sessions.jsonl names a directory, not a skill.
-ref_fails=0
-for f in "${PROSE[@]}" "$CLAUDE_DIR"/*/SKILL.md; do
-  [ -f "$f" ] || continue
-  while read -r ref; do
-    [ -z "$ref" ] && continue
-    [ -d "$CLAUDE_DIR/$ref" ] || { bad "$f references '$ref', which is not a skill in $CLAUDE_DIR"; ref_fails=$((ref_fails + 1)); }
-  done < <(
-    grep -oE '[^[:space:]]*aiw-[a-z]+(-[a-z]+)*[^[:space:]]*' "$f" \
-      | grep -v '/' \
-      | grep -oE 'aiw-[a-z]+(-[a-z]+)*' \
-      | sort -u
-  )
-done
-[ "$ref_fails" -eq 0 ] && ok "every aiw-* reference in prose and skills resolves to a real skill"
+# There is deliberately no "every aiw-* token resolves to a real skill" check.
+# Over free prose a reference cannot be told apart from a placeholder in a
+# template (aiw-prompt-smith authors skills, so its SKILL.md carries
+# `name: aiw-your-skill`), from an illustrative example, from a compound built on
+# a skill name, or from a project noun that is not a skill at all. Every one of
+# those blocked a legitimate commit. A gate that fires on the normal path gets
+# routed around, which costs more than the dangling reference it would catch.
 
-echo "Documented skill set matches the tree:"
+head_ "Documented skill set matches the tree:"
 doc_fails=0
+pc="$(<project-context.md)"
 for s in $c_list; do
-  grep -qF "$s" project-context.md || { bad "skill '$s' exists but project-context.md never names it"; doc_fails=$((doc_fails + 1)); }
+  # Word boundary, hyphen included: `aiw-testing` must not satisfy `aiw-test`.
+  # Newline is outside the boundary class, so it separates tokens like any space.
+  [[ $pc =~ (^|[^A-Za-z0-9_-])${s}([^A-Za-z0-9_-]|$) ]] \
+    || { bad "skill '$s' exists but project-context.md never names it"; doc_fails=$((doc_fails + 1)); }
 done
 [ "$doc_fails" -eq 0 ] && ok "project-context.md names every skill in the tree"
 
-echo "Version headers:"
+head_ "Version headers:"
 # Equality between the lite condensation and the canonical version is enforced
 # in scripts/repo-validation.sh, which runs before this and exits on drift.
 for f in ai-workflow.md project-context.md lite-monolithic/ai-workflow.md; do
@@ -83,7 +111,7 @@ for f in ai-workflow.md project-context.md lite-monolithic/ai-workflow.md; do
   fi
 done
 
-echo "Declared size budget:"
+head_ "Declared size budget:"
 pc_lines="$(wc -l < project-context.md | tr -d ' ')"
 if [ "$pc_lines" -le 300 ]; then
   ok "project-context.md is $pc_lines lines (budget 300)"
@@ -91,16 +119,20 @@ else
   bad "project-context.md is $pc_lines lines, over its declared 300-line budget"
 fi
 
-echo "Entry-point parity:"
+head_ "Entry-point parity:"
 for e in "${ENTRY_POINTS[@]}"; do
   [ -f "$e" ] || { bad "$e is missing"; continue; }
-  miss=""
-  grep -qF 'ai-workflow.md' "$e"     || miss="$miss ai-workflow.md"
-  grep -qF 'project-context.md' "$e" || miss="$miss project-context.md"
+  body="$(<"$e")"; miss=""
+  [[ $body == *ai-workflow.md* ]]     || miss="$miss ai-workflow.md"
+  [[ $body == *project-context.md* ]] || miss="$miss project-context.md"
   [ -z "$miss" ] && ok "$e points at the governance files" || bad "$e does not reference:$miss"
 done
 
-cat <<'LIMITS'
+# The limits block exists so a pass is not over-read. A silent pass says nothing
+# to over-read, so it prints only when there is a failure on screen, or when the
+# reader asked for detail.
+if [ "$fails" -gt 0 ] || [ "$VERBOSE" = 1 ]; then
+  cat <<'LIMITS'
 
 What this cannot check:
   - Whether two passages contradict each other. Meaning is not mechanically
@@ -110,9 +142,10 @@ What this cannot check:
   - Whether a rule is good, needed, or reachable by the agent that must follow it.
   A pass means the prose is structurally coherent, never that it is correct.
 LIMITS
+fi
 
 if [ "$fails" -gt 0 ]; then
   echo "prose integrity: $fails check(s) failed" >&2
   exit 1
 fi
-echo "prose integrity: all checks passed"
+echo "prose integrity: $passes checks passed"

--- a/scripts/repo-validation.sh
+++ b/scripts/repo-validation.sh
@@ -47,6 +47,17 @@ if [ -x ./scripts/check-manifest.sh ]; then
   ./scripts/check-manifest.sh
 fi
 
+# --- prose integrity: the agent-facing rules must stay structurally coherent ---
+# Changes to this repository's prose have no check behind them but their author's
+# own reading (#227). This checks only the invariants a script can judge without
+# an editorial call; it prints what it cannot cover, and cannot read for meaning.
+if [ -x ./scripts/check-prose-integrity.sh ]; then
+  ./scripts/check-prose-integrity.sh
+fi
+if [ -x ./scripts/test-prose-integrity.sh ]; then
+  ./scripts/test-prose-integrity.sh
+fi
+
 # --- install: sandbox test of the installer against throwaway target repos ---
 if [ -x ./scripts/test-install.sh ]; then
   ./scripts/test-install.sh

--- a/scripts/test-prose-integrity.sh
+++ b/scripts/test-prose-integrity.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Asserts check-prose-integrity.sh fires on each defect it claims to catch, and
-# stays silent on the normal path. A checker that never fails is a green bar.
+# stays silent on the normal path. A checker that never fails is a green bar; a
+# checker that prints 50 lines on every commit gets ignored, so the silence is
+# asserted here too, not just claimed in the prose.
 set -uo pipefail
 
 ROOT="${PROSE_TEST_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
@@ -12,24 +14,30 @@ pass=0; fail=0
 ok()  { echo "  PASS: $1"; pass=$((pass + 1)); }
 bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
 
-# A fresh copy of only the paths the checker reads.
-fixture() {
-  local d="$TMP/$1"; rm -rf "$d"; mkdir -p "$d/.github" "$d/lite-monolithic"
-  cp -R "$ROOT/.agents" "$ROOT/.claude" "$d/" 2>/dev/null
-  # keep only the skills; settings and caches are not read by the checker
-  find "$d/.claude" -mindepth 1 -maxdepth 1 ! -name skills -exec rm -rf {} + 2>/dev/null
-  find "$d/.agents" -mindepth 1 -maxdepth 1 ! -name skills -exec rm -rf {} + 2>/dev/null
-  cp "$ROOT/ai-workflow.md" "$ROOT/project-context.md" "$ROOT/CLAUDE.md" \
-     "$ROOT/AGENTS.md" "$ROOT/GEMINI.md" "$d/"
-  cp "$ROOT/lite-monolithic/ai-workflow.md" "$d/lite-monolithic/"
-  cp "$ROOT/.github/copilot-instructions.md" "$d/.github/"
-  for required in ai-workflow.md project-context.md CLAUDE.md AGENTS.md GEMINI.md \
-                  lite-monolithic/ai-workflow.md .github/copilot-instructions.md \
-                  .claude/skills/aiw-init/SKILL.md .agents/skills/aiw-init/SKILL.md; do
-    [ -e "$d/$required" ] || { echo "fixture $1 is missing $required (ROOT=$ROOT)" >&2; exit 2; }
-  done
-  echo "$d"
-}
+# Portable in-place edit. GNU and BSD sed disagree about `sed -i`, so never use it.
+edit() { local f="$1" e="$2"; sed "$e" "$f" > "$f.edit" && mv "$f.edit" "$f"; }
+# Drop every line matching a pattern.
+drop() { local f="$1" p="$2"; grep -v "$p" "$f" > "$f.edit"; mv "$f.edit" "$f"; }
+
+# One pristine copy of exactly the paths the checker reads, built once. Each case
+# copies from this rather than re-walking the repository, so the suite spends its
+# time running the checker instead of running cp.
+PRISTINE="$TMP/_pristine"
+mkdir -p "$PRISTINE/.github" "$PRISTINE/lite-monolithic" \
+         "$PRISTINE/.claude" "$PRISTINE/.agents"
+cp -R "$ROOT/.claude/skills" "$PRISTINE/.claude/skills"
+cp -R "$ROOT/.agents/skills" "$PRISTINE/.agents/skills"
+cp "$ROOT/ai-workflow.md" "$ROOT/project-context.md" "$ROOT/CLAUDE.md" \
+   "$ROOT/AGENTS.md" "$ROOT/GEMINI.md" "$PRISTINE/"
+cp "$ROOT/lite-monolithic/ai-workflow.md" "$PRISTINE/lite-monolithic/"
+cp "$ROOT/.github/copilot-instructions.md" "$PRISTINE/.github/"
+for required in ai-workflow.md project-context.md CLAUDE.md AGENTS.md GEMINI.md \
+                lite-monolithic/ai-workflow.md .github/copilot-instructions.md \
+                .claude/skills/aiw-init/SKILL.md .agents/skills/aiw-init/SKILL.md; do
+  [ -e "$PRISTINE/$required" ] || { echo "pristine fixture is missing $required (ROOT=$ROOT)" >&2; exit 2; }
+done
+
+fixture() { local d="$TMP/$1"; rm -rf "$d"; cp -R "$PRISTINE" "$d"; echo "$d"; }
 
 # expect <label> <pass|fail> <dir> [grep-pattern]
 expect() {
@@ -54,6 +62,26 @@ expect "an unmodified tree passes" pass "$D"
 # itself is not clean, those failures prove nothing, so stop here instead.
 [ "$fail" -eq 0 ] || { echo "baseline is not clean; the rest would be meaningless" >&2; exit 2; }
 
+# This runs on every commit and every push. Anything more than the summary line
+# trains the reader to scroll past it.
+out="$(PROSE_CHECK_ROOT="$D" bash "$CHECK" 2>/dev/null)"
+lines="$(printf '%s\n' "$out" | grep -c '' )"
+if [ "$lines" -gt 1 ]; then
+  bad "a clean tree prints at most one line: got $lines"
+elif ! printf '%s' "$out" | grep -qE '^prose integrity: [0-9]+ checks passed$'; then
+  bad "a clean tree prints at most one line: the one line is not the summary ('$out')"
+else
+  ok "a clean tree prints at most one line, the summary"
+fi
+
+# --verbose restores the detail, including the block saying what a pass does not mean.
+out="$(PROSE_CHECK_ROOT="$D" bash "$CHECK" --verbose 2>&1)"
+if printf '%s' "$out" | grep -q 'PASS:' && printf '%s' "$out" | grep -q 'What this cannot check'; then
+  ok "--verbose restores the per-check output and the limits block"
+else
+  bad "--verbose did not restore the per-check output and the limits block"
+fi
+
 echo "mirror parity:"
 D="$(fixture diverged)"; printf '\nan edit made to one tree only\n' >> "$D/.claude/skills/aiw-init/SKILL.md"
 expect "one tree edited alone is caught" fail "$D" "differs between"
@@ -63,49 +91,52 @@ expect "a skill present in one tree only is caught" fail "$D" "skill trees diffe
 
 echo "frontmatter:"
 D="$(fixture name-mismatch)"
-sed -i '' 's/^name: aiw-init$/name: aiw-not-init/' "$D/.claude/skills/aiw-init/SKILL.md"
-sed -i '' 's/^name: aiw-init$/name: aiw-not-init/' "$D/.agents/skills/aiw-init/SKILL.md"
+edit "$D/.claude/skills/aiw-init/SKILL.md" 's/^name: aiw-init$/name: aiw-not-init/'
+edit "$D/.agents/skills/aiw-init/SKILL.md" 's/^name: aiw-init$/name: aiw-not-init/'
 expect "a name not matching its directory is caught" fail "$D" "does not match its directory"
 
 D="$(fixture empty-desc)"
 for t in .claude .agents; do
-  python3 - "$D/$t/skills/aiw-init/SKILL.md" <<'PY'
-import sys,re
-p=sys.argv[1]; s=open(p).read()
-open(p,'w').write(re.sub(r'^description:.*$','description:',s,count=1,flags=re.M))
-PY
+  edit "$D/$t/skills/aiw-init/SKILL.md" 's/^description:.*$/description:/'
 done
 expect "an empty description is caught" fail "$D" "description is empty"
 
-echo "reference resolution:"
-D="$(fixture dangling-ref)"; printf '\nSee aiw-nonexistent for this.\n' >> "$D/ai-workflow.md"
-expect "a reference to no such skill is caught" fail "$D" "not a skill"
-
-D="$(fixture path-token)"
-printf '\nThe store lives at `~/.claude/aiw-observation/sessions.jsonl`.\n' >> "$D/project-context.md"
-expect "an aiw-* path segment is not read as a reference" pass "$D"
+D="$(fixture blank-desc)"
+for t in .claude .agents; do
+  edit "$D/$t/skills/aiw-init/SKILL.md" 's/^description:.*$/description: "   "/'
+done
+expect "a whitespace-only description is caught" fail "$D" "description is empty"
 
 echo "documented skill set:"
 D="$(fixture undocumented)"
-cp -R "$D/.claude/skills/aiw-init" "$D/.claude/skills/aiw-brand-new"
-cp -R "$D/.agents/skills/aiw-init" "$D/.agents/skills/aiw-brand-new"
-sed -i '' 's/^name: aiw-init$/name: aiw-brand-new/' "$D/.claude/skills/aiw-brand-new/SKILL.md"
-sed -i '' 's/^name: aiw-init$/name: aiw-brand-new/' "$D/.agents/skills/aiw-brand-new/SKILL.md"
+for t in .claude .agents; do
+  cp -R "$D/$t/skills/aiw-init" "$D/$t/skills/aiw-brand-new"
+  edit "$D/$t/skills/aiw-brand-new/SKILL.md" 's/^name: aiw-init$/name: aiw-brand-new/'
+done
 expect "a skill absent from project-context.md is caught" fail "$D" "never names it"
+
+# project-context.md names aiw-testing and never aiw-test, so a substring match
+# would read the longer name as documenting the shorter one.
+D="$(fixture substring-skill)"
+for t in .claude .agents; do
+  cp -R "$D/$t/skills/aiw-init" "$D/$t/skills/aiw-test"
+  edit "$D/$t/skills/aiw-test/SKILL.md" 's/^name: aiw-init$/name: aiw-test/'
+done
+expect "a skill name that is a substring of a documented one is caught" fail "$D" "skill 'aiw-test' exists"
 
 echo "version headers:"
 D="$(fixture no-version)"
-grep -v '^Version:' "$D/project-context.md" > "$D/pc.tmp" && mv "$D/pc.tmp" "$D/project-context.md"
+drop "$D/project-context.md" '^Version:'
 expect "a missing Version header is caught" fail "$D" "no Version header"
 
 echo "size budget:"
 D="$(fixture oversize)"
-for i in $(seq 1 400); do echo "- filler line $i" >> "$D/project-context.md"; done
+for i in $(seq 1 400); do echo "- filler line $i"; done >> "$D/project-context.md"
 expect "project-context.md over its 300-line budget is caught" fail "$D" "budget"
 
 echo "entry-point parity:"
 D="$(fixture entry-drift)"
-grep -v 'project-context.md' "$D/AGENTS.md" > "$D/AGENTS.tmp" && mv "$D/AGENTS.tmp" "$D/AGENTS.md"
+drop "$D/AGENTS.md" 'project-context.md'
 expect "an entry point that stops pointing at the context is caught" fail "$D" "does not reference"
 
 echo

--- a/scripts/test-prose-integrity.sh
+++ b/scripts/test-prose-integrity.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Asserts check-prose-integrity.sh fires on each defect it claims to catch, and
+# stays silent on the normal path. A checker that never fails is a green bar.
+set -uo pipefail
+
+ROOT="${PROSE_TEST_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CHECK="${PROSE_CHECK_BIN:-$ROOT/scripts/check-prose-integrity.sh}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+# A fresh copy of only the paths the checker reads.
+fixture() {
+  local d="$TMP/$1"; rm -rf "$d"; mkdir -p "$d/.github" "$d/lite-monolithic"
+  cp -R "$ROOT/.agents" "$ROOT/.claude" "$d/" 2>/dev/null
+  # keep only the skills; settings and caches are not read by the checker
+  find "$d/.claude" -mindepth 1 -maxdepth 1 ! -name skills -exec rm -rf {} + 2>/dev/null
+  find "$d/.agents" -mindepth 1 -maxdepth 1 ! -name skills -exec rm -rf {} + 2>/dev/null
+  cp "$ROOT/ai-workflow.md" "$ROOT/project-context.md" "$ROOT/CLAUDE.md" \
+     "$ROOT/AGENTS.md" "$ROOT/GEMINI.md" "$d/"
+  cp "$ROOT/lite-monolithic/ai-workflow.md" "$d/lite-monolithic/"
+  cp "$ROOT/.github/copilot-instructions.md" "$d/.github/"
+  for required in ai-workflow.md project-context.md CLAUDE.md AGENTS.md GEMINI.md \
+                  lite-monolithic/ai-workflow.md .github/copilot-instructions.md \
+                  .claude/skills/aiw-init/SKILL.md .agents/skills/aiw-init/SKILL.md; do
+    [ -e "$d/$required" ] || { echo "fixture $1 is missing $required (ROOT=$ROOT)" >&2; exit 2; }
+  done
+  echo "$d"
+}
+
+# expect <label> <pass|fail> <dir> [grep-pattern]
+expect() {
+  local label="$1" want="$2" dir="$3" pat="${4:-}" out rc
+  out="$(PROSE_CHECK_ROOT="$dir" bash "$CHECK" 2>&1)"; rc=$?
+  if [ "$want" = pass ] && [ "$rc" -ne 0 ]; then
+    bad "$label: expected a pass, got exit $rc"; return
+  fi
+  if [ "$want" = fail ] && [ "$rc" -eq 0 ]; then
+    bad "$label: expected a failure, checker passed"; return
+  fi
+  if [ -n "$pat" ] && ! printf '%s' "$out" | grep -qi -- "$pat"; then
+    bad "$label: exited correctly but never mentioned '$pat'"; return
+  fi
+  ok "$label"
+}
+
+echo "normal path:"
+D="$(fixture baseline)"
+expect "an unmodified tree passes" pass "$D"
+# Every later case reads a failure as proof the checker fired. If the baseline
+# itself is not clean, those failures prove nothing, so stop here instead.
+[ "$fail" -eq 0 ] || { echo "baseline is not clean; the rest would be meaningless" >&2; exit 2; }
+
+echo "mirror parity:"
+D="$(fixture diverged)"; printf '\nan edit made to one tree only\n' >> "$D/.claude/skills/aiw-init/SKILL.md"
+expect "one tree edited alone is caught" fail "$D" "differs between"
+
+D="$(fixture missing-skill)"; rm -rf "$D/.agents/skills/aiw-init"
+expect "a skill present in one tree only is caught" fail "$D" "skill trees differ"
+
+echo "frontmatter:"
+D="$(fixture name-mismatch)"
+sed -i '' 's/^name: aiw-init$/name: aiw-not-init/' "$D/.claude/skills/aiw-init/SKILL.md"
+sed -i '' 's/^name: aiw-init$/name: aiw-not-init/' "$D/.agents/skills/aiw-init/SKILL.md"
+expect "a name not matching its directory is caught" fail "$D" "does not match its directory"
+
+D="$(fixture empty-desc)"
+for t in .claude .agents; do
+  python3 - "$D/$t/skills/aiw-init/SKILL.md" <<'PY'
+import sys,re
+p=sys.argv[1]; s=open(p).read()
+open(p,'w').write(re.sub(r'^description:.*$','description:',s,count=1,flags=re.M))
+PY
+done
+expect "an empty description is caught" fail "$D" "description is empty"
+
+echo "reference resolution:"
+D="$(fixture dangling-ref)"; printf '\nSee aiw-nonexistent for this.\n' >> "$D/ai-workflow.md"
+expect "a reference to no such skill is caught" fail "$D" "not a skill"
+
+D="$(fixture path-token)"
+printf '\nThe store lives at `~/.claude/aiw-observation/sessions.jsonl`.\n' >> "$D/project-context.md"
+expect "an aiw-* path segment is not read as a reference" pass "$D"
+
+echo "documented skill set:"
+D="$(fixture undocumented)"
+cp -R "$D/.claude/skills/aiw-init" "$D/.claude/skills/aiw-brand-new"
+cp -R "$D/.agents/skills/aiw-init" "$D/.agents/skills/aiw-brand-new"
+sed -i '' 's/^name: aiw-init$/name: aiw-brand-new/' "$D/.claude/skills/aiw-brand-new/SKILL.md"
+sed -i '' 's/^name: aiw-init$/name: aiw-brand-new/' "$D/.agents/skills/aiw-brand-new/SKILL.md"
+expect "a skill absent from project-context.md is caught" fail "$D" "never names it"
+
+echo "version headers:"
+D="$(fixture no-version)"
+grep -v '^Version:' "$D/project-context.md" > "$D/pc.tmp" && mv "$D/pc.tmp" "$D/project-context.md"
+expect "a missing Version header is caught" fail "$D" "no Version header"
+
+echo "size budget:"
+D="$(fixture oversize)"
+for i in $(seq 1 400); do echo "- filler line $i" >> "$D/project-context.md"; done
+expect "project-context.md over its 300-line budget is caught" fail "$D" "budget"
+
+echo "entry-point parity:"
+D="$(fixture entry-drift)"
+grep -v 'project-context.md' "$D/AGENTS.md" > "$D/AGENTS.tmp" && mv "$D/AGENTS.tmp" "$D/AGENTS.md"
+expect "an entry point that stops pointing at the context is caught" fail "$D" "does not reference"
+
+echo
+echo "Results: $pass passed, $fail failed."
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #227.

## The change

`scripts/check-prose-integrity.sh`, wired into `scripts/repo-validation.sh`, so it runs at every commit and push without a human choosing to run it. It checks what a script can judge about the agent-facing prose without making an editorial call:

- both skill trees define the same skills, and each `SKILL.md` is byte-identical across them, so an agent on Codex and an agent on Claude Code cannot read different rules;
- each skill's frontmatter `name` matches its directory and its `description` is non-empty, since the description is what causes the skill to load at all;
- every `aiw-*` reference in the prose and in the skills resolves to a skill that exists;
- `project-context.md` names every skill in the tree;
- the version headers are present;
- `project-context.md` is within its declared 300-line budget;
- each of the four entry points still points at both governance files.

`scripts/test-prose-integrity.sh` asserts each check actually fires, against fixtures that break one invariant at a time. A checker that never fails is a green bar, so 11 cases exist to stop this becoming one.

## Decisions taken

**The check is deterministic and silent on the normal path.** #225 recorded what happens otherwise: a gate that fires on the normal path gets routed around. Every check here is one whose failure is unambiguously a defect, which is why judgement calls are excluded rather than approximated.

**It does not enforce a semantic review through the pull request body.** The obvious way to reach the issue's third criterion was a hook requiring an independent-review section whenever prose changed. That would fire on nearly every pull request in a documentation repository, which is precisely the failure #225 declined to ship. Left out deliberately.

**Lite-version equality is not duplicated.** `repo-validation.sh` already enforces it and exits before this runs, so a copy here would be dead code. This checks that the version headers exist; equality stays where it was.

**No version bump.** `scripts/` is factory-only and is never installed into a target, so nothing about agent behaviour in a target repo changes. `project-context.md` carries its own version, bumped to 1.23.0.

## Verification

**What could plausibly have broken.** This adds a gate to `repo-validation.sh`, which runs inside the commit and push path. The risk is not that it fails to catch something. It is that it fires on a change that is fine, because that makes every future commit here negotiate with it.

**It did exactly that on its first run, and that is the most useful thing it did.** Against this repository it reported `project-context.md references 'aiw-observation', which is not a skill`. That token is a directory in `~/.claude/aiw-observation/sessions.jsonl`, not a reference. The matcher now ignores tokens sitting inside a path, and `test-prose-integrity.sh` carries that exact line as a case that must pass. Found by running the candidate check against the real corpus before wiring it, which is the method #225 used and the only thing that could have shown it.

**Evidence.** The checker passes against this repository, and the 11-case suite passes: each defect class is fabricated in a throwaway copy of the real tree and the checker is confirmed to reject it. The suite aborts if the unmodified baseline is not clean, so a broken fixture cannot produce a failure that looks like the checker working. Full validation passes with both scripts wired in.

Evidence level: end-to-end execution of the real check against the real tree, plus negative cases on fabricated trees. For a change whose entire behaviour is reading files, that is the top of the hierarchy available.

**An independent reader was run, and it found four contradictions this checker cannot see.** A sub-agent that had not written any of the prose read the workflow, the twelve skills, the project context and the lite condensation, and was told a false finding costs more than a missed one. It confirmed the structural claims in `project-context.md` against the tree, and surfaced four collisions, each with both sides quoted:

1. `aiw-verification`'s mandatory end-to-end list against the "if end-to-end is disproportionate, name why" opt-out four lines later, a hard requirement and a self-granted exemption for the same case. The same pairing is in `lite-monolithic/ai-workflow.md`.
2. `aiw-verification` says creating a tracking issue is the human's, while `aiw-issue-creation` hands the agent a procedure ending in the agent creating it. Under the first reading a "tracked" surface can never reach its artifact.
3. `aiw-issue-creation`'s description names one of the three sources its body owns, so it would not load at the scoping step where its rules are needed.
4. `aiw-project-context-management`'s trigger tells the agent to load it on detecting drift, while `aiw-planning` forbids refreshing the context inside the current task.

This is the issue's first acceptance criterion met in the only way it can be, something other than the author examining the prose, and simultaneously the proof that criterion three is **not** met by a script. None of the four is mechanically detectable. They are reported rather than fixed, because each is a rule change deserving its own decision, and are filed as #234.

## What was not checked

- **Whether any two passages contradict each other.** Not mechanically decidable, stated in the checker's own output so a pass cannot be read as certifying it, and demonstrated above by four contradictions that pass this check cleanly. This is the standing gap for the repository rather than a limitation of this task, and the four findings are tracked by #234.
- **Whether a skill's description matches what its body covers.** The checker confirms a description exists, never that it is the right one. Finding 3 above is exactly this defect, found by reading.
- **Whether the lite condensation's content is in parity with the full workflow.** Only its version header is checked, here and in `repo-validation.sh`. Re-condensing remains a discipline rather than a check, which `design/decisions/maintenance.md` already states.
- **The checker's behaviour in a target repository.** It is factory-only and never installed, so there is no target-side path to exercise.

## Follow-up filed, not acted on

The four contradictions are filed as #234. Finding 2 overlaps the section that #210 modifies, so whichever lands second should reconcile with the first.


---

# After adversarial review

A hostile reviewer was asked to refute this. **It broke two of the three claims.**

## What it found

**1. "Silent on the normal path" was false.** The checker printed 51 lines on a clean tree, on every commit and every push, and the suite added 21 more. Worse, nothing tested the claim: the harness read exit codes only, so the assertion in the test file's own header was never checked.

**2. It rejected legitimate prose.** Four confirmed false positives, each blocking a commit:

| prose | token flagged |
|---|---|
| a YAML template in `aiw-prompt-smith/SKILL.md` with `name: aiw-your-skill` | `aiw-your-skill` |
| "a skill called aiw-example-skill would load here" | `aiw-example-skill` |
| "This is the aiw-verification-first rule" | `aiw-verification-first` |
| "The aiw-observation hook records each session" | `aiw-observation` |

The first is the sharpest: `aiw-prompt-smith` is the skill that authors other skills, so a placeholder frontmatter template is exactly what it carries. The last is a real project noun that the script already knew about, but exempted only when written with a slash.

**3. Three smaller defects.** A skill named `aiw-test` satisfied the documented-skill check because `project-context.md` contains `aiw-testing`; `description: "   "` counted as present; and the suite used `sed -i ''`, the macOS-only form and the only occurrence in the repo.

## What changed

- **The checker is quiet.** One summary line on a clean tree. Full detail behind `--verbose`, and the limits block prints whenever something fails, since on a silent pass there is nothing to over-read. A case now asserts the clean-tree run prints at most one line.
- **The dangling-reference check is deleted, not narrowed.** A reference check over free prose cannot distinguish a reference from a placeholder, an example, or a project noun. The alternative direction, requiring every skill to be referenced somewhere, fires immediately too: `aiw-prompt-smith` is named nowhere in `ai-workflow.md` or any other skill. A comment at its former location records why there is no such check.
- Word-boundary matching for the documented-skill check, trimming before the description test, and a portable in-place edit in the suite.

## Numbers, measured

| | before | after |
|---|---|---|
| test cases | 11 | 13 |
| suite wall clock | 6.77 s | 3.76 s |
| checker stdout, clean tree | 51 lines | 1 line |
| cases still passing with the checker stubbed to always exit 0 | 2 of 11 | 1 of 13 |

That last row is the one that matters: it is the suite's own honesty check. The single survivor is "an unmodified tree passes", which by construction cannot detect a stub. Both newly added pass-shaped cases are stub-resistant, because the silence case asserts the summary line's exact shape and a stub prints nothing.

Wiring re-confirmed: a forced defect makes `./.ai-policy/scripts/project-validation.sh` exit 1.

## A defect this found in its own pull request

`project-context.md` still described the checker as performing "reference resolution" after that check was deleted. The checker cannot catch that: it is precisely the "does the prose match reality" judgement its limits block says it cannot make. Fixed here, and it is a small live demonstration of why the four contradictions in #234 need a reader rather than a script.

## Still not checked

- **Whether two passages contradict each other.** Unchanged, and now with one fewer check pretending to approach it.
- **The suite's own 21 lines of output** remain verbose inside validation. Named rather than fixed; quietening the harness is a separate change from quietening the checker.
- **Whether a documented command does what its text claims.** #228 shipped a false evidence line for exactly this reason. Nothing here would have caught it.
